### PR TITLE
fix: --dangerously-allow-all を特定ツール指定に置き換え

### DIFF
--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -35,7 +35,7 @@ jobs:
         uses: anthropics/claude-code-action@v1
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
-          claude_args: '--dangerously-allow-all'
+          claude_args: '--allowedTools "Bash(npm install),Bash(npm ci),Bash(git add:*),Bash(git commit:*),Bash(git push:*)"'
 
           # This is an optional setting that allows Claude to read CI results on PRs
           additional_permissions: |

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -35,7 +35,7 @@ jobs:
         uses: anthropics/claude-code-action@v1
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
-          claude_args: '--allowedTools "Bash(npm install),Bash(npm ci),Bash(git add:*),Bash(git commit:*),Bash(git push:*)"'
+          claude_args: '--allowed-tools "Bash(npm install),Bash(npm ci),Bash(git add:*),Bash(git commit:*),Bash(git push:*)"'
 
           # This is an optional setting that allows Claude to read CI results on PRs
           additional_permissions: |


### PR DESCRIPTION
## 変更内容

`--dangerously-allow-all` を削除し、必要なコマンドのみを明示的に許可する方式に変更。

## 理由

`--dangerously-allow-all` が claude-code-action の SDK ツール制限と競合し、認証エラーでクラッシュしていた。