### PR TITLE
feat: タスクツリーの表示カラムをカスタマイズできるようにする (#35)

### DIFF
--- a/src/components/TreeTable.svelte
+++ b/src/components/TreeTable.svelte
@@ -540,7 +540,7 @@
   aria-label="Task tree"
   on:scroll={handleScroll}
 >
-  <TreeTableHeader headers={visibleHeaders} />
+  <TreeTableHeader headers={visibleHeaders} allHeaders={$tree_data?.headers ?? []} />
   {#if stickyTrail.length > 0}
     <div class="StickyTrail" aria-hidden="true">
       <div class="StickyTrailContent">

--- a/src/components/TreeTable.svelte
+++ b/src/components/TreeTable.svelte
@@ -9,6 +9,7 @@
     closed_node_ids,
     table_selected_id,
     theme,
+    column_settings,
   } from "../stores.ts";
   import {
     flattenVisibleTree,
@@ -29,13 +30,36 @@
   let table_root; // Bind
 
   // Resize
-  let resizers, handlers, resize_observer;
+  let resizers = [], handlers, resize_observer;
 
-  // Min width
-  let minWidth;
   $: rows = $filtered_data ? flattenVisibleTree($filtered_data, $closed_node_ids) : [];
   $: isDark = $theme == "dark";
   let scrollTop = 0;
+
+  // Compute visible headers from tree_data.headers filtered/ordered by column_settings
+  function computeVisibleHeaders(treeHeaders, settings) {
+    if (!treeHeaders) return [];
+    if (!settings) return treeHeaders;
+
+    const result = [];
+    for (const setting of settings) {
+      if (setting.id === "name" || setting.visible) {
+        const header = treeHeaders.find((h) => h.name === setting.id);
+        if (header) result.push(header);
+      }
+    }
+
+    // Include any headers not covered by settings
+    const settingIds = new Set(settings.map((s) => s.id));
+    for (const header of treeHeaders) {
+      if (!settingIds.has(header.name)) result.push(header);
+    }
+
+    return result;
+  }
+
+  $: visibleHeaders = computeVisibleHeaders($tree_data?.headers, $column_settings);
+  $: minWidth = visibleHeaders.length ? `${4 * visibleHeaders.length}rem` : "auto";
 
   const getRowHeightPx = () => {
     if (typeof window === "undefined") {
@@ -84,109 +108,130 @@
   let deleteTargetName = "";
 
   onMount(() => {
-    let headers, data_rows;
-    // Create resizres
-    [resizers, headers, data_rows, resize_observer] = createResizers();
-    // Event listners
-    handlers = setResizersEvents(resizers, headers, data_rows);
+    let domHeaders, data_rows;
+    [resizers, domHeaders, data_rows, resize_observer] = createResizers(visibleHeaders);
+    handlers = setResizersEvents(resizers, domHeaders, data_rows);
 
-    // Min width
-    minWidth = `${4 * headers.length}rem`; // magic number 4rem defined in TreeTableHeader.
-
-    // Observe slot change
     let mutation_observer = new MutationObserver(() => {
-      let headers, data_rows;
-      // Create resizres
-      [resizers, headers, data_rows] = createResizers(resizers, false, resize_observer);
-      // Event listners
-      unsetResizerEvents(resizers, handlers);
-      handlers = setResizersEvents(resizers, headers, data_rows);
+      const currentDomHeaderCount = Array.from(
+        table_root.querySelectorAll(".TableRow")[0]?.querySelectorAll(".TableHeader") ?? []
+      ).length;
+      const columnCountChanged = currentDomHeaderCount !== resizers.length + 1;
+
+      let newDomHeaders, newDataRows;
+
+      if (columnCountChanged && currentDomHeaderCount > 0) {
+        // Column was added or removed — full reinit
+        resizers.forEach((r) => r.parentNode?.removeChild(r));
+        resizers = [];
+        unsetResizerEvents(resizers, handlers);
+        [resizers, newDomHeaders, newDataRows, resize_observer] = createResizers(
+          visibleHeaders,
+          [],
+          true,
+          resize_observer
+        );
+      } else {
+        [resizers, newDomHeaders, newDataRows] = createResizers(
+          visibleHeaders,
+          resizers,
+          false,
+          resize_observer
+        );
+        unsetResizerEvents(resizers, handlers);
+      }
+
+      handlers = setResizersEvents(resizers, newDomHeaders, newDataRows);
     });
     mutation_observer.observe(table_root, { subtree: true, childList: true });
   });
 
-  const createResizers = (resizers = [], is_default = true, resize_observer = null) => {
+  const createResizers = (
+    currentHeaders,
+    existingResizers = [],
+    is_default = true,
+    existingResizeObserver = null
+  ) => {
     // Get elms
-    let rows = table_root.querySelectorAll(".TableRow");
-    let headers = Array.from(rows[0].querySelectorAll(".TableHeader"));
+    let tableRows = table_root.querySelectorAll(".TableRow");
+    let domHeaders = Array.from(tableRows[0].querySelectorAll(".TableHeader"));
     let data_rows = [];
-    rows.forEach((data_row, index) => {
+    tableRows.forEach((data_row, index) => {
       if (index != 0) {
         data_rows.push(data_row.querySelectorAll(".TableData"));
       }
     });
+
     // Set width
-    const default_ratio_sum = $tree_data.headers.reduce(
-      (partialSum, header) => partialSum + header.default_ratio,
-      0
-    );
-    const default_root_width = rows[0].getBoundingClientRect().width;
-    const default_data_widths = $tree_data.headers.map(
-      (header) => (default_root_width * header.default_ratio) / default_ratio_sum
-    );
-    headers.forEach((header, index) => {
-      if (is_default) {
+    if (is_default) {
+      const default_ratio_sum = currentHeaders.reduce(
+        (partialSum, header) => partialSum + header.default_ratio,
+        0
+      );
+      const default_root_width = tableRows[0].getBoundingClientRect().width;
+      const default_data_widths = currentHeaders.map(
+        (header) => (default_root_width * header.default_ratio) / default_ratio_sum
+      );
+      domHeaders.forEach((header, index) => {
         header.style.width = `calc(${default_data_widths[index]}px)`;
         data_rows.forEach((data_row, _) => {
           data_row[index].style.width = `calc(${default_data_widths[index]}px)`;
         });
-      } else {
-        data_rows.forEach((data_row, _) => {
-          data_row[index].style.width = `${header.getBoundingClientRect().width}px)`;
-        });
-      }
-    });
-    // Create resizer
-    if (is_default) {
-      headers.forEach((header, index) => {
+      });
+
+      // Create resizer elements
+      domHeaders.forEach((header, index) => {
         if (index == 0) {
           return;
         }
-        // Create resizer
         const resizer = document.createElement("div");
         resizer.classList.add("Resizer");
-        resizer.style.height = `${table_root.offsetHeight}px`; //テーブルの高さ
-        // Postions of resizer
+        resizer.style.height = `${table_root.offsetHeight}px`;
         resizer.style.left = `calc(${default_data_widths.reduce((partialSum, width) => partialSum + width, 0) - 3}px)`;
-        // Add resizer into Dom
         header.parentNode.insertBefore(resizer, header);
-        // Keep resizer
-        resizers.push(resizer);
+        existingResizers.push(resizer);
+      });
+    } else {
+      domHeaders.forEach((header, index) => {
+        data_rows.forEach((data_row, _) => {
+          data_row[index].style.width = `${header.getBoundingClientRect().width}px`;
+        });
       });
     }
+
     // For table_root resizing
-    if (resize_observer) {
-      resize_observer.disconnect(table_root);
+    if (existingResizeObserver) {
+      existingResizeObserver.disconnect(table_root);
     }
-    resize_observer = new ResizeObserver((entries) => {
+    const newResizeObserver = new ResizeObserver((entries) => {
       // Height setting
-      for (let resizer of resizers) {
+      for (let resizer of existingResizers) {
         resizer.style.height = `${entries[0].contentRect.height}px`;
       }
       // Width setting
       let table_width = 0;
-      headers.forEach((header, index) => {
+      domHeaders.forEach((header, index) => {
         table_width += header.getBoundingClientRect().width;
       });
       let new_table_width = entries[0].contentRect.width;
-      const new_header_widths = headers.map(
+      const new_header_widths = domHeaders.map(
         (h) => (h.getBoundingClientRect().width * new_table_width) / table_width
       );
-      headers.forEach((header, index) => {
+      domHeaders.forEach((header, index) => {
         header.style.width = `${new_header_widths[index]}px`;
         data_rows.forEach((data_row) => {
           data_row[index].style.width = `${new_header_widths[index]}px`;
         });
       });
       let left = 0;
-      resizers.forEach((resizer, index) => {
+      existingResizers.forEach((resizer, index) => {
         resizer.style.left = `${left + new_header_widths[index] - 3}px`;
         left += new_header_widths[index];
       });
     });
-    resize_observer.observe(table_root);
-    // Return
-    return [resizers, headers, data_rows, resize_observer];
+    newResizeObserver.observe(table_root);
+
+    return [existingResizers, domHeaders, data_rows, newResizeObserver];
   };
 
   const setResizersEvents = (resizers, headers, data_rows) => {
@@ -299,6 +344,7 @@
     }
     return handlers;
   };
+
   const unsetResizerEvents = (resizers, handlers) => {
     resizers.forEach((resizer, index) => {
       resizer.removeEventListener("mousedown", handlers[index]);
@@ -492,7 +538,7 @@
   aria-label="Task tree"
   on:scroll={handleScroll}
 >
-  <TreeTableHeader headers={$tree_data.headers} />
+  <TreeTableHeader headers={visibleHeaders} />
   {#if stickyTrail.length > 0}
     <div class="StickyTrail" aria-hidden="true">
       <div class="StickyTrailContent">
@@ -514,7 +560,7 @@
     {#each rows as row (row.id)}
       <TreeTableRow
         {row}
-        headers={$tree_data.headers}
+        headers={visibleHeaders}
         selected={$table_selected_id === row.id}
         {isDark}
         canDrop={canDropTarget}

--- a/src/components/TreeTable.svelte
+++ b/src/components/TreeTable.svelte
@@ -30,7 +30,9 @@
   let table_root; // Bind
 
   // Resize
-  let resizers = [], handlers, resize_observer;
+  let resizers = [],
+    handlers,
+    resize_observer;
 
   $: rows = $filtered_data ? flattenVisibleTree($filtered_data, $closed_node_ids) : [];
   $: isDark = $theme == "dark";

--- a/src/components/TreeTableHeader.svelte
+++ b/src/components/TreeTableHeader.svelte
@@ -1,13 +1,46 @@
 <script>
   import { filter } from "../stores.ts";
+  import { column_settings } from "../stores/column_settings.ts";
   import MultiSelect from "./MultiSelect.svelte";
+
   export let headers;
+
   let selected = [];
   $: $filter = {
     ...$filter,
     status: selected.length > 0 ? selected : undefined,
   };
+
+  let showPanel = false;
+  let panelElement;
+  let panelStyle = "";
+
+  $: availableIds = new Set(headers.map((h) => h.name));
+
+  function openPanel(e) {
+    e.stopPropagation();
+    const rect = e.currentTarget.getBoundingClientRect();
+    panelStyle = `top: ${rect.bottom}px; right: calc(100vw - ${rect.right}px);`;
+    showPanel = !showPanel;
+  }
+
+  function handleWindowClick(e) {
+    if (showPanel && panelElement && !panelElement.contains(e.target)) {
+      showPanel = false;
+    }
+  }
+
+  function portal(node) {
+    document.body.appendChild(node);
+    return {
+      destroy() {
+        if (node.parentNode) node.parentNode.removeChild(node);
+      },
+    };
+  }
 </script>
+
+<svelte:window on:click={handleWindowClick} />
 
 <div class:TableRow={true} role="row">
   {#each headers as header}
@@ -30,7 +63,85 @@
       {/if}
     </div>
   {/each}
+
+  <button
+    class="ColumnSettingsBtn"
+    aria-label="Column settings"
+    aria-expanded={showPanel}
+    on:click={openPanel}
+  >
+    <svg viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
+      <path
+        d="M12 15a3 3 0 1 0 0-6 3 3 0 0 0 0 6Z"
+        stroke-width="2"
+        stroke-linecap="round"
+        stroke-linejoin="round"
+      />
+      <path
+        d="M19.4 15a1.65 1.65 0 0 0 .33 1.82l.06.06a2 2 0 0 1-2.83 2.83l-.06-.06a1.65 1.65 0 0 0-1.82-.33 1.65 1.65 0 0 0-1 1.51V21a2 2 0 0 1-4 0v-.09A1.65 1.65 0 0 0 9 19.4a1.65 1.65 0 0 0-1.82.33l-.06.06a2 2 0 0 1-2.83-2.83l.06-.06A1.65 1.65 0 0 0 4.68 15a1.65 1.65 0 0 0-1.51-1H3a2 2 0 0 1 0-4h.09A1.65 1.65 0 0 0 4.6 9a1.65 1.65 0 0 0-.33-1.82l-.06-.06a2 2 0 0 1 2.83-2.83l.06.06A1.65 1.65 0 0 0 9 4.68a1.65 1.65 0 0 0 1-1.51V3a2 2 0 0 1 4 0v.09a1.65 1.65 0 0 0 1 1.51 1.65 1.65 0 0 0 1.82-.33l.06-.06a2 2 0 0 1 2.83 2.83l-.06.06A1.65 1.65 0 0 0 19.4 9a1.65 1.65 0 0 0 1.51 1H21a2 2 0 0 1 0 4h-.09a1.65 1.65 0 0 0-1.51 1Z"
+        stroke-width="2"
+        stroke-linecap="round"
+        stroke-linejoin="round"
+      />
+    </svg>
+  </button>
 </div>
+
+{#if showPanel}
+  <div
+    bind:this={panelElement}
+    class="ColumnSettingsPanel"
+    style={panelStyle}
+    role="dialog"
+    aria-label="カラム表示設定"
+    use:portal
+  >
+    <div class="PanelTitle">カラム表示設定</div>
+    {#each $column_settings as setting}
+      {#if availableIds.has(setting.id)}
+        <div class="SettingsRow">
+          {#if setting.id === "name"}
+            <span class="LockIcon" aria-hidden="true">
+              <svg viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
+                <rect x="3" y="11" width="18" height="11" rx="2" ry="2" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" />
+                <path d="M7 11V7a5 5 0 0 1 10 0v4" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" />
+              </svg>
+            </span>
+            <span class="ColumnLabel">{setting.label}</span>
+          {:else}
+            <input
+              type="checkbox"
+              id={`col-vis-${setting.id}`}
+              checked={setting.visible}
+              on:change={() => column_settings.toggle(setting.id)}
+            />
+            <label for={`col-vis-${setting.id}`} class="ColumnLabel">{setting.label}</label>
+            <div class="MoveButtons">
+              <button
+                class="MoveBtn"
+                aria-label="Move {setting.label} up"
+                on:click|stopPropagation={() => column_settings.moveUp(setting.id)}
+              >
+                <svg viewBox="0 0 24 24" fill="currentColor" xmlns="http://www.w3.org/2000/svg">
+                  <path d="M12 5l-7 7h4v7h6v-7h4z" />
+                </svg>
+              </button>
+              <button
+                class="MoveBtn"
+                aria-label="Move {setting.label} down"
+                on:click|stopPropagation={() => column_settings.moveDown(setting.id)}
+              >
+                <svg viewBox="0 0 24 24" fill="currentColor" xmlns="http://www.w3.org/2000/svg">
+                  <path d="M12 19l7-7h-4V5h-6v7H5z" />
+                </svg>
+              </button>
+            </div>
+          {/if}
+        </div>
+      {/if}
+    {/each}
+  </div>
+{/if}
 
 <style>
   .TableRow {
@@ -60,15 +171,128 @@
     justify-content: center;
     font-weight: bold;
   }
-  .TableHeader:last-child {
+  .TableHeader:last-of-type {
     border-right: 0px;
   }
-  .TableHeader:first-child {
+  .TableHeader:first-of-type {
     border-left: 0px;
   }
   .TextOverFlow {
     text-overflow: ellipsis;
     overflow: hidden;
     white-space: nowrap;
+  }
+
+  .ColumnSettingsBtn {
+    position: absolute;
+    top: 0;
+    right: 0;
+    height: 100%;
+    width: 2rem;
+    flex-shrink: 0;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    background-color: var(--theme-color-Sub-light);
+    border: none;
+    border-left: 1px solid var(--theme-color-Sub-dark);
+    border-bottom: 1px solid;
+    cursor: pointer;
+    z-index: 1;
+    opacity: 0.6;
+    padding: 0.4rem;
+    box-sizing: border-box;
+  }
+  .ColumnSettingsBtn:hover,
+  .ColumnSettingsBtn[aria-expanded="true"] {
+    opacity: 1;
+    background-color: var(--theme-color-Accent-dark);
+  }
+  .ColumnSettingsBtn svg {
+    width: 100%;
+    height: 100%;
+    stroke: var(--theme-color-Main-light);
+  }
+
+  .ColumnSettingsPanel {
+    position: fixed;
+    z-index: 99999999;
+    background: var(--theme-color-Main-main);
+    border: 1px solid var(--theme-color-Sub-dark);
+    border-radius: 0.5rem;
+    box-shadow: 0 0.25rem 0.75rem rgba(0, 0, 0, 0.25);
+    padding: 0.5rem 0;
+    min-width: 13rem;
+  }
+  .PanelTitle {
+    font-size: 0.75rem;
+    font-weight: bold;
+    color: var(--theme-color-Sub-dark);
+    padding: 0.25rem 0.75rem 0.5rem;
+    border-bottom: 1px solid var(--theme-color-Sub-dark);
+    margin-bottom: 0.25rem;
+  }
+  .SettingsRow {
+    display: flex;
+    align-items: center;
+    padding: 0.3rem 0.75rem;
+    gap: 0.5rem;
+    color: var(--theme-color-Sub-light);
+    font-size: 0.875rem;
+  }
+  .SettingsRow:hover {
+    background-color: var(--theme-color-Main-dark);
+  }
+  .LockIcon {
+    width: 0.9rem;
+    height: 0.9rem;
+    flex-shrink: 0;
+    opacity: 0.4;
+    display: flex;
+    align-items: center;
+  }
+  .LockIcon svg {
+    width: 100%;
+    height: 100%;
+    stroke: currentColor;
+  }
+  .ColumnLabel {
+    flex: 1;
+    cursor: pointer;
+    user-select: none;
+  }
+  input[type="checkbox"] {
+    width: 0.9rem;
+    height: 0.9rem;
+    flex-shrink: 0;
+    cursor: pointer;
+    accent-color: var(--theme-color-Accent-dark);
+  }
+  .MoveButtons {
+    display: flex;
+    gap: 0.1rem;
+    flex-shrink: 0;
+  }
+  .MoveBtn {
+    width: 1.2rem;
+    height: 1.2rem;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    background: transparent;
+    border: none;
+    cursor: pointer;
+    border-radius: 0.2rem;
+    padding: 0.1rem;
+    color: var(--theme-color-Sub-light);
+    opacity: 0.6;
+  }
+  .MoveBtn:hover {
+    background-color: var(--theme-color-Accent-dark);
+    opacity: 1;
+  }
+  .MoveBtn svg {
+    width: 100%;
+    height: 100%;
   }
 </style>

--- a/src/components/TreeTableHeader.svelte
+++ b/src/components/TreeTableHeader.svelte
@@ -4,6 +4,7 @@
   import MultiSelect from "./MultiSelect.svelte";
 
   export let headers;
+  export let allHeaders = [];
 
   let selected = [];
   $: $filter = {
@@ -15,7 +16,7 @@
   let panelElement;
   let panelStyle = "";
 
-  $: availableIds = new Set(headers.map((h) => h.name));
+  $: availableIds = new Set(allHeaders.map((h) => h.name));
 
   function openPanel(e) {
     e.stopPropagation();

--- a/src/components/TreeTableHeader.svelte
+++ b/src/components/TreeTableHeader.svelte
@@ -103,8 +103,23 @@
           {#if setting.id === "name"}
             <span class="LockIcon" aria-hidden="true">
               <svg viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
-                <rect x="3" y="11" width="18" height="11" rx="2" ry="2" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" />
-                <path d="M7 11V7a5 5 0 0 1 10 0v4" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" />
+                <rect
+                  x="3"
+                  y="11"
+                  width="18"
+                  height="11"
+                  rx="2"
+                  ry="2"
+                  stroke-width="2"
+                  stroke-linecap="round"
+                  stroke-linejoin="round"
+                />
+                <path
+                  d="M7 11V7a5 5 0 0 1 10 0v4"
+                  stroke-width="2"
+                  stroke-linecap="round"
+                  stroke-linejoin="round"
+                />
               </svg>
             </span>
             <span class="ColumnLabel">{setting.label}</span>

--- a/src/stores/column_settings.ts
+++ b/src/stores/column_settings.ts
@@ -1,0 +1,113 @@
+import { writable, type Writable } from "svelte/store";
+
+export interface ColumnSetting {
+  id: string;
+  label: string;
+  visible: boolean;
+}
+
+export interface ColumnSettingsStore extends Writable<ColumnSetting[]> {
+  init: () => void;
+  toggle: (id: string) => void;
+  moveUp: (id: string) => void;
+  moveDown: (id: string) => void;
+}
+
+const META_KEY = "column_settings";
+
+export const DEFAULT_COLUMN_SETTINGS: ColumnSetting[] = [
+  { id: "name", label: "タスク名", visible: true },
+  { id: "status", label: "ステータス", visible: true },
+  { id: "due date", label: "期限日", visible: true },
+  { id: "memo", label: "メモ数", visible: false },
+];
+
+function isColumnSettingsArray(value: unknown): value is ColumnSetting[] {
+  return (
+    Array.isArray(value) &&
+    value.every(
+      (item) =>
+        typeof item === "object" &&
+        item !== null &&
+        typeof (item as Record<string, unknown>).id === "string" &&
+        typeof (item as Record<string, unknown>).visible === "boolean"
+    )
+  );
+}
+
+function createColumnSettings(): ColumnSettingsStore {
+  const { subscribe, set, update } = writable<ColumnSetting[]>(DEFAULT_COLUMN_SETTINGS);
+
+  const save = (settings: ColumnSetting[]) => {
+    try {
+      window.electronAPI.setMetaData(META_KEY, settings);
+    } catch {
+      // ignore
+    }
+  };
+
+  return {
+    subscribe,
+    set,
+    update,
+    init: () => {
+      window.electronAPI
+        .getMetaData(META_KEY)
+        .then((saved) => {
+          if (!isColumnSettingsArray(saved)) return;
+
+          // Merge saved settings with defaults (handles new columns added later)
+          const merged = DEFAULT_COLUMN_SETTINGS.map((def) => {
+            const found = saved.find((s) => s.id === def.id);
+            return found ? { ...def, visible: found.visible } : def;
+          });
+
+          // Restore saved column ordering
+          const savedOrder = saved.map((s) => s.id);
+          merged.sort((a, b) => {
+            const ai = savedOrder.indexOf(a.id);
+            const bi = savedOrder.indexOf(b.id);
+            if (ai === -1 && bi === -1) return 0;
+            if (ai === -1) return 1;
+            if (bi === -1) return -1;
+            return ai - bi;
+          });
+
+          set(merged);
+        })
+        .catch(() => {
+          // keep defaults
+        });
+    },
+    toggle: (id: string) => {
+      if (id === "name") return;
+      update((settings) => {
+        const next = settings.map((s) => (s.id === id ? { ...s, visible: !s.visible } : s));
+        save(next);
+        return next;
+      });
+    },
+    moveUp: (id: string) => {
+      update((settings) => {
+        const index = settings.findIndex((s) => s.id === id);
+        if (index <= 1) return settings; // Cannot move before 'name'
+        const next = [...settings];
+        [next[index - 1], next[index]] = [next[index], next[index - 1]];
+        save(next);
+        return next;
+      });
+    },
+    moveDown: (id: string) => {
+      update((settings) => {
+        const index = settings.findIndex((s) => s.id === id);
+        if (index < 0 || index >= settings.length - 1) return settings;
+        const next = [...settings];
+        [next[index], next[index + 1]] = [next[index + 1], next[index]];
+        save(next);
+        return next;
+      });
+    },
+  };
+}
+
+export const column_settings = createColumnSettings();

--- a/src/stores/index.ts
+++ b/src/stores/index.ts
@@ -3,12 +3,14 @@ export * from "./tree";
 export * from "./project";
 export * from "./search";
 export * from "./ui";
+export * from "./column_settings";
 
 import { tree_data } from "./tree";
 import { project_ids } from "./project";
 import { selected_id, closed_node_ids } from "./ui";
 import { filter } from "./search";
 import { theme } from "./theme";
+import { column_settings } from "./column_settings";
 
 export function init_store() {
   tree_data.init();
@@ -17,4 +19,5 @@ export function init_store() {
   filter.init();
   theme.init();
   closed_node_ids.init();
+  column_settings.init();
 }

--- a/tests/unit/column_settings.test.js
+++ b/tests/unit/column_settings.test.js
@@ -1,0 +1,149 @@
+import { get } from "svelte/store";
+import { vi, describe, test, expect, beforeEach } from "vitest";
+import { column_settings, DEFAULT_COLUMN_SETTINGS } from "../../src/stores/column_settings.ts";
+
+describe("column_settings store", () => {
+  let mockSetMetaData;
+  let mockGetMetaData;
+
+  beforeEach(() => {
+    mockSetMetaData = vi.fn();
+    mockGetMetaData = vi.fn().mockResolvedValue(null);
+
+    Object.defineProperty(window, "electronAPI", {
+      configurable: true,
+      value: {
+        setMetaData: mockSetMetaData,
+        getMetaData: mockGetMetaData,
+      },
+    });
+
+    column_settings.set([...DEFAULT_COLUMN_SETTINGS]);
+  });
+
+  test("has correct default settings", () => {
+    const settings = get(column_settings);
+    expect(settings.find((s) => s.id === "name").visible).toBe(true);
+    expect(settings.find((s) => s.id === "status").visible).toBe(true);
+    expect(settings.find((s) => s.id === "due date").visible).toBe(true);
+    expect(settings.find((s) => s.id === "memo").visible).toBe(false);
+  });
+
+  test("name column is always first by default", () => {
+    const settings = get(column_settings);
+    expect(settings[0].id).toBe("name");
+  });
+
+  test("toggle changes column visibility", () => {
+    column_settings.toggle("status");
+    expect(get(column_settings).find((s) => s.id === "status").visible).toBe(false);
+
+    column_settings.toggle("status");
+    expect(get(column_settings).find((s) => s.id === "status").visible).toBe(true);
+  });
+
+  test("toggle does not affect name column", () => {
+    column_settings.toggle("name");
+    expect(get(column_settings).find((s) => s.id === "name").visible).toBe(true);
+  });
+
+  test("toggle saves to metaData", () => {
+    column_settings.toggle("status");
+    expect(mockSetMetaData).toHaveBeenCalledWith("column_settings", expect.any(Array));
+  });
+
+  test("moveUp reorders columns", () => {
+    const before = get(column_settings).map((s) => s.id);
+    const dueDateIndex = before.indexOf("due date");
+    column_settings.moveUp("due date");
+    const after = get(column_settings).map((s) => s.id);
+    expect(after.indexOf("due date")).toBe(dueDateIndex - 1);
+  });
+
+  test("moveUp cannot move past name column", () => {
+    // status is at index 1 (right after name)
+    column_settings.moveUp("status");
+    expect(get(column_settings)[0].id).toBe("name");
+    expect(get(column_settings)[1].id).toBe("status");
+  });
+
+  test("moveDown reorders columns", () => {
+    const before = get(column_settings).map((s) => s.id);
+    const statusIndex = before.indexOf("status");
+    column_settings.moveDown("status");
+    const after = get(column_settings).map((s) => s.id);
+    expect(after.indexOf("status")).toBe(statusIndex + 1);
+  });
+
+  test("moveDown does nothing for last column", () => {
+    const before = get(column_settings).map((s) => s.id);
+    const lastId = before[before.length - 1];
+    column_settings.moveDown(lastId);
+    const after = get(column_settings).map((s) => s.id);
+    expect(after[after.length - 1]).toBe(lastId);
+  });
+
+  test("moveUp saves to metaData", () => {
+    column_settings.moveUp("due date");
+    expect(mockSetMetaData).toHaveBeenCalledWith("column_settings", expect.any(Array));
+  });
+
+  test("moveDown saves to metaData", () => {
+    column_settings.moveDown("status");
+    expect(mockSetMetaData).toHaveBeenCalledWith("column_settings", expect.any(Array));
+  });
+
+  test("init loads saved settings from metaData", async () => {
+    const savedSettings = [
+      { id: "name", label: "タスク名", visible: true },
+      { id: "due date", label: "期限日", visible: true },
+      { id: "status", label: "ステータス", visible: false },
+      { id: "memo", label: "メモ数", visible: true },
+    ];
+    mockGetMetaData.mockResolvedValue(savedSettings);
+
+    await column_settings.init();
+    // Allow promise to settle
+    await new Promise((r) => setTimeout(r, 0));
+
+    const settings = get(column_settings);
+    expect(settings.find((s) => s.id === "status").visible).toBe(false);
+    expect(settings.find((s) => s.id === "memo").visible).toBe(true);
+  });
+
+  test("init preserves saved column ordering", async () => {
+    const savedSettings = [
+      { id: "name", label: "タスク名", visible: true },
+      { id: "memo", label: "メモ数", visible: false },
+      { id: "status", label: "ステータス", visible: true },
+      { id: "due date", label: "期限日", visible: true },
+    ];
+    mockGetMetaData.mockResolvedValue(savedSettings);
+
+    await column_settings.init();
+    await new Promise((r) => setTimeout(r, 0));
+
+    const ids = get(column_settings).map((s) => s.id);
+    expect(ids.indexOf("memo")).toBeLessThan(ids.indexOf("status"));
+  });
+
+  test("init keeps defaults when metaData returns invalid data", async () => {
+    mockGetMetaData.mockResolvedValue("invalid");
+
+    await column_settings.init();
+    await new Promise((r) => setTimeout(r, 0));
+
+    const settings = get(column_settings);
+    expect(settings).toEqual(DEFAULT_COLUMN_SETTINGS);
+  });
+
+  test("init keeps defaults when metaData fails", async () => {
+    mockGetMetaData.mockRejectedValue(new Error("network error"));
+
+    await column_settings.init();
+    await new Promise((r) => setTimeout(r, 0));
+
+    const settings = get(column_settings);
+    expect(settings).toEqual(DEFAULT_COLUMN_SETTINGS);
+  });
+});


### PR DESCRIPTION
## 概要

issue #35 の実装。タスクツリーに表示するカラムをユーザーが自由に表示/非表示・並び替えできるようにした。

## 変更内容

### 新規ファイル
- `src/stores/column_settings.ts` — カラム設定ストア（表示状態・順序・meta.json 永続化）
- `tests/unit/column_settings.test.js` — ストアのユニットテスト（15ケース）

### 変更ファイル
- `src/stores/index.ts` — `column_settings` を export・init に追加
- `src/components/TreeTableHeader.svelte` — ヘッダー右端にギアボタン＋「カラム表示設定」パネルを追加
- `src/components/TreeTable.svelte` — `visibleHeaders` を算出してヘッダー・行・リサイザーに反映

## 動作

| 機能 | 詳細 |
|------|------|
| 表示/非表示 | ヘッダー右端のギアアイコンからパネルを開き、チェックボックスで切り替え |
| 並び替え | パネル内の ↑↓ ボタンで順序変更 |
| タスク名は常に表示 | ロックアイコンで示し、非表示・移動不可 |
| 永続化 | `meta.json` の `column_settings` キーに保存（全プロジェクト共通） |
| デフォルト | タスク名・ステータス・期限日 ON、メモ数 OFF |

## スクリーンショット

**通常のテーブル表示（メモ数は非表示）**

![通常表示](https://github.com/user-attachments/assets/placeholder-table)

カラム設定パネル（ギアボタンクリック時）：
- 🔒 タスク名（固定）
- ☑ ステータス ↑↓
- ☑ 期限日 ↑↓
- ☐ メモ数 ↑↓（チェックするとカラムが追加される）

## テスト

- 既存74テストすべて通過
- column_settings ストアの新規テスト15ケース追加

https://claude.ai/code/session_01DDZGTzDCou1r7wLdupDcq4

---
_Generated by [Claude Code](https://claude.ai/code/session_01DDZGTzDCou1r7wLdupDcq4)_