### PR TITLE
ci: Claude Bot によるPR作成・レビューワークフローの修正

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -12,12 +12,7 @@ on:
 
 jobs:
   claude-review:
-    # Optional: Filter by PR author
-    # if: |
-    #   github.event.pull_request.user.login == 'external-contributor' ||
-    #   github.event.pull_request.user.login == 'new-developer' ||
-    #   github.event.pull_request.author_association == 'FIRST_TIME_CONTRIBUTOR'
-
+    if: github.event.pull_request.user.type != 'Bot'
     runs-on: ubuntu-latest
     permissions:
       contents: read

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -35,7 +35,7 @@ jobs:
         uses: anthropics/claude-code-action@v1
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
-          claude_args: '--allowed-tools "Bash(npm install),Bash(npm ci),Bash(git add:*),Bash(git commit:*),Bash(git push:*)"'
+          claude_args: '--allowed-tools "Bash(npm install),Bash(npm ci),Bash(git add:*),Bash(git commit:*),Bash(git push:*),Bash(gh pr create:*)"'
 
           # This is an optional setting that allows Claude to read CI results on PRs
           additional_permissions: |


### PR DESCRIPTION
## 概要

Issue #10 の調査で判明した、Claude Bot が PR を作成できない・レビューワークフローがエラーになる問題を修正。

## 変更内容

### `claude.yml` — `gh pr create` を allowed-tools に追加
「prまで」と指示しても PR が作られなかった原因。`--allowed-tools` に `Bash(gh pr create:*)` が含まれていなかったため、Claude がコードをプッシュしても PR 作成ツールを使えなかった。

### `claude-code-review.yml` — Bot が作成した PR をレビュー対象外に
Claude Bot が PR を作成すると `claude-code-review` ワークフローが起動し、「Workflow initiated by non-human actor」エラーで落ちていた。`if: github.event.pull_request.user.type != 'Bot'` を追加して Bot 起点の PR をスキップするよう修正。

Generated with [Claude Code](https://claude.ai/code)