### PR TITLE
ci: gh pr create を allowed-tools に追加

### DIFF
--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -35,7 +35,7 @@ jobs:
         uses: anthropics/claude-code-action@v1
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
-          claude_args: '--allowed-tools "Bash(npm install),Bash(npm ci),Bash(git add:*),Bash(git commit:*),Bash(git push:*)"'
+          claude_args: '--allowed-tools "Bash(npm install),Bash(npm ci),Bash(git add:*),Bash(git commit:*),Bash(git push:*),Bash(gh pr create:*)"'
 
           # This is an optional setting that allows Claude to read CI results on PRs
           additional_permissions: |


### PR DESCRIPTION
Closes #10 対応のように「prまで」と指示したときに Claude が PR を自動作成できるよう gh pr create を許可ツールに追加。

https://claude.ai/code/session_01LMHPX1yMV4AkFFceXMCmae