### PR TITLE
Adjust sticky trail calculation to account for sticky overlay row

### DIFF
--- a/src/components/TreeTable.svelte
+++ b/src/components/TreeTable.svelte
@@ -55,9 +55,10 @@
       return [];
     }
 
+    const stickyOverlayRows = 1;
     const topVisibleIndex = Math.min(
       visibleRows.length - 1,
-      Math.max(0, Math.floor(currentScrollTop / rowHeightPx))
+      Math.max(0, Math.floor(currentScrollTop / rowHeightPx) - stickyOverlayRows)
     );
     const topRow = visibleRows[topVisibleIndex];
     if (!topRow || topRow.depth === 0) {


### PR DESCRIPTION
### Motivation
- Ensure the computed sticky ancestor trail includes the correct parent rows when the top visible row is partially obscured by a sticky overlay.

### Description
- Introduce `stickyOverlayRows = 1` and subtract it from the computed `topVisibleIndex` inside `buildStickyTrail` so the trail starts earlier by one row.
- All other trail-building logic is preserved and the change updates the reactive `stickyTrail` output.

### Testing
- Ran the existing component/unit test suite and snapshot tests against the updated `TreeTable` component, and they passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e9fbcdb3148330b21a91301ab930d4)