### PR TITLE
feat: ワークスペース用DAGデータ層を追加（#60 #61）

### DIFF
--- a/electron/index.js
+++ b/electron/index.js
@@ -4,6 +4,7 @@ const fs = require("fs");
 const path = require("path");
 const { LowSync, JSONFileSync } = require("@commonify/lowdb");
 const log = require("electron-log/main");
+const workspace = require("./workspace");
 
 function resolveAppDataPath(fileName) {
   const customDataDir = process.env.TASK_MANAGE_DATA_DIR;
@@ -464,5 +465,113 @@ app.on("ready", () => {
   // 検索ウィンドウからテーマ情報を要求された場合
   ipcMain.handle("get-current-theme", async (event) => {
     return db_meta.data.theme || "dark";
+  });
+
+  ////////////// Workspace IPC //////////////
+  // projectDir → { tasks: Map, taskDirs: Map } のインメモリキャッシュ
+  const wsCache = new Map();
+
+  ipcMain.handle("ws:get-workspaces", async () => {
+    return {
+      workspaces: db_meta.data.workspaces || [],
+      activeWorkspace: db_meta.data.activeWorkspace || null,
+    };
+  });
+
+  ipcMain.on("ws:set-workspaces", (event, { workspaces, activeWorkspace }) => {
+    db_meta.data.workspaces = workspaces;
+    if (activeWorkspace !== undefined) db_meta.data.activeWorkspace = activeWorkspace;
+    try {
+      db_meta.write();
+    } catch (err) {
+      showSaveError("ws:set-workspaces", err);
+    }
+  });
+
+  ipcMain.handle("ws:list-projects", async (event, { workspacePath }) => {
+    try {
+      return workspace.listProjects(workspacePath);
+    } catch (err) {
+      log.error("ws:list-projects error:", err.message);
+      return [];
+    }
+  });
+
+  ipcMain.handle("ws:read-project", async (event, { projectDir }) => {
+    try {
+      const { tasks, taskDirs } = workspace.readProject(projectDir);
+      wsCache.set(projectDir, { tasks, taskDirs });
+      // Map → plain object for IPC serialisation
+      return { tasks: Object.fromEntries(tasks) };
+    } catch (err) {
+      log.error("ws:read-project error:", err.message);
+      throw err;
+    }
+  });
+
+  ipcMain.handle("ws:write-task", async (event, { projectDir, task }) => {
+    try {
+      let cached = wsCache.get(projectDir);
+      if (!cached) {
+        const { tasks, taskDirs } = workspace.readProject(projectDir);
+        cached = { tasks, taskDirs };
+        wsCache.set(projectDir, cached);
+      }
+      const { tasks, taskDirs } = cached;
+
+      // Cycle check when parents are being set
+      if (task.parents && task.parents.length > 0) {
+        // Merge updated task into the map for a correct check
+        const tasksWithUpdate = new Map(tasks);
+        tasksWithUpdate.set(task.id, task);
+        if (workspace.wouldCreateCycle(tasksWithUpdate, task.id, task.parents)) {
+          return { success: false, error: "循環が発生するため保存できません" };
+        }
+      }
+
+      workspace.writeTask(projectDir, task, taskDirs);
+      tasks.set(task.id, task);
+      return { success: true };
+    } catch (err) {
+      log.error("ws:write-task error:", err.message);
+      return { success: false, error: err.message };
+    }
+  });
+
+  ipcMain.handle("ws:delete-task", async (event, { projectDir, taskId }) => {
+    try {
+      let cached = wsCache.get(projectDir);
+      if (!cached) {
+        const { tasks, taskDirs } = workspace.readProject(projectDir);
+        cached = { tasks, taskDirs };
+        wsCache.set(projectDir, cached);
+      }
+      const { tasks, taskDirs } = cached;
+
+      // Orphan check: any task whose only parent is taskId would be orphaned
+      const wouldOrphan = [...tasks.values()].some(
+        (t) => t.parents.length === 1 && t.parents[0] === taskId,
+      );
+      if (wouldOrphan) {
+        return { success: false, error: "子タスクが孤立するため削除できません" };
+      }
+
+      workspace.deleteTaskDir(projectDir, taskDirs, taskId);
+      tasks.delete(taskId);
+      return { success: true };
+    } catch (err) {
+      log.error("ws:delete-task error:", err.message);
+      return { success: false, error: err.message };
+    }
+  });
+
+  ipcMain.handle("ws:create-project", async (event, { workspacePath, name, id }) => {
+    try {
+      const result = workspace.createProject(workspacePath, name, id);
+      return { success: true, ...result };
+    } catch (err) {
+      log.error("ws:create-project error:", err.message);
+      return { success: false, error: err.message };
+    }
   });
 });

--- a/electron/index.js
+++ b/electron/index.js
@@ -550,7 +550,7 @@ app.on("ready", () => {
 
       // Orphan check: any task whose only parent is taskId would be orphaned
       const wouldOrphan = [...tasks.values()].some(
-        (t) => t.parents.length === 1 && t.parents[0] === taskId,
+        (t) => t.parents.length === 1 && t.parents[0] === taskId
       );
       if (wouldOrphan) {
         return { success: false, error: "子タスクが孤立するため削除できません" };

--- a/electron/preload.js
+++ b/electron/preload.js
@@ -2,6 +2,8 @@ const { contextBridge, ipcRenderer } = require("electron");
 
 /** @typedef {import("../src/types/app").ElectronAPI} ElectronAPI */
 /** @typedef {import("../src/types/app").FindInPageResult} FindInPageResult */
+/** @typedef {import("../src/types/workspace").WorkspaceTask} WorkspaceTask */
+/** @typedef {import("../src/types/workspace").WorkspaceInfo} WorkspaceInfo */
 
 /** @type {ElectronAPI} */
 const electronAPI = {
@@ -72,6 +74,20 @@ const electronAPI = {
   getCurrentTheme: () => {
     return ipcRenderer.invoke("get-current-theme");
   },
+
+  // ワークスペース操作
+  wsGetWorkspaces: () => ipcRenderer.invoke("ws:get-workspaces"),
+  wsSetWorkspaces: (config) => ipcRenderer.send("ws:set-workspaces", config),
+  wsListProjects: (workspacePath) =>
+    ipcRenderer.invoke("ws:list-projects", { workspacePath }),
+  wsReadProject: (projectDir) =>
+    ipcRenderer.invoke("ws:read-project", { projectDir }),
+  wsWriteTask: (projectDir, task) =>
+    ipcRenderer.invoke("ws:write-task", { projectDir, task }),
+  wsDeleteTask: (projectDir, taskId) =>
+    ipcRenderer.invoke("ws:delete-task", { projectDir, taskId }),
+  wsCreateProject: (workspacePath, name, id) =>
+    ipcRenderer.invoke("ws:create-project", { workspacePath, name, id }),
 };
 
 contextBridge.exposeInMainWorld("electronAPI", electronAPI);

--- a/electron/preload.js
+++ b/electron/preload.js
@@ -78,12 +78,9 @@ const electronAPI = {
   // ワークスペース操作
   wsGetWorkspaces: () => ipcRenderer.invoke("ws:get-workspaces"),
   wsSetWorkspaces: (config) => ipcRenderer.send("ws:set-workspaces", config),
-  wsListProjects: (workspacePath) =>
-    ipcRenderer.invoke("ws:list-projects", { workspacePath }),
-  wsReadProject: (projectDir) =>
-    ipcRenderer.invoke("ws:read-project", { projectDir }),
-  wsWriteTask: (projectDir, task) =>
-    ipcRenderer.invoke("ws:write-task", { projectDir, task }),
+  wsListProjects: (workspacePath) => ipcRenderer.invoke("ws:list-projects", { workspacePath }),
+  wsReadProject: (projectDir) => ipcRenderer.invoke("ws:read-project", { projectDir }),
+  wsWriteTask: (projectDir, task) => ipcRenderer.invoke("ws:write-task", { projectDir, task }),
   wsDeleteTask: (projectDir, taskId) =>
     ipcRenderer.invoke("ws:delete-task", { projectDir, taskId }),
   wsCreateProject: (workspacePath, name, id) =>

--- a/electron/workspace.js
+++ b/electron/workspace.js
@@ -106,11 +106,7 @@ function readRootTask(projectDir) {
 function readTaskDir(taskDir) {
   const content = fs.readFileSync(path.join(taskDir, "_index.md"), "utf8");
   const { data } = parseFrontmatter(content);
-  const parents = Array.isArray(data.parents)
-    ? data.parents
-    : data.parents
-      ? [data.parents]
-      : [];
+  const parents = Array.isArray(data.parents) ? data.parents : data.parents ? [data.parents] : [];
   return {
     id: data.id,
     name: data.name || "",
@@ -193,9 +189,7 @@ function writeTask(projectDir, task, taskDirs) {
   fs.writeFileSync(path.join(taskDir, "_index.md"), stringifyFrontmatter(data));
 
   // Replace all memo files
-  const existing = fs
-    .readdirSync(taskDir)
-    .filter((f) => f.endsWith(".md") && f !== "_index.md");
+  const existing = fs.readdirSync(taskDir).filter((f) => f.endsWith(".md") && f !== "_index.md");
   for (const f of existing) fs.unlinkSync(path.join(taskDir, f));
   for (const memo of task.memos || []) {
     const base = `${slugify(memo.title) || "memo"}.md`;

--- a/electron/workspace.js
+++ b/electron/workspace.js
@@ -1,0 +1,326 @@
+const fs = require("fs");
+const path = require("path");
+
+/** Convert a human name to a filesystem-safe slug. */
+function slugify(name) {
+  return (
+    String(name)
+      .trim()
+      .toLowerCase()
+      .replace(/[/\\:*?"<>|\x00]/g, "")
+      .replace(/\s+/g, "-")
+      .replace(/^-+|-+$/g, "")
+      .slice(0, 64) || "task"
+  );
+}
+
+/** Return a name that does not already exist inside parentDir. */
+function uniqueName(parentDir, baseName) {
+  if (!fs.existsSync(path.join(parentDir, baseName))) return baseName;
+  let i = 2;
+  while (fs.existsSync(path.join(parentDir, `${baseName}-${i}`))) i++;
+  return `${baseName}-${i}`;
+}
+
+/**
+ * Parse YAML frontmatter from a markdown string.
+ * Returns { data: Record<string, string | string[]>, body: string }.
+ */
+function parseFrontmatter(content) {
+  const match = content.match(/^---\r?\n([\s\S]*?)\r?\n---(?:\r?\n|$)/);
+  if (!match) return { data: {}, body: content };
+
+  const yaml = match[1];
+  const body = content.slice(match[0].length).trim();
+  const data = {};
+  let currentKey = null;
+
+  for (const line of yaml.split(/\r?\n/)) {
+    const listMatch = line.match(/^  - (.+)/);
+    if (listMatch && currentKey) {
+      if (!Array.isArray(data[currentKey])) data[currentKey] = [];
+      data[currentKey].push(listMatch[1].trim());
+      continue;
+    }
+    const kvMatch = line.match(/^([^:]+):\s*(.*)/);
+    if (kvMatch) {
+      currentKey = kvMatch[1].trim();
+      const value = kvMatch[2].trim();
+      data[currentKey] = value || null;
+    }
+  }
+  return { data, body };
+}
+
+/**
+ * Serialize data object + optional body to markdown with YAML frontmatter.
+ */
+function stringifyFrontmatter(data, body = "") {
+  const lines = ["---"];
+  for (const [key, value] of Object.entries(data)) {
+    if (value === undefined || value === null) continue;
+    if (Array.isArray(value)) {
+      lines.push(`${key}:`);
+      for (const item of value) lines.push(`  - ${item}`);
+    } else {
+      lines.push(`${key}: ${value}`);
+    }
+  }
+  lines.push("---");
+  if (body) lines.push("", body);
+  return lines.join("\n") + "\n";
+}
+
+/** Read memos from a task directory (all .md files except _index.md). */
+function readMemos(taskDir) {
+  const memos = [];
+  const files = fs
+    .readdirSync(taskDir)
+    .filter((f) => f.endsWith(".md") && f !== "_index.md")
+    .sort();
+  for (const file of files) {
+    const content = fs.readFileSync(path.join(taskDir, file), "utf8");
+    const headingMatch = content.match(/^#\s+(.+)/m);
+    const title = headingMatch ? headingMatch[1].trim() : file.replace(/\.md$/, "");
+    memos.push({ title, content: content.trim() });
+  }
+  return memos;
+}
+
+/** Read the root task from _project.md inside projectDir. */
+function readRootTask(projectDir) {
+  const content = fs.readFileSync(path.join(projectDir, "_project.md"), "utf8");
+  const { data } = parseFrontmatter(content);
+  return {
+    id: data.id,
+    name: data.name || "",
+    status: data.status || "Open",
+    dueDate: data.due || undefined,
+    parents: [],
+    memos: [],
+    createdAt: data.created || "",
+  };
+}
+
+/** Read a regular task from its subdirectory. */
+function readTaskDir(taskDir) {
+  const content = fs.readFileSync(path.join(taskDir, "_index.md"), "utf8");
+  const { data } = parseFrontmatter(content);
+  const parents = Array.isArray(data.parents)
+    ? data.parents
+    : data.parents
+      ? [data.parents]
+      : [];
+  return {
+    id: data.id,
+    name: data.name || "",
+    status: data.status || "Open",
+    dueDate: data.due || undefined,
+    parents,
+    memos: readMemos(taskDir),
+    createdAt: data.created || "",
+  };
+}
+
+/**
+ * Read all tasks from a project directory.
+ * Returns { tasks: Map<id, task>, taskDirs: Map<id, dirName> }
+ */
+function readProject(projectDir) {
+  const tasks = new Map();
+  const taskDirs = new Map();
+
+  const rootFile = path.join(projectDir, "_project.md");
+  if (fs.existsSync(rootFile)) {
+    const root = readRootTask(projectDir);
+    if (root.id) {
+      tasks.set(root.id, root);
+      taskDirs.set(root.id, "_project");
+    }
+  }
+
+  const entries = fs.readdirSync(projectDir, { withFileTypes: true });
+  for (const entry of entries) {
+    if (!entry.isDirectory() || entry.name.startsWith("_")) continue;
+    const taskDir = path.join(projectDir, entry.name);
+    if (!fs.existsSync(path.join(taskDir, "_index.md"))) continue;
+    try {
+      const task = readTaskDir(taskDir);
+      if (task.id) {
+        tasks.set(task.id, task);
+        taskDirs.set(task.id, entry.name);
+      }
+    } catch (_) {
+      // Skip malformed task directories
+    }
+  }
+
+  return { tasks, taskDirs };
+}
+
+/** Write root task to _project.md. */
+function writeRootTask(projectDir, task) {
+  fs.mkdirSync(projectDir, { recursive: true });
+  const data = { id: task.id, name: task.name, status: task.status };
+  if (task.dueDate) data.due = task.dueDate;
+  data.created = task.createdAt || new Date().toISOString().slice(0, 10);
+  fs.writeFileSync(path.join(projectDir, "_project.md"), stringifyFrontmatter(data));
+}
+
+/**
+ * Write a task to its directory. Creates directory on first write.
+ * taskDirs (Map<id, dirName>) is mutated when a new dir is allocated.
+ */
+function writeTask(projectDir, task, taskDirs) {
+  if (!task.parents || task.parents.length === 0) {
+    writeRootTask(projectDir, task);
+    if (!taskDirs.has(task.id)) taskDirs.set(task.id, "_project");
+    return;
+  }
+
+  let dirName = taskDirs.get(task.id);
+  if (!dirName) {
+    dirName = uniqueName(projectDir, slugify(task.name));
+    taskDirs.set(task.id, dirName);
+  }
+  const taskDir = path.join(projectDir, dirName);
+  fs.mkdirSync(taskDir, { recursive: true });
+
+  const data = { id: task.id, name: task.name, status: task.status };
+  if (task.dueDate) data.due = task.dueDate;
+  if (task.parents.length > 0) data.parents = task.parents;
+  data.created = task.createdAt || new Date().toISOString().slice(0, 10);
+  fs.writeFileSync(path.join(taskDir, "_index.md"), stringifyFrontmatter(data));
+
+  // Replace all memo files
+  const existing = fs
+    .readdirSync(taskDir)
+    .filter((f) => f.endsWith(".md") && f !== "_index.md");
+  for (const f of existing) fs.unlinkSync(path.join(taskDir, f));
+  for (const memo of task.memos || []) {
+    const base = `${slugify(memo.title) || "memo"}.md`;
+    const fileName = uniqueName(taskDir, base);
+    fs.writeFileSync(path.join(taskDir, fileName), memo.content + "\n");
+  }
+}
+
+/**
+ * Delete a task's directory (and its files).
+ * The root task (_project) cannot be deleted here.
+ */
+function deleteTaskDir(projectDir, taskDirs, taskId) {
+  const dirName = taskDirs.get(taskId);
+  if (!dirName || dirName === "_project") return;
+  const taskDir = path.join(projectDir, dirName);
+  if (fs.existsSync(taskDir)) fs.rmSync(taskDir, { recursive: true });
+  taskDirs.delete(taskId);
+}
+
+/**
+ * Create a new project directory with a root _project.md.
+ * Returns { dirName, projectDir }.
+ */
+function createProject(workspacePath, name, id) {
+  const dirName = uniqueName(workspacePath, slugify(name) || "project");
+  const projectDir = path.join(workspacePath, dirName);
+  fs.mkdirSync(projectDir, { recursive: true });
+  const today = new Date().toISOString().slice(0, 10);
+  writeRootTask(projectDir, { id, name, status: "Open", parents: [], memos: [], createdAt: today });
+  return { dirName, projectDir };
+}
+
+/**
+ * List all projects (directories containing _project.md) inside a workspace.
+ * Returns WorkspaceProjectListItem[].
+ */
+function listProjects(workspacePath) {
+  if (!fs.existsSync(workspacePath)) return [];
+  const entries = fs.readdirSync(workspacePath, { withFileTypes: true });
+  const projects = [];
+  for (const entry of entries) {
+    if (!entry.isDirectory()) continue;
+    const projectFile = path.join(workspacePath, entry.name, "_project.md");
+    if (!fs.existsSync(projectFile)) continue;
+    try {
+      const content = fs.readFileSync(projectFile, "utf8");
+      const { data } = parseFrontmatter(content);
+      projects.push({ name: data.name || entry.name, rootId: data.id, dirName: entry.name });
+    } catch (_) {}
+  }
+  return projects;
+}
+
+/**
+ * DAG cycle check: would setting taskId's parents to newParents create a cycle?
+ * tasks: Map<id, { parents: string[] }>
+ */
+function wouldCreateCycle(tasks, taskId, newParents) {
+  if (!newParents || newParents.length === 0) return false;
+
+  // Self-cycle: taskId is listed as its own parent
+  if (newParents.includes(taskId)) return true;
+
+  // Build children map from current parent links
+  const children = new Map();
+  for (const [id, task] of tasks) {
+    for (const parent of task.parents) {
+      if (!children.has(parent)) children.set(parent, []);
+      children.get(parent).push(id);
+    }
+  }
+
+  // BFS from taskId following children. If any newParent is reachable → cycle.
+  const visited = new Set();
+  const queue = [taskId];
+  while (queue.length > 0) {
+    const current = queue.shift();
+    if (visited.has(current)) continue;
+    visited.add(current);
+    for (const child of children.get(current) || []) {
+      if (newParents.includes(child)) return true;
+      queue.push(child);
+    }
+  }
+  return false;
+}
+
+/**
+ * BFS traversal from rootId over a task map.
+ * Returns ordered array of task IDs (visited nodes only once).
+ */
+function bfsFromRoot(tasks, rootId) {
+  const children = new Map();
+  for (const [id, task] of tasks) {
+    for (const parent of task.parents) {
+      if (!children.has(parent)) children.set(parent, []);
+      children.get(parent).push(id);
+    }
+  }
+
+  const visited = new Set();
+  const order = [];
+  const queue = [rootId];
+  while (queue.length > 0) {
+    const current = queue.shift();
+    if (visited.has(current)) continue;
+    visited.add(current);
+    order.push(current);
+    for (const child of children.get(current) || []) {
+      queue.push(child);
+    }
+  }
+  return order;
+}
+
+module.exports = {
+  slugify,
+  parseFrontmatter,
+  stringifyFrontmatter,
+  readProject,
+  writeTask,
+  deleteTaskDir,
+  createProject,
+  listProjects,
+  wouldCreateCycle,
+  bfsFromRoot,
+};

--- a/src/types/app.ts
+++ b/src/types/app.ts
@@ -1,4 +1,10 @@
 import type { ProjectData } from "../common/tree_control";
+import type {
+  WorkspaceInfo,
+  WorkspaceProject,
+  WorkspaceProjectListItem,
+  WorkspaceTask,
+} from "./workspace";
 
 export type ThemeName = "dark" | "light";
 export type SelectedType = "Projects" | "Info" | undefined;
@@ -48,4 +54,13 @@ export interface ElectronAPI {
   onProjectDeleted: (callback: (projectId: string) => void) => void;
   onSaveError: (callback: (message: string) => void) => void;
   getCurrentTheme: () => Promise<ThemeName>;
+
+  // Workspace API
+  wsGetWorkspaces: () => Promise<{ workspaces: WorkspaceInfo[]; activeWorkspace: string | null }>;
+  wsSetWorkspaces: (config: { workspaces: WorkspaceInfo[]; activeWorkspace?: string }) => void;
+  wsListProjects: (workspacePath: string) => Promise<WorkspaceProjectListItem[]>;
+  wsReadProject: (projectDir: string) => Promise<WorkspaceProject>;
+  wsWriteTask: (projectDir: string, task: WorkspaceTask) => Promise<{ success: boolean; error?: string }>;
+  wsDeleteTask: (projectDir: string, taskId: string) => Promise<{ success: boolean; error?: string }>;
+  wsCreateProject: (workspacePath: string, name: string, id: string) => Promise<{ success: boolean; projectDir?: string; dirName?: string; error?: string }>;
 }

--- a/src/types/app.ts
+++ b/src/types/app.ts
@@ -60,7 +60,17 @@ export interface ElectronAPI {
   wsSetWorkspaces: (config: { workspaces: WorkspaceInfo[]; activeWorkspace?: string }) => void;
   wsListProjects: (workspacePath: string) => Promise<WorkspaceProjectListItem[]>;
   wsReadProject: (projectDir: string) => Promise<WorkspaceProject>;
-  wsWriteTask: (projectDir: string, task: WorkspaceTask) => Promise<{ success: boolean; error?: string }>;
-  wsDeleteTask: (projectDir: string, taskId: string) => Promise<{ success: boolean; error?: string }>;
-  wsCreateProject: (workspacePath: string, name: string, id: string) => Promise<{ success: boolean; projectDir?: string; dirName?: string; error?: string }>;
+  wsWriteTask: (
+    projectDir: string,
+    task: WorkspaceTask
+  ) => Promise<{ success: boolean; error?: string }>;
+  wsDeleteTask: (
+    projectDir: string,
+    taskId: string
+  ) => Promise<{ success: boolean; error?: string }>;
+  wsCreateProject: (
+    workspacePath: string,
+    name: string,
+    id: string
+  ) => Promise<{ success: boolean; projectDir?: string; dirName?: string; error?: string }>;
 }

--- a/src/types/workspace.ts
+++ b/src/types/workspace.ts
@@ -1,0 +1,32 @@
+export type WorkspaceTaskStatus = "Open" | "Pending" | "In Progress" | "Completed" | "Canceled";
+
+export interface WorkspaceMemo {
+  title: string;
+  content: string; // Markdown
+}
+
+export interface WorkspaceTask {
+  id: string;
+  name: string;
+  status: WorkspaceTaskStatus;
+  dueDate?: string; // YYYY-MM-DD
+  /** Empty array means this is the root task (project itself). */
+  parents: string[];
+  memos: WorkspaceMemo[];
+  createdAt: string; // YYYY-MM-DD
+}
+
+export interface WorkspaceInfo {
+  path: string;
+  label: string;
+}
+
+export interface WorkspaceProjectListItem {
+  name: string;
+  rootId: string;
+  dirName: string;
+}
+
+export interface WorkspaceProject {
+  tasks: Record<string, WorkspaceTask>;
+}

--- a/tests/unit/workspace.test.js
+++ b/tests/unit/workspace.test.js
@@ -1,0 +1,278 @@
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import fs from "fs";
+import path from "path";
+import os from "os";
+import {
+  slugify,
+  parseFrontmatter,
+  stringifyFrontmatter,
+  wouldCreateCycle,
+  bfsFromRoot,
+  createProject,
+  readProject,
+  writeTask,
+  deleteTaskDir,
+  listProjects,
+} from "../../electron/workspace.js";
+
+// ── slugify ──────────────────────────────────────────────────────────────────
+
+describe("slugify", () => {
+  it("converts spaces to hyphens", () => {
+    expect(slugify("Hello World")).toBe("hello-world");
+  });
+
+  it("removes forbidden filesystem characters", () => {
+    expect(slugify('task: foo/bar*"baz')).toBe("task-foobarbaz");
+  });
+
+  it("trims leading/trailing hyphens", () => {
+    expect(slugify("  -foo-  ")).toBe("foo");
+  });
+
+  it("falls back to 'task' for empty string", () => {
+    expect(slugify("")).toBe("task");
+    expect(slugify("???")).toBe("task");
+  });
+
+  it("truncates at 64 characters", () => {
+    const long = "a".repeat(100);
+    expect(slugify(long).length).toBe(64);
+  });
+});
+
+// ── parseFrontmatter / stringifyFrontmatter ───────────────────────────────────
+
+describe("parseFrontmatter", () => {
+  it("parses simple key-value pairs", () => {
+    const md = "---\nid: abc\nname: My Task\nstatus: Open\n---\n";
+    const { data, body } = parseFrontmatter(md);
+    expect(data.id).toBe("abc");
+    expect(data.name).toBe("My Task");
+    expect(data.status).toBe("Open");
+    expect(body).toBe("");
+  });
+
+  it("parses list values", () => {
+    const md = "---\nparents:\n  - id-1\n  - id-2\n---\n";
+    const { data } = parseFrontmatter(md);
+    expect(data.parents).toEqual(["id-1", "id-2"]);
+  });
+
+  it("returns body text after frontmatter", () => {
+    const md = "---\nid: x\n---\n\nHello body";
+    const { body } = parseFrontmatter(md);
+    expect(body).toBe("Hello body");
+  });
+
+  it("returns empty data when no frontmatter", () => {
+    const { data, body } = parseFrontmatter("No frontmatter here");
+    expect(data).toEqual({});
+    expect(body).toBe("No frontmatter here");
+  });
+});
+
+describe("stringifyFrontmatter", () => {
+  it("round-trips scalar fields", () => {
+    const data = { id: "abc", name: "Task", status: "Open" };
+    const result = parseFrontmatter(stringifyFrontmatter(data));
+    expect(result.data).toMatchObject(data);
+  });
+
+  it("round-trips array fields", () => {
+    const data = { parents: ["p1", "p2"] };
+    const result = parseFrontmatter(stringifyFrontmatter(data));
+    expect(result.data.parents).toEqual(["p1", "p2"]);
+  });
+
+  it("omits null/undefined values", () => {
+    const md = stringifyFrontmatter({ id: "x", due: null, name: undefined });
+    expect(md).not.toContain("due:");
+    expect(md).not.toContain("name:");
+  });
+
+  it("appends body after frontmatter", () => {
+    const md = stringifyFrontmatter({ id: "x" }, "body content");
+    expect(md).toContain("body content");
+    expect(md.indexOf("---\n")).toBeLessThan(md.indexOf("body content"));
+  });
+});
+
+// ── wouldCreateCycle ──────────────────────────────────────────────────────────
+
+function makeTasks(spec) {
+  // spec: { id: { parents: [ids] } }
+  const tasks = new Map();
+  for (const [id, { parents }] of Object.entries(spec)) {
+    tasks.set(id, { id, parents, name: id, status: "Open", memos: [], createdAt: "" });
+  }
+  return tasks;
+}
+
+describe("wouldCreateCycle", () => {
+  it("returns false for empty newParents", () => {
+    const tasks = makeTasks({ root: { parents: [] }, a: { parents: ["root"] } });
+    expect(wouldCreateCycle(tasks, "a", [])).toBe(false);
+  });
+
+  it("detects direct self-cycle", () => {
+    const tasks = makeTasks({ root: { parents: [] }, a: { parents: ["root"] } });
+    expect(wouldCreateCycle(tasks, "a", ["a"])).toBe(true);
+  });
+
+  it("detects indirect cycle (parent → child relationship reversed)", () => {
+    // root → a → b; asking if we can set root's parent to b (b is descendant of root)
+    const tasks = makeTasks({
+      root: { parents: [] },
+      a: { parents: ["root"] },
+      b: { parents: ["a"] },
+    });
+    expect(wouldCreateCycle(tasks, "root", ["b"])).toBe(true);
+  });
+
+  it("returns false for a valid new parent", () => {
+    const tasks = makeTasks({
+      root: { parents: [] },
+      a: { parents: ["root"] },
+      b: { parents: ["root"] },
+    });
+    // Adding b as another parent of a is fine (diamond DAG)
+    expect(wouldCreateCycle(tasks, "a", ["b"])).toBe(false);
+  });
+
+  it("returns false when tasks map is empty", () => {
+    expect(wouldCreateCycle(new Map(), "x", ["y"])).toBe(false);
+  });
+});
+
+// ── bfsFromRoot ───────────────────────────────────────────────────────────────
+
+describe("bfsFromRoot", () => {
+  it("returns only root when no children", () => {
+    const tasks = makeTasks({ root: { parents: [] } });
+    expect(bfsFromRoot(tasks, "root")).toEqual(["root"]);
+  });
+
+  it("returns BFS order for linear chain", () => {
+    const tasks = makeTasks({
+      root: { parents: [] },
+      a: { parents: ["root"] },
+      b: { parents: ["a"] },
+    });
+    expect(bfsFromRoot(tasks, "root")).toEqual(["root", "a", "b"]);
+  });
+
+  it("visits each node exactly once in a diamond DAG", () => {
+    // root → a, root → b, a → c, b → c
+    const tasks = makeTasks({
+      root: { parents: [] },
+      a: { parents: ["root"] },
+      b: { parents: ["root"] },
+      c: { parents: ["a", "b"] },
+    });
+    const order = bfsFromRoot(tasks, "root");
+    expect(order.filter((id) => id === "c")).toHaveLength(1);
+    expect(order).toContain("root");
+    expect(order).toContain("a");
+    expect(order).toContain("b");
+    expect(order).toContain("c");
+  });
+
+  it("does not infinite-loop on a cyclic graph", () => {
+    // Simulate corrupt data: a ↔ b cycle
+    const tasks = makeTasks({
+      root: { parents: [] },
+      a: { parents: ["root", "b"] },
+      b: { parents: ["a"] },
+    });
+    const order = bfsFromRoot(tasks, "root");
+    // Should terminate and visit each at most once
+    const unique = new Set(order);
+    expect(unique.size).toBe(order.length);
+  });
+});
+
+// ── File system integration (createProject / readProject / writeTask / deleteTaskDir) ───
+
+describe("file system operations", () => {
+  let tmpDir;
+
+  beforeEach(() => {
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "ws-test-"));
+  });
+
+  afterEach(() => {
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  it("createProject writes _project.md with correct fields", () => {
+    const { projectDir } = createProject(tmpDir, "My Project", "proj-id-1");
+    const content = fs.readFileSync(path.join(projectDir, "_project.md"), "utf8");
+    const { data } = parseFrontmatter(content);
+    expect(data.id).toBe("proj-id-1");
+    expect(data.name).toBe("My Project");
+    expect(data.status).toBe("Open");
+  });
+
+  it("listProjects finds created project", () => {
+    createProject(tmpDir, "Alpha", "alpha-id");
+    createProject(tmpDir, "Beta", "beta-id");
+    const projects = listProjects(tmpDir);
+    expect(projects).toHaveLength(2);
+    expect(projects.map((p) => p.name)).toEqual(expect.arrayContaining(["Alpha", "Beta"]));
+  });
+
+  it("readProject returns root task with empty parents", () => {
+    const { projectDir } = createProject(tmpDir, "Proj", "root-id");
+    const { tasks } = readProject(projectDir);
+    const root = tasks.get("root-id");
+    expect(root).toBeDefined();
+    expect(root.parents).toEqual([]);
+  });
+
+  it("writeTask + readProject round-trips a regular task", () => {
+    const { projectDir } = createProject(tmpDir, "Proj", "root-id");
+    const taskDirs = new Map([["root-id", "_project"]]);
+    const task = {
+      id: "task-1",
+      name: "First Task",
+      status: "In Progress",
+      dueDate: "2026-06-01",
+      parents: ["root-id"],
+      memos: [{ title: "Notes", content: "# Notes\n\nSome content" }],
+      createdAt: "2026-04-24",
+    };
+    writeTask(projectDir, task, taskDirs);
+
+    const { tasks } = readProject(projectDir);
+    const loaded = tasks.get("task-1");
+    expect(loaded).toBeDefined();
+    expect(loaded.name).toBe("First Task");
+    expect(loaded.status).toBe("In Progress");
+    expect(loaded.dueDate).toBe("2026-06-01");
+    expect(loaded.parents).toEqual(["root-id"]);
+    expect(loaded.memos).toHaveLength(1);
+    expect(loaded.memos[0].title).toBe("Notes");
+  });
+
+  it("deleteTaskDir removes the task directory", () => {
+    const { projectDir } = createProject(tmpDir, "Proj", "root-id");
+    const taskDirs = new Map([["root-id", "_project"]]);
+    const task = {
+      id: "task-del",
+      name: "To Delete",
+      status: "Open",
+      parents: ["root-id"],
+      memos: [],
+      createdAt: "2026-04-24",
+    };
+    writeTask(projectDir, task, taskDirs);
+
+    const dirName = taskDirs.get("task-del");
+    expect(fs.existsSync(path.join(projectDir, dirName))).toBe(true);
+
+    deleteTaskDir(projectDir, taskDirs, "task-del");
+    expect(fs.existsSync(path.join(projectDir, dirName))).toBe(false);
+    expect(taskDirs.has("task-del")).toBe(false);
+  });
+});


### PR DESCRIPTION
- electron/workspace.js: ファイルシステムI/O（readProject/writeTask/createProject等）、
  DAGロジック（wouldCreateCycle/bfsFromRoot）、フロントマターパーサーを実装
- electron/index.js: ws:* IPCハンドラ群を追加（read/write/create/delete/list）
- electron/preload.js: ワークスペースAPIをレンダラーへ公開
- src/types/workspace.ts: WorkspaceTask等の型定義を新設
- src/types/app.ts: ElectronAPIにワークスペースメソッドを追加
- tests/unit/workspace.test.js: ユニットテスト27件（全パス）

https://claude.ai/code/session_01XpvSnjiHSHdvJgGzFJ6DFK