### PR TITLE
fix: 空メモに戻った際にQuillエディターが更新されない問題を修正

### DIFF
--- a/src/components/Memo.svelte
+++ b/src/components/Memo.svelte
@@ -41,7 +41,8 @@
     }
 
     if (!nextContent) {
-      quill.setText("");
+      // Use explicit empty Delta to reliably clear Quill content
+      quill.setContents([{ insert: "\n" }]);
       return;
     }
 
@@ -154,9 +155,9 @@
 
           // カーソル位置情報も一緒に送信
           if (currentSelection) {
-            saveMemo(contents, memoIndex, currentSelection);
+            saveMemo(contents, currentSelection);
           } else {
-            saveMemo(contents, memoIndex);
+            saveMemo(contents);
           }
 
           // 編集フラグをリセット
@@ -205,19 +206,28 @@
   });
 
   // 外部から更新されたコンテンツとの同期（編集中は同期しない）
-  $: if (quill && !isEditing && !isEqual(content, lastSavedContent)) {
-    // 一時的に編集中フラグを立てる（再描画防止）
-    isEditing = true;
+  $: if (quill && !isEditing) {
+    // 空コンテンツへの切り替えは常に適用し、既存コンテンツが残らないようにする
+    const contentIsEmpty = !content;
+    const lastSavedIsEmpty = !lastSavedContent;
+    const needsUpdate =
+      (contentIsEmpty !== lastSavedIsEmpty) ||
+      (!contentIsEmpty && !isEqual(content, lastSavedContent));
 
-    // コンテンツを更新
-    applyContent(content);
-    lastSavedContent = content;
+    if (needsUpdate) {
+      // 一時的に編集中フラグを立てる（再描画防止）
+      isEditing = true;
 
-    // 外部更新後はカーソル位置を保存せずにシンプルに編集フラグのみリセット
-    setTimeout(() => {
-      // 編集フラグをリセット
-      isEditing = false;
-    }, 50);
+      // コンテンツを更新
+      applyContent(content);
+      lastSavedContent = content;
+
+      // 外部更新後はカーソル位置を保存せずにシンプルに編集フラグのみリセット
+      setTimeout(() => {
+        // 編集フラグをリセット
+        isEditing = false;
+      }, 50);
+    }
   }
 </script>
 

--- a/src/components/Memo.svelte
+++ b/src/components/Memo.svelte
@@ -210,7 +210,7 @@
     const contentIsEmpty = !content;
     const lastSavedIsEmpty = !lastSavedContent;
     const needsUpdate =
-      (contentIsEmpty !== lastSavedIsEmpty) ||
+      contentIsEmpty !== lastSavedIsEmpty ||
       (!contentIsEmpty && !isEqual(content, lastSavedContent));
 
     if (needsUpdate) {

--- a/src/components/Memo.svelte
+++ b/src/components/Memo.svelte
@@ -6,7 +6,6 @@
 
   export let saveMemo;
   export let content = "";
-  export let memoIndex = 0; // メモのインデックスを受け取る
   export let readOnly = false;
 
   let editor;

--- a/src/components/MemoTab.svelte
+++ b/src/components/MemoTab.svelte
@@ -164,7 +164,6 @@
           saveMemo={(editedContent, cursorPosition) =>
             saveMemo(editedContent, selectedMemoIndex, cursorPosition)}
           content={editedContent}
-          memoIndex={selectedMemoIndex}
         />
       {/key}
     {:else}

--- a/src/components/MemoTab.svelte
+++ b/src/components/MemoTab.svelte
@@ -108,9 +108,10 @@
         {disabled}
         activeColor={"var(--theme-color-Primary-dark)"}
         normalColor={"var(--theme-color-Primary-main)"}
-        on:click={() => {
+        on:click={async () => {
           if (addMemo(newMemoTitle)) {
-            selectedMemoIndex = memo.length;
+            await tick();
+            selectedMemoIndex = memo.length - 1;
           }
         }}
       >

--- a/tests/component/TaskDetail.test.js
+++ b/tests/component/TaskDetail.test.js
@@ -131,22 +131,20 @@ describe("TaskDetail", () => {
     await fireEvent.click(addButton);
     await tick();
 
-    // Now on the new empty memo (index 1)
-    const memoStub = screen.getByTestId("memo-stub");
-    expect(memoStub.getAttribute("data-memo-index")).toBe("1");
+    // Now on the new empty memo (index 1) - verify "memo" tab is selected
+    expect(screen.getByDisplayValue("memo").closest("button")).toHaveClass("selected");
 
     // Switch to existing memo (index 0)
     await fireEvent.click(screen.getByDisplayValue("existing").closest("button"));
     await tick();
-    expect(screen.getByTestId("memo-stub").getAttribute("data-memo-index")).toBe("0");
+    expect(screen.getByDisplayValue("existing").closest("button")).toHaveClass("selected");
 
     // Switch back to the empty memo (index 1)
     await fireEvent.click(screen.getByDisplayValue("memo").closest("button"));
     await tick();
 
-    const stub = screen.getByTestId("memo-stub");
-    expect(stub.getAttribute("data-memo-index")).toBe("1");
+    expect(screen.getByDisplayValue("memo").closest("button")).toHaveClass("selected");
     // content should be empty string for the new empty memo
-    expect(stub.textContent.trim()).toBe("");
+    expect(screen.getByTestId("memo-stub").textContent.trim()).toBe("");
   });
 });

--- a/tests/component/TaskDetail.test.js
+++ b/tests/component/TaskDetail.test.js
@@ -117,4 +117,36 @@ describe("TaskDetail", () => {
 
     expect(screen.getByDisplayValue("review").closest("button")).toHaveClass("selected");
   });
+
+  test("shows empty content after switching from existing memo to new empty memo and back", async () => {
+    const project = createProjectData();
+    project.data.children[0].data.memo = [{ title: "existing", content: "some content" }];
+    tree_data.set(project);
+    table_selected_id.set("task-1");
+
+    const { container } = render(TaskDetail);
+
+    // Add a new empty memo
+    const addButton = container.querySelectorAll(".memotab-control button")[0];
+    await fireEvent.click(addButton);
+    await tick();
+
+    // Now on the new empty memo (index 1)
+    const memoStub = screen.getByTestId("memo-stub");
+    expect(memoStub.getAttribute("data-memo-index")).toBe("1");
+
+    // Switch to existing memo (index 0)
+    await fireEvent.click(screen.getByDisplayValue("existing").closest("button"));
+    await tick();
+    expect(screen.getByTestId("memo-stub").getAttribute("data-memo-index")).toBe("0");
+
+    // Switch back to the empty memo (index 1)
+    await fireEvent.click(screen.getByDisplayValue("memo").closest("button"));
+    await tick();
+
+    const stub = screen.getByTestId("memo-stub");
+    expect(stub.getAttribute("data-memo-index")).toBe("1");
+    // content should be empty string for the new empty memo
+    expect(stub.textContent.trim()).toBe("");
+  });
 });


### PR DESCRIPTION
Fixes #38

## 修正内容

- `applyContent`: 空コンテンツ設定を `quill.setText("")` から `quill.setContents[{insert:"\n"}]` に変更
- リアクティブ宣言: 空⇔非空の状態遷移を明示的に判定するロジックに変更
- `saveMemo` 引数修正: `memoIndex` ではなく `currentSelection` を渡すよう修正
- `addMemo` 後の `selectedMemoIndex`: `await tick()` + `memo.length - 1` で正確なインデックスをセット

Generated with [Claude Code](https://claude.ai/code)