### PR TITLE
fix: --dangerously-allow-all のフラグ名を修正

### DIFF
--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -35,7 +35,7 @@ jobs:
         uses: anthropics/claude-code-action@v1
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
-          claude_args: '--dangerouslyAllowAll'
+          claude_args: '--dangerously-allow-all'
 
           # This is an optional setting that allows Claude to read CI results on PRs
           additional_permissions: |


### PR DESCRIPTION
## 変更内容

`--dangerouslyAllowAll`（無効）→ `--dangerously-allow-all`（正しいフラグ名）に修正。

## 原因

フラグ名のキャメルケース/ハイフン区切りの誤りにより、Claude Code Action が起動直後にクラッシュしていた。