### PR TITLE
fix: Quillエディタ間のコピー&ペースト不具合を修正

### DIFF
--- a/src/components/Memo.svelte
+++ b/src/components/Memo.svelte
@@ -129,6 +129,9 @@
       theme: "snow",
       modules: {
         toolbar: readOnly ? false : toolbarOptions,
+        clipboard: {
+          matchVisual: false,
+        },
       },
     });
 


### PR DESCRIPTION
Fixes #37

## 変更内容

Quill v2 のクリップボード設定に `matchVisual: false` を追加し、メモタブ間のコピー&ペーストの不具合を修正。

Generated with [Claude Code](https://claude.ai/code)