### PR TITLE
feat: git pre-push フックでlint・テストを自動実行する

### DIFF
--- a/.githooks/pre-push
+++ b/.githooks/pre-push
@@ -1,0 +1,24 @@
+#!/bin/sh
+
+echo "Running lint..."
+npm run lint
+if [ $? -ne 0 ]; then
+  echo "Lint failed. Push aborted."
+  exit 1
+fi
+
+echo "Running format check..."
+npm run format:check
+if [ $? -ne 0 ]; then
+  echo "Format check failed. Push aborted."
+  exit 1
+fi
+
+echo "Running tests..."
+npm test
+if [ $? -ne 0 ]; then
+  echo "Tests failed. Push aborted."
+  exit 1
+fi
+
+echo "All checks passed."

--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
     "publish": null
   },
   "scripts": {
+    "prepare": "git config core.hooksPath .githooks",
     "build": "vite build",
     "dev": "vite",
     "start": "electron .",


### PR DESCRIPTION
Closes #42

## 変更内容

- `.githooks/pre-push` を追加
  - push 前に `npm run lint` → `npm run format:check` → `npm test` を順番に実行
  - いずれかが失敗した場合はプッシュをブロック
- `package.json` に `prepare` スクリプトを追加
  - `npm install` 後に `git config core.hooksPath .githooks` が自動実行され、フックが有効化される

## セットアップ方法

```sh
npm install  # prepare スクリプトが自動でフックを有効化
```

既存の環境では一度 `npm install` または手動で以下を実行してください：

```sh
git config core.hooksPath .githooks
```

https://claude.ai/code/session_01U8Nm881nC6CUVsmAu53v7f