### PR TITLE
e2e: add test to ensure task row is selected when clicking task name input

### DIFF
--- a/tests/e2e/app.smoke.spec.js
+++ b/tests/e2e/app.smoke.spec.js
@@ -143,6 +143,20 @@ test("adds a sibling task from the project toolbar and persists it", async () =>
   }
 });
 
+test("selects a task row when clicking the task name input", async () => {
+  const app = await launchSeededApp();
+
+  try {
+    const taskNameInput = app.window.locator('#task-1 input[type="text"]').first();
+    await taskNameInput.click();
+
+    await expect(app.window.locator("#task-1")).toHaveAttribute("aria-selected", "true");
+    await expect(app.window.locator("#project-1")).toHaveAttribute("aria-selected", "false");
+  } finally {
+    await closeSeededApp(app);
+  }
+});
+
 test("toggles the theme and persists the new value into meta.json", async () => {
   const app = await launchSeededApp();
 


### PR DESCRIPTION
### Motivation
- Verify that clicking the task name input selects the corresponding task row and does not select the parent project, preventing a UI selection regression.

### Description
- Add a new end-to-end test `selects a task row when clicking the task name input` to `tests/e2e/app.smoke.spec.js` that clicks the task name input and asserts `aria-selected` is `true` for the task and `false` for the project while reusing `launchSeededApp` and `closeSeededApp`.

### Testing
- Ran the e2e test file with Playwright using `npx playwright test tests/e2e/app.smoke.spec.js` and the test suite completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e949e0f5708330aaf67c670b42385e)