### PR TITLE
fix: タスク名クリックで行選択できるよう修正 (issue #50)

### DIFF
--- a/src/components/TaskName.svelte
+++ b/src/components/TaskName.svelte
@@ -266,7 +266,9 @@
       debouncedCommit();
     }}
     on:click={(e) => {
-      e.stopPropagation();
+      if (!disabled) {
+        e.stopPropagation();
+      }
     }}
     on:keydown={(e) => {
       if (e.key === "Enter") {

--- a/tests/component/TaskName.test.js
+++ b/tests/component/TaskName.test.js
@@ -1,0 +1,13 @@
+import { fireEvent, render, screen } from "@testing-library/svelte";
+
+import TaskNameClickHarness from "../mocks/TaskNameClickHarness.svelte";
+
+describe("TaskName", () => {
+  test("allows click on disabled input to bubble to row selection handler", async () => {
+    render(TaskNameClickHarness);
+
+    await fireEvent.click(screen.getByDisplayValue("Task 1"));
+
+    expect(screen.getByTestId("count")).toHaveTextContent("1");
+  });
+});

--- a/tests/mocks/TaskNameClickHarness.svelte
+++ b/tests/mocks/TaskNameClickHarness.svelte
@@ -1,0 +1,21 @@
+<script>
+  import TaskName from "../../src/components/TaskName.svelte";
+
+  let clickCount = 0;
+</script>
+
+<div
+  data-testid="row"
+  role="button"
+  tabindex="0"
+  on:click={() => (clickCount += 1)}
+  on:keydown={(e) => {
+    if (e.key === "Enter" || e.key === " ") {
+      clickCount += 1;
+    }
+  }}
+>
+  <TaskName text="Task 1" />
+</div>
+
+<p data-testid="count">{clickCount}</p>


### PR DESCRIPTION
### Motivation

- 修正対象は issue #50 の「タスクツリーの選択範囲が狭い」問題で、表示状態のタスク名をクリックしても行の選択が発火しない不具合を解消するための変更です。
- 原因は `TaskName` 内の `input` が編集無効（`disabled === true`）でも常に `stopPropagation` しており、親行のクリックハンドラへイベントが伝播しなかったことです。

### Description

- `src/components/TaskName.svelte` の `input` の `on:click` を修正し、`stopPropagation` を行うのは編集中（`disabled === false`）の場合のみになるように変更しました。
- 回帰テストとして `tests/component/TaskName.test.js` を追加し、ハーネス `tests/mocks/TaskNameClickHarness.svelte` を使って「表示時（disabled）の入力クリックが親のクリックハンドラへ伝播する」ことを検証するようにしました。
- テストハーネスにアクセシビリティ上の要件（`role="button"`, `tabindex`, キーボードハンドラ）を追加してキー操作でも動作検証できるようにしています。

### Testing

- 実行コマンド `npm test tests/component/TaskName.test.js` により追加テストは個別にパスしました.
- フルテストスイートを `npm test` で実行し、全自動テストは成功しており出力は `8 files 40 passed (40)`（全テスト合格）でした.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e8cdbc51188330a26c1d95eab5be5b)