### PR TITLE
chore: Claude Code action に --dangerouslyAllowAll を追加

### DIFF
--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -35,6 +35,7 @@ jobs:
         uses: anthropics/claude-code-action@v1
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+          claude_args: '--dangerouslyAllowAll'
 
           # This is an optional setting that allows Claude to read CI results on PRs
           additional_permissions: |
@@ -42,9 +43,3 @@ jobs:
 
           # Optional: Give a custom prompt to Claude. If this is not specified, Claude will perform the instructions specified in the comment that tagged it.
           # prompt: 'Update the pull request description to include a summary of changes.'
-
-          # Optional: Add claude_args to customize behavior and configuration
-          # See https://github.com/anthropics/claude-code-action/blob/main/docs/usage.md
-          # or https://code.claude.com/docs/en/cli-reference for available options
-          # claude_args: '--allowed-tools Bash(gh pr *)'
-


### PR DESCRIPTION
## 変更内容

`claude_args: '--dangerouslyAllowAll'` を追加。

## 理由

GitHub Actions の使い捨て ubuntu コンテナ内で `npm install` 等のコマンドが実行できず CI が失敗していたため、コンテナ内のコマンド実行を全許可する。