### PR TITLE
fix: isHandlingLink フラグがエラー時にスタックするバグを修正

### DIFF
--- a/src/components/Memo.svelte
+++ b/src/components/Memo.svelte
@@ -56,14 +56,13 @@
   // Quillのリンクツールチップを処理するための関数
   function handleLinkTooltips() {
     // イベントハンドラー関数を定義
-    const handleLinkClick = (e) => {
+    const handleLinkClick = async (e) => {
       // Visit (ql-preview) ボタンがクリックされた場合
       if (e.target && e.target.classList.contains("ql-preview")) {
         const href = e.target.getAttribute("href");
         if (href && href.trim() !== "") {
           // 既に処理中なら何もしない（二重実行防止）
           if (isHandlingLink) return;
-          isHandlingLink = true;
 
           // クリックイベントのデフォルト動作を停止（内部ブラウザでの開封を防止）
           e.preventDefault();
@@ -74,14 +73,13 @@
             quill.theme.tooltip.hide();
           }
 
-          // 外部ブラウザでリンクを開く
-          window.electronAPI.openExternalLink(href);
-
-          // フラグをリセット（次のリンククリックのため）
-          // 適切な時間でリセットし、短時間での複数回クリックを防止
-          setTimeout(() => {
+          try {
+            isHandlingLink = true;
+            // 外部ブラウザでリンクを開く
+            await window.electronAPI.openExternalLink(href);
+          } finally {
             isHandlingLink = false;
-          }, 300);
+          }
         }
       }
     };


### PR DESCRIPTION
## 概要

`Memo.svelte` の `isHandlingLink` フラグが、`openExternalLink` 呼び出し中に例外が発生した場合にリセットされない問題を修正しました。

Closes #3

## 変更内容

- `handleLinkClick` を `async` 関数に変更
- `setTimeout` による不確実なフラグリセットを `try/finally` に置き換え
- エラー発生時でも確実に `isHandlingLink = false` にリセットされるようになった

## 修正前

```js
isHandlingLink = true;
window.electronAPI.openExternalLink(href);
// openExternalLink が例外を投げると setTimeout に到達しない
setTimeout(() => {
  isHandlingLink = false;
}, 300);
```

## 修正後

```js
try {
  isHandlingLink = true;
  await window.electronAPI.openExternalLink(href);
} finally {
  isHandlingLink = false;
}
```

https://claude.ai/code/session_01T6cxNpHucwQVRyHHn9nf23