### PR TITLE
feat: アンドゥ/リドゥ機能の実装（Quill含む全体状態）

### DIFF
--- a/src/App.svelte
+++ b/src/App.svelte
@@ -99,7 +99,9 @@
 
     if (
       ((event.ctrlKey || event.metaKey) && event.key === "y") ||
-      ((event.ctrlKey || event.metaKey) && event.shiftKey && (event.key === "z" || event.key === "Z"))
+      ((event.ctrlKey || event.metaKey) &&
+        event.shiftKey &&
+        (event.key === "z" || event.key === "Z"))
     ) {
       event.preventDefault();
       event.stopPropagation();

--- a/src/App.svelte
+++ b/src/App.svelte
@@ -8,6 +8,8 @@
     init_store,
     showPageSearch,
     theme,
+    undoHistory,
+    redoHistory,
   } from "./stores.ts";
   import { onMount, onDestroy } from "svelte";
   import ProjectPage from "./components/ProjectPage.svelte";
@@ -81,11 +83,28 @@
   }
 
   function handleKeyDown(event) {
-    // Ctrl+FまたはCmd+F (Macの場合)
     if ((event.ctrlKey || event.metaKey) && event.key === "f") {
       event.preventDefault();
       $showPageSearch = true;
       searchBox?.focusInput();
+      return;
+    }
+
+    if ((event.ctrlKey || event.metaKey) && !event.shiftKey && event.key === "z") {
+      event.preventDefault();
+      event.stopPropagation();
+      undoHistory();
+      return;
+    }
+
+    if (
+      ((event.ctrlKey || event.metaKey) && event.key === "y") ||
+      ((event.ctrlKey || event.metaKey) && event.shiftKey && (event.key === "z" || event.key === "Z"))
+    ) {
+      event.preventDefault();
+      event.stopPropagation();
+      redoHistory();
+      return;
     }
   }
 
@@ -106,11 +125,11 @@
       });
     }
 
-    window.addEventListener("keydown", handleKeyDown);
+    window.addEventListener("keydown", handleKeyDown, true);
   });
 
   onDestroy(() => {
-    window.removeEventListener("keydown", handleKeyDown);
+    window.removeEventListener("keydown", handleKeyDown, true);
   });
 </script>
 

--- a/src/components/TaskDetail.svelte
+++ b/src/components/TaskDetail.svelte
@@ -1,7 +1,8 @@
 <script>
   import { getNode, updateNodeDataById } from "../common/tree_control.ts";
-  import { tree_data, table_selected_id } from "../stores.ts";
+  import { tree_data, table_selected_id, cancelPendingOperations } from "../stores.ts";
   import { debounce } from "lodash";
+  import { onDestroy } from "svelte";
   import MemoTab from "./MemoTab.svelte";
 
   $: is_selected = $table_selected_id ? true : false;
@@ -20,6 +21,14 @@
   };
   // データストア更新処理のdebounce - 全てのUI更新を統合的に処理
   const changeDataDebounce = debounce(changeData, 500);
+
+  const unsubscribeCancelPending = cancelPendingOperations.subscribe(() => {
+    changeDataDebounce.cancel();
+  });
+
+  onDestroy(() => {
+    unsubscribeCancelPending();
+  });
   const addMemo = (newMemoTitle) => {
     if (newMemoTitle) {
       let newMemo = { title: newMemoTitle, content: "" };

--- a/src/stores.ts
+++ b/src/stores.ts
@@ -180,6 +180,28 @@ function createProjectIds(initialValue: ProjectListItem[] | undefined): ProjectI
   };
 }
 
+const MAX_HISTORY = 50;
+let undoStack: ProjectData[] = [];
+let redoStack: ProjectData[] = [];
+let skipSnapshot = false;
+let pendingSkipSnapshot = false;
+
+export const cancelPendingOperations = writable<number>(0);
+
+function captureSnapshot(data: ProjectData) {
+  undoStack.push(_.cloneDeep(data));
+  if (undoStack.length > MAX_HISTORY) {
+    undoStack.shift();
+  }
+  redoStack = [];
+}
+
+export function clearHistory() {
+  undoStack = [];
+  redoStack = [];
+  skipSnapshot = true;
+}
+
 function createTreeData(initialValue: ProjectData | undefined): TreeDataStore {
   const { subscribe, set, update } = writable<ProjectData | undefined>(initialValue);
   let previousData: ProjectData | null = null;
@@ -226,6 +248,11 @@ function createTreeData(initialValue: ProjectData | undefined): TreeDataStore {
     }
 
     if (previousData) {
+      if (!pendingSkipSnapshot) {
+        captureSnapshot(previousData);
+      }
+      pendingSkipSnapshot = false;
+
       const removedIds = findRemovedNodeIds(previousData, current);
       if (removedIds.length > 0) {
         const projectId = get(selected_id);
@@ -309,6 +336,13 @@ function createTreeData(initialValue: ProjectData | undefined): TreeDataStore {
           }
         }
 
+        if (skipSnapshot) {
+          pendingSkipSnapshot = true;
+          skipSnapshot = false;
+        } else if (current !== undefined) {
+          pendingSkipSnapshot = false;
+        }
+
         persistTreeData(current);
       });
     },
@@ -326,6 +360,7 @@ function createSelectedID(initialValue: string | undefined): SelectedIdStore {
       subscribe((current) => {
         const currentSelectedType = get(selected_type);
         if (currentSelectedType === "Projects" && current) {
+          clearHistory();
           window.electronAPI.getTreeData(current).then((result) => {
             tree_data.set(result);
 
@@ -440,6 +475,36 @@ function createFilter(initialValue: FilterState): FilterStore {
 }
 
 tree_data = createTreeData(undefined);
+
+export function undoHistory() {
+  if (undoStack.length === 0) return;
+  const current = get(tree_data);
+  if (current) {
+    redoStack.push(_.cloneDeep(current));
+    if (redoStack.length > MAX_HISTORY) {
+      redoStack.shift();
+    }
+  }
+  const previous = undoStack.pop()!;
+  cancelPendingOperations.update((n) => n + 1);
+  skipSnapshot = true;
+  tree_data.set(previous);
+}
+
+export function redoHistory() {
+  if (redoStack.length === 0) return;
+  const current = get(tree_data);
+  if (current) {
+    undoStack.push(_.cloneDeep(current));
+    if (undoStack.length > MAX_HISTORY) {
+      undoStack.shift();
+    }
+  }
+  const next = redoStack.pop()!;
+  cancelPendingOperations.update((n) => n + 1);
+  skipSnapshot = true;
+  tree_data.set(next);
+}
 
 function collectNodeAndDescendantIds(node: TreeData | undefined): string[] {
   if (!node) return [];


### PR DESCRIPTION
Closes #10

## 変更内容

**`src/stores.ts`**
- `undoStack` / `redoStack`（最大50件）をモジュールレベルで管理
- `persistTreeData`（1000ms throttle）内で `captureSnapshot(previousData)` を呼び出し、変更前のスナップショットを捕捉
- `undoHistory()` / `redoHistory()` をエクスポート：スタックから ProjectData を復元して `tree_data.set()` する
- `cancelPendingOperations` ストア：アンドゥ/リドゥ時に increment し、TaskDetail の pending debounce をキャンセル
- プロジェクト切替時に `clearHistory()` で履歴をリセット
- `skipSnapshot` フラグで、アンドゥ/リドゥ操作自体がスタックに積まれないよう制御

**`src/App.svelte`**
- `Ctrl+Z` → `undoHistory()`、`Ctrl+Y` / `Ctrl+Shift+Z` → `redoHistory()`
- キャプチャフェーズで Quill より先にイベントを横取り

**`src/components/TaskDetail.svelte`**
- `cancelPendingOperations` を購読し、アンドゥ/リドゥ時に `changeDataDebounce.cancel()` を呼び出し
- 「タイプ → Ctrl+Z」の際、debounced memo save がアンドゥ結果を上書きするバグを防止

## パフォーマンス対策
- スナップショット捕捉は throttle（1000ms）済みの `persistTreeData` 内なので、連続入力時も最大 1回/秒
- スタック上限 50件で古い履歴を自動削除
- `_.cloneDeep` は既存コードと同じ方式（追加コストは 1 cloneDeep/秒以内）

Generated with [Claude Code](https://claude.ai/code)