### PR TITLE
feat: ワークスペースプロジェクトをBFS+循環検出でツリー表示 (#62)

### DIFF
--- a/electron/workspace.js
+++ b/electron/workspace.js
@@ -238,7 +238,12 @@ function listProjects(workspacePath) {
     try {
       const content = fs.readFileSync(projectFile, "utf8");
       const { data } = parseFrontmatter(content);
-      projects.push({ name: data.name || entry.name, rootId: data.id, dirName: entry.name });
+      projects.push({
+        name: data.name || entry.name,
+        rootId: data.id,
+        dirName: entry.name,
+        projectDir: path.join(workspacePath, entry.name),
+      });
     } catch (_) {}
   }
   return projects;

--- a/src/common/workspace_tree.ts
+++ b/src/common/workspace_tree.ts
@@ -1,0 +1,58 @@
+import type { WorkspaceTask } from "../types/workspace";
+import type { ProjectData, TreeData } from "./tree_control";
+
+const DEFAULT_HEADERS = [
+  { name: "name", default_ratio: 10 },
+  { name: "status", default_ratio: 4 },
+  { name: "due date", default_ratio: 4 },
+  { name: "memo", default_ratio: 2 },
+];
+
+/**
+ * Convert a flat WorkspaceTask map to a ProjectData tree for display.
+ * Uses DFS with a global visited set for cycle detection (DAG → tree projection).
+ * Multi-parent tasks appear only under the first parent reached.
+ */
+export function workspaceToProjectData(
+  tasks: Record<string, WorkspaceTask>,
+  rootId: string
+): ProjectData {
+  const childrenMap = new Map<string, string[]>();
+  for (const [id, task] of Object.entries(tasks)) {
+    for (const parent of task.parents) {
+      if (!childrenMap.has(parent)) childrenMap.set(parent, []);
+      childrenMap.get(parent)!.push(id);
+    }
+  }
+
+  const visited = new Set<string>();
+
+  function buildNode(id: string): TreeData {
+    visited.add(id);
+    const task = tasks[id];
+    const childIds = (childrenMap.get(id) ?? []).filter((cid) => !visited.has(cid));
+    return {
+      id,
+      data: {
+        name: task.name,
+        status: task.status,
+        "due date": task.dueDate as `${string}-${string}-${string}` | undefined,
+        memo: task.memos.map((m) => ({ title: m.title, content: m.content })),
+      },
+      children: childIds.map((cid) => buildNode(cid)),
+    };
+  }
+
+  if (!tasks[rootId]) {
+    return {
+      headers: DEFAULT_HEADERS,
+      data: {
+        id: rootId,
+        data: { name: "unknown", status: "Open", "due date": undefined, memo: [] },
+        children: [],
+      },
+    };
+  }
+
+  return { headers: DEFAULT_HEADERS, data: buildNode(rootId) };
+}

--- a/src/components/MenuList.svelte
+++ b/src/components/MenuList.svelte
@@ -12,6 +12,12 @@
   import { project_ids, info_ids, selected_type, selected_id } from "../stores.ts";
   import { workspace_store } from "../stores/workspace";
 
+  function selectWorkspaceProject(proj) {
+    workspace_store.setActiveProject(proj.projectDir);
+    $selected_type = "WorkspaceProject";
+    $selected_id = proj.rootId;
+  }
+
   let show_workspace_setup = false;
 
   // Dialog
@@ -270,6 +276,28 @@
       </button>
     {/if}
   </div>
+  {#if $workspace_store.projects.length > 0}
+    <div class="Contents">
+      {#each $workspace_store.projects as proj (proj.rootId)}
+        <button
+          class="MenuRow"
+          class:Selected={proj.rootId === $selected_id && $selected_type === "WorkspaceProject"}
+          use:ripple
+          on:click={() => selectWorkspaceProject(proj)}
+        >
+          <div class="TreeLine" style="flex-shrink: 0"></div>
+          <span
+            class="TextOverFlow"
+            use:tooltip={{
+              color: "var(--theme-color-Main-main)",
+              backgroundColor: "var(--theme-color-Sub-main)",
+              content: proj.name,
+            }}>{proj.name}</span
+          >
+        </button>
+      {/each}
+    </div>
+  {/if}
 
   {#if menu_data}
     {#each menu_data as menu, i}

--- a/src/stores/ui.ts
+++ b/src/stores/ui.ts
@@ -1,7 +1,9 @@
 import { get, writable, type Writable } from "svelte/store";
 import { getNode, type TreeData } from "../common/tree_control";
+import { workspaceToProjectData } from "../common/workspace_tree";
 import type { PendingTaskDetailSelection, SelectedType } from "../types/app";
 import { clearHistory, tree_data } from "./tree";
+import { workspace_store } from "./workspace";
 
 const currentHash = typeof window !== "undefined" ? window.location.hash : "";
 const currentSearch =
@@ -77,6 +79,16 @@ function createSelectedID(initialValue: string | undefined): SelectedIdStore {
             } else {
               table_selected_id.set(undefined);
             }
+          });
+        } else if (currentSelectedType === "WorkspaceProject" && current) {
+          clearHistory();
+          const { activeProjectDir } = get(workspace_store);
+          if (!activeProjectDir) return;
+          window.electronAPI.wsReadProject?.(activeProjectDir).then((result) => {
+            if (!result) return;
+            const converted = workspaceToProjectData(result.tasks, current);
+            tree_data.set(converted);
+            table_selected_id.set(undefined);
           });
         }
       });

--- a/src/stores/workspace.ts
+++ b/src/stores/workspace.ts
@@ -4,6 +4,7 @@ import type { WorkspaceInfo, WorkspaceProjectListItem } from "../types/workspace
 export interface WorkspaceState {
   workspaces: WorkspaceInfo[];
   activeWorkspacePath: string | null;
+  activeProjectDir: string | null;
   projects: WorkspaceProjectListItem[];
 }
 
@@ -14,12 +15,14 @@ export interface WorkspaceStore extends Writable<WorkspaceState> {
   removeWorkspace: (path: string) => void;
   setActive: (path: string) => Promise<void>;
   refreshProjects: () => Promise<void>;
+  setActiveProject: (projectDir: string) => void;
 }
 
 function createWorkspaceStore(): WorkspaceStore {
   const { subscribe, set, update } = writable<WorkspaceState>({
     workspaces: [],
     activeWorkspacePath: null,
+    activeProjectDir: null,
     projects: [],
   });
 
@@ -51,6 +54,7 @@ function createWorkspaceStore(): WorkspaceStore {
         set({
           workspaces: workspaces ?? [],
           activeWorkspacePath: activeWorkspace,
+          activeProjectDir: null,
           projects,
         });
       })();
@@ -96,6 +100,10 @@ function createWorkspaceStore(): WorkspaceStore {
       if (!activeWorkspacePath) return;
       const projects = await loadProjects(activeWorkspacePath);
       update((s) => ({ ...s, projects }));
+    },
+
+    setActiveProject(projectDir: string) {
+      update((s) => ({ ...s, activeProjectDir: projectDir }));
     },
   };
 }

--- a/src/types/app.ts
+++ b/src/types/app.ts
@@ -7,7 +7,7 @@ import type {
 } from "./workspace";
 
 export type ThemeName = "dark" | "light";
-export type SelectedType = "Projects" | "Info" | undefined;
+export type SelectedType = "Projects" | "Info" | "WorkspaceProject" | undefined;
 export type FilterState = Record<string, string[]>;
 
 export interface ProjectListItem {

--- a/src/types/workspace.ts
+++ b/src/types/workspace.ts
@@ -25,6 +25,7 @@ export interface WorkspaceProjectListItem {
   name: string;
   rootId: string;
   dirName: string;
+  projectDir: string;
 }
 
 export interface WorkspaceProject {


### PR DESCRIPTION
## Summary

- ワークスペースのフラットDAGタスクマップをツリー表示に変換する仕組みを実装
- サイドメニューのワークスペースセクションにプロジェクト一覧を表示し、クリックで選択できる
- 既存の `TreeTable` / `TreeTableRow` コンポーネントはそのまま再利用

## Changes

### 変換ロジック
- `src/common/workspace_tree.ts` (新規): `workspaceToProjectData()` — フラット `WorkspaceTask` マップを `ProjectData` ネストツリーへ変換。DFS + グローバル visited セットで循環保護。多重親タスクは最初に到達した親の子としてのみ表示

### ルーティング
- `src/types/app.ts`: `SelectedType` に `"WorkspaceProject"` を追加
- `src/stores/ui.ts`: `selected_id` subscriber に WorkspaceProject ブランチを追加 — `wsReadProject` → `workspaceToProjectData` → `tree_data.set()` の流れ
- `src/stores/workspace.ts`: `activeProjectDir` フィールドと `setActiveProject()` メソッドを追加

### データ
- `src/types/workspace.ts`: `WorkspaceProjectListItem` に `projectDir`（フルパス）を追加
- `electron/workspace.js`: `listProjects()` で `projectDir` を返すよう更新

### UI
- `src/components/MenuList.svelte`: ワークスペースセクションにプロジェクト一覧を表示。クリックで `WorkspaceProject` タイプとして選択

## Test plan

- [ ] ワークスペースを設定しプロジェクトを作成 or 移行後、サイドメニューにプロジェクトが表示される
- [ ] プロジェクトをクリックするとツリーテーブルにタスクが表示される
- [ ] 親子関係が正しくインデントで表現されている
- [ ] 複数親タスクが最初に到達した親の下に一度だけ表示される
- [ ] 既存の db.json プロジェクト選択が引き続き動作する
- [ ] ユニットテスト 105件すべて通過: `npm run test`

---
_Generated by [Claude Code](https://claude.ai/code/session_01XpvSnjiHSHdvJgGzFJ6DFK)_