### PR TITLE
feat: replace Quill.js with CodeMirror 6 Markdown editor

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,10 +8,15 @@
       "name": "task-manage",
       "version": "0.1.3",
       "dependencies": {
+        "@codemirror/commands": "^6.10.3",
+        "@codemirror/lang-markdown": "^6.5.0",
+        "@codemirror/language-data": "^6.5.2",
+        "@codemirror/search": "^6.7.0",
+        "@codemirror/state": "^6.6.0",
+        "@codemirror/view": "^6.41.1",
         "@commonify/lowdb": "^3.0.0",
         "electron-log": "^5.4.3",
-        "lodash": "^4.18.1",
-        "quill": "^2.0.3"
+        "lodash": "^4.18.1"
       },
       "devDependencies": {
         "@editorjs/editorjs": "^2.31.6",
@@ -209,6 +214,407 @@
       "license": "MIT",
       "dependencies": {
         "@keyv/serialize": "^1.1.1"
+      }
+    },
+    "node_modules/@codemirror/autocomplete": {
+      "version": "6.20.1",
+      "resolved": "https://registry.npmjs.org/@codemirror/autocomplete/-/autocomplete-6.20.1.tgz",
+      "integrity": "sha512-1cvg3Vz1dSSToCNlJfRA2WSI4ht3K+WplO0UMOgmUYPivCyy2oueZY6Lx7M9wThm7SDUBViRmuT+OG/i8+ON9A==",
+      "license": "MIT",
+      "dependencies": {
+        "@codemirror/language": "^6.0.0",
+        "@codemirror/state": "^6.0.0",
+        "@codemirror/view": "^6.17.0",
+        "@lezer/common": "^1.0.0"
+      }
+    },
+    "node_modules/@codemirror/commands": {
+      "version": "6.10.3",
+      "resolved": "https://registry.npmjs.org/@codemirror/commands/-/commands-6.10.3.tgz",
+      "integrity": "sha512-JFRiqhKu+bvSkDLI+rUhJwSxQxYb759W5GBezE8Uc8mHLqC9aV/9aTC7yJSqCtB3F00pylrLCwnyS91Ap5ej4Q==",
+      "license": "MIT",
+      "dependencies": {
+        "@codemirror/language": "^6.0.0",
+        "@codemirror/state": "^6.6.0",
+        "@codemirror/view": "^6.27.0",
+        "@lezer/common": "^1.1.0"
+      }
+    },
+    "node_modules/@codemirror/lang-angular": {
+      "version": "0.1.4",
+      "resolved": "https://registry.npmjs.org/@codemirror/lang-angular/-/lang-angular-0.1.4.tgz",
+      "integrity": "sha512-oap+gsltb/fzdlTQWD6BFF4bSLKcDnlxDsLdePiJpCVNKWXSTAbiiQeYI3UmES+BLAdkmIC1WjyztC1pi/bX4g==",
+      "license": "MIT",
+      "dependencies": {
+        "@codemirror/lang-html": "^6.0.0",
+        "@codemirror/lang-javascript": "^6.1.2",
+        "@codemirror/language": "^6.0.0",
+        "@lezer/common": "^1.2.0",
+        "@lezer/highlight": "^1.0.0",
+        "@lezer/lr": "^1.3.3"
+      }
+    },
+    "node_modules/@codemirror/lang-cpp": {
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/@codemirror/lang-cpp/-/lang-cpp-6.0.3.tgz",
+      "integrity": "sha512-URM26M3vunFFn9/sm6rzqrBzDgfWuDixp85uTY49wKudToc2jTHUrKIGGKs+QWND+YLofNNZpxcNGRynFJfvgA==",
+      "license": "MIT",
+      "dependencies": {
+        "@codemirror/language": "^6.0.0",
+        "@lezer/cpp": "^1.0.0"
+      }
+    },
+    "node_modules/@codemirror/lang-css": {
+      "version": "6.3.1",
+      "resolved": "https://registry.npmjs.org/@codemirror/lang-css/-/lang-css-6.3.1.tgz",
+      "integrity": "sha512-kr5fwBGiGtmz6l0LSJIbno9QrifNMUusivHbnA1H6Dmqy4HZFte3UAICix1VuKo0lMPKQr2rqB+0BkKi/S3Ejg==",
+      "license": "MIT",
+      "dependencies": {
+        "@codemirror/autocomplete": "^6.0.0",
+        "@codemirror/language": "^6.0.0",
+        "@codemirror/state": "^6.0.0",
+        "@lezer/common": "^1.0.2",
+        "@lezer/css": "^1.1.7"
+      }
+    },
+    "node_modules/@codemirror/lang-go": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/@codemirror/lang-go/-/lang-go-6.0.1.tgz",
+      "integrity": "sha512-7fNvbyNylvqCphW9HD6WFnRpcDjr+KXX/FgqXy5H5ZS0eC5edDljukm/yNgYkwTsgp2busdod50AOTIy6Jikfg==",
+      "license": "MIT",
+      "dependencies": {
+        "@codemirror/autocomplete": "^6.0.0",
+        "@codemirror/language": "^6.6.0",
+        "@codemirror/state": "^6.0.0",
+        "@lezer/common": "^1.0.0",
+        "@lezer/go": "^1.0.0"
+      }
+    },
+    "node_modules/@codemirror/lang-html": {
+      "version": "6.4.11",
+      "resolved": "https://registry.npmjs.org/@codemirror/lang-html/-/lang-html-6.4.11.tgz",
+      "integrity": "sha512-9NsXp7Nwp891pQchI7gPdTwBuSuT3K65NGTHWHNJ55HjYcHLllr0rbIZNdOzas9ztc1EUVBlHou85FFZS4BNnw==",
+      "license": "MIT",
+      "dependencies": {
+        "@codemirror/autocomplete": "^6.0.0",
+        "@codemirror/lang-css": "^6.0.0",
+        "@codemirror/lang-javascript": "^6.0.0",
+        "@codemirror/language": "^6.4.0",
+        "@codemirror/state": "^6.0.0",
+        "@codemirror/view": "^6.17.0",
+        "@lezer/common": "^1.0.0",
+        "@lezer/css": "^1.1.0",
+        "@lezer/html": "^1.3.12"
+      }
+    },
+    "node_modules/@codemirror/lang-java": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/@codemirror/lang-java/-/lang-java-6.0.2.tgz",
+      "integrity": "sha512-m5Nt1mQ/cznJY7tMfQTJchmrjdjQ71IDs+55d1GAa8DGaB8JXWsVCkVT284C3RTASaY43YknrK2X3hPO/J3MOQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@codemirror/language": "^6.0.0",
+        "@lezer/java": "^1.0.0"
+      }
+    },
+    "node_modules/@codemirror/lang-javascript": {
+      "version": "6.2.5",
+      "resolved": "https://registry.npmjs.org/@codemirror/lang-javascript/-/lang-javascript-6.2.5.tgz",
+      "integrity": "sha512-zD4e5mS+50htS7F+TYjBPsiIFGanfVqg4HyUz6WNFikgOPf2BgKlx+TQedI1w6n/IqRBVBbBWmGFdLB/7uxO4A==",
+      "license": "MIT",
+      "dependencies": {
+        "@codemirror/autocomplete": "^6.0.0",
+        "@codemirror/language": "^6.6.0",
+        "@codemirror/lint": "^6.0.0",
+        "@codemirror/state": "^6.0.0",
+        "@codemirror/view": "^6.17.0",
+        "@lezer/common": "^1.0.0",
+        "@lezer/javascript": "^1.0.0"
+      }
+    },
+    "node_modules/@codemirror/lang-jinja": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/@codemirror/lang-jinja/-/lang-jinja-6.0.1.tgz",
+      "integrity": "sha512-P5kyHLObzjtbGj16h+hyvZTxJhSjBEeSx4wMjbnAf3b0uwTy2+F0zGjMZL4PQOm/mh2eGZ5xUDVZXgwP783Nsw==",
+      "license": "MIT",
+      "dependencies": {
+        "@codemirror/autocomplete": "^6.0.0",
+        "@codemirror/lang-html": "^6.0.0",
+        "@codemirror/language": "^6.0.0",
+        "@codemirror/state": "^6.0.0",
+        "@codemirror/view": "^6.0.0",
+        "@lezer/common": "^1.2.0",
+        "@lezer/highlight": "^1.2.0",
+        "@lezer/lr": "^1.4.0"
+      }
+    },
+    "node_modules/@codemirror/lang-json": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/@codemirror/lang-json/-/lang-json-6.0.2.tgz",
+      "integrity": "sha512-x2OtO+AvwEHrEwR0FyyPtfDUiloG3rnVTSZV1W8UteaLL8/MajQd8DpvUb2YVzC+/T18aSDv0H9mu+xw0EStoQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@codemirror/language": "^6.0.0",
+        "@lezer/json": "^1.0.0"
+      }
+    },
+    "node_modules/@codemirror/lang-less": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/@codemirror/lang-less/-/lang-less-6.0.2.tgz",
+      "integrity": "sha512-EYdQTG22V+KUUk8Qq582g7FMnCZeEHsyuOJisHRft/mQ+ZSZ2w51NupvDUHiqtsOy7It5cHLPGfHQLpMh9bqpQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@codemirror/lang-css": "^6.2.0",
+        "@codemirror/language": "^6.0.0",
+        "@lezer/common": "^1.2.0",
+        "@lezer/highlight": "^1.0.0",
+        "@lezer/lr": "^1.0.0"
+      }
+    },
+    "node_modules/@codemirror/lang-liquid": {
+      "version": "6.3.2",
+      "resolved": "https://registry.npmjs.org/@codemirror/lang-liquid/-/lang-liquid-6.3.2.tgz",
+      "integrity": "sha512-6PDVU3ZnfeYyz1at1E/ttorErZvZFXXt1OPhtfe1EZJ2V2iDFa0CwPqPgG5F7NXN0yONGoBogKmFAafKTqlwIw==",
+      "license": "MIT",
+      "dependencies": {
+        "@codemirror/autocomplete": "^6.0.0",
+        "@codemirror/lang-html": "^6.0.0",
+        "@codemirror/language": "^6.0.0",
+        "@codemirror/state": "^6.0.0",
+        "@codemirror/view": "^6.0.0",
+        "@lezer/common": "^1.0.0",
+        "@lezer/highlight": "^1.0.0",
+        "@lezer/lr": "^1.3.1"
+      }
+    },
+    "node_modules/@codemirror/lang-markdown": {
+      "version": "6.5.0",
+      "resolved": "https://registry.npmjs.org/@codemirror/lang-markdown/-/lang-markdown-6.5.0.tgz",
+      "integrity": "sha512-0K40bZ35jpHya6FriukbgaleaqzBLZfOh7HuzqbMxBXkbYMJDxfF39c23xOgxFezR+3G+tR2/Mup+Xk865OMvw==",
+      "license": "MIT",
+      "dependencies": {
+        "@codemirror/autocomplete": "^6.7.1",
+        "@codemirror/lang-html": "^6.0.0",
+        "@codemirror/language": "^6.3.0",
+        "@codemirror/state": "^6.0.0",
+        "@codemirror/view": "^6.0.0",
+        "@lezer/common": "^1.2.1",
+        "@lezer/markdown": "^1.0.0"
+      }
+    },
+    "node_modules/@codemirror/lang-php": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/@codemirror/lang-php/-/lang-php-6.0.2.tgz",
+      "integrity": "sha512-ZKy2v1n8Fc8oEXj0Th0PUMXzQJ0AIR6TaZU+PbDHExFwdu+guzOA4jmCHS1Nz4vbFezwD7LyBdDnddSJeScMCA==",
+      "license": "MIT",
+      "dependencies": {
+        "@codemirror/lang-html": "^6.0.0",
+        "@codemirror/language": "^6.0.0",
+        "@codemirror/state": "^6.0.0",
+        "@lezer/common": "^1.0.0",
+        "@lezer/php": "^1.0.0"
+      }
+    },
+    "node_modules/@codemirror/lang-python": {
+      "version": "6.2.1",
+      "resolved": "https://registry.npmjs.org/@codemirror/lang-python/-/lang-python-6.2.1.tgz",
+      "integrity": "sha512-IRjC8RUBhn9mGR9ywecNhB51yePWCGgvHfY1lWN/Mrp3cKuHr0isDKia+9HnvhiWNnMpbGhWrkhuWOc09exRyw==",
+      "license": "MIT",
+      "dependencies": {
+        "@codemirror/autocomplete": "^6.3.2",
+        "@codemirror/language": "^6.8.0",
+        "@codemirror/state": "^6.0.0",
+        "@lezer/common": "^1.2.1",
+        "@lezer/python": "^1.1.4"
+      }
+    },
+    "node_modules/@codemirror/lang-rust": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/@codemirror/lang-rust/-/lang-rust-6.0.2.tgz",
+      "integrity": "sha512-EZaGjCUegtiU7kSMvOfEZpaCReowEf3yNidYu7+vfuGTm9ow4mthAparY5hisJqOHmJowVH3Upu+eJlUji6qqA==",
+      "license": "MIT",
+      "dependencies": {
+        "@codemirror/language": "^6.0.0",
+        "@lezer/rust": "^1.0.0"
+      }
+    },
+    "node_modules/@codemirror/lang-sass": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/@codemirror/lang-sass/-/lang-sass-6.0.2.tgz",
+      "integrity": "sha512-l/bdzIABvnTo1nzdY6U+kPAC51czYQcOErfzQ9zSm9D8GmNPD0WTW8st/CJwBTPLO8jlrbyvlSEcN20dc4iL0Q==",
+      "license": "MIT",
+      "dependencies": {
+        "@codemirror/lang-css": "^6.2.0",
+        "@codemirror/language": "^6.0.0",
+        "@codemirror/state": "^6.0.0",
+        "@lezer/common": "^1.0.2",
+        "@lezer/sass": "^1.0.0"
+      }
+    },
+    "node_modules/@codemirror/lang-sql": {
+      "version": "6.10.0",
+      "resolved": "https://registry.npmjs.org/@codemirror/lang-sql/-/lang-sql-6.10.0.tgz",
+      "integrity": "sha512-6ayPkEd/yRw0XKBx5uAiToSgGECo/GY2NoJIHXIIQh1EVwLuKoU8BP/qK0qH5NLXAbtJRLuT73hx7P9X34iO4w==",
+      "license": "MIT",
+      "dependencies": {
+        "@codemirror/autocomplete": "^6.0.0",
+        "@codemirror/language": "^6.0.0",
+        "@codemirror/state": "^6.0.0",
+        "@lezer/common": "^1.2.0",
+        "@lezer/highlight": "^1.0.0",
+        "@lezer/lr": "^1.0.0"
+      }
+    },
+    "node_modules/@codemirror/lang-vue": {
+      "version": "0.1.3",
+      "resolved": "https://registry.npmjs.org/@codemirror/lang-vue/-/lang-vue-0.1.3.tgz",
+      "integrity": "sha512-QSKdtYTDRhEHCfo5zOShzxCmqKJvgGrZwDQSdbvCRJ5pRLWBS7pD/8e/tH44aVQT6FKm0t6RVNoSUWHOI5vNug==",
+      "license": "MIT",
+      "dependencies": {
+        "@codemirror/lang-html": "^6.0.0",
+        "@codemirror/lang-javascript": "^6.1.2",
+        "@codemirror/language": "^6.0.0",
+        "@lezer/common": "^1.2.0",
+        "@lezer/highlight": "^1.0.0",
+        "@lezer/lr": "^1.3.1"
+      }
+    },
+    "node_modules/@codemirror/lang-wast": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/@codemirror/lang-wast/-/lang-wast-6.0.2.tgz",
+      "integrity": "sha512-Imi2KTpVGm7TKuUkqyJ5NRmeFWF7aMpNiwHnLQe0x9kmrxElndyH0K6H/gXtWwY6UshMRAhpENsgfpSwsgmC6Q==",
+      "license": "MIT",
+      "dependencies": {
+        "@codemirror/language": "^6.0.0",
+        "@lezer/common": "^1.2.0",
+        "@lezer/highlight": "^1.0.0",
+        "@lezer/lr": "^1.0.0"
+      }
+    },
+    "node_modules/@codemirror/lang-xml": {
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/@codemirror/lang-xml/-/lang-xml-6.1.0.tgz",
+      "integrity": "sha512-3z0blhicHLfwi2UgkZYRPioSgVTo9PV5GP5ducFH6FaHy0IAJRg+ixj5gTR1gnT/glAIC8xv4w2VL1LoZfs+Jg==",
+      "license": "MIT",
+      "dependencies": {
+        "@codemirror/autocomplete": "^6.0.0",
+        "@codemirror/language": "^6.4.0",
+        "@codemirror/state": "^6.0.0",
+        "@codemirror/view": "^6.0.0",
+        "@lezer/common": "^1.0.0",
+        "@lezer/xml": "^1.0.0"
+      }
+    },
+    "node_modules/@codemirror/lang-yaml": {
+      "version": "6.1.3",
+      "resolved": "https://registry.npmjs.org/@codemirror/lang-yaml/-/lang-yaml-6.1.3.tgz",
+      "integrity": "sha512-AZ8DJBuXGVHybpBQhmZtgew5//4hv3tdkXnr3vDmOUMJRuB6vn/uuwtmTOTlqEaQFg3hQSVeA90NmvIQyUV6FQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@codemirror/autocomplete": "^6.0.0",
+        "@codemirror/language": "^6.0.0",
+        "@codemirror/state": "^6.0.0",
+        "@lezer/common": "^1.2.0",
+        "@lezer/highlight": "^1.2.0",
+        "@lezer/lr": "^1.0.0",
+        "@lezer/yaml": "^1.0.0"
+      }
+    },
+    "node_modules/@codemirror/language": {
+      "version": "6.12.3",
+      "resolved": "https://registry.npmjs.org/@codemirror/language/-/language-6.12.3.tgz",
+      "integrity": "sha512-QwCZW6Tt1siP37Jet9Tb02Zs81TQt6qQrZR2H+eGMcFsL1zMrk2/b9CLC7/9ieP1fjIUMgviLWMmgiHoJrj+ZA==",
+      "license": "MIT",
+      "dependencies": {
+        "@codemirror/state": "^6.0.0",
+        "@codemirror/view": "^6.23.0",
+        "@lezer/common": "^1.5.0",
+        "@lezer/highlight": "^1.0.0",
+        "@lezer/lr": "^1.0.0",
+        "style-mod": "^4.0.0"
+      }
+    },
+    "node_modules/@codemirror/language-data": {
+      "version": "6.5.2",
+      "resolved": "https://registry.npmjs.org/@codemirror/language-data/-/language-data-6.5.2.tgz",
+      "integrity": "sha512-CPkWBKrNS8stYbEU5kwBwTf3JB1kghlbh4FSAwzGW2TEscdeHHH4FGysREW86Mqnj3Qn09s0/6Ea/TutmoTobg==",
+      "license": "MIT",
+      "dependencies": {
+        "@codemirror/lang-angular": "^0.1.0",
+        "@codemirror/lang-cpp": "^6.0.0",
+        "@codemirror/lang-css": "^6.0.0",
+        "@codemirror/lang-go": "^6.0.0",
+        "@codemirror/lang-html": "^6.0.0",
+        "@codemirror/lang-java": "^6.0.0",
+        "@codemirror/lang-javascript": "^6.0.0",
+        "@codemirror/lang-jinja": "^6.0.0",
+        "@codemirror/lang-json": "^6.0.0",
+        "@codemirror/lang-less": "^6.0.0",
+        "@codemirror/lang-liquid": "^6.0.0",
+        "@codemirror/lang-markdown": "^6.0.0",
+        "@codemirror/lang-php": "^6.0.0",
+        "@codemirror/lang-python": "^6.0.0",
+        "@codemirror/lang-rust": "^6.0.0",
+        "@codemirror/lang-sass": "^6.0.0",
+        "@codemirror/lang-sql": "^6.0.0",
+        "@codemirror/lang-vue": "^0.1.1",
+        "@codemirror/lang-wast": "^6.0.0",
+        "@codemirror/lang-xml": "^6.0.0",
+        "@codemirror/lang-yaml": "^6.0.0",
+        "@codemirror/language": "^6.0.0",
+        "@codemirror/legacy-modes": "^6.4.0"
+      }
+    },
+    "node_modules/@codemirror/legacy-modes": {
+      "version": "6.5.2",
+      "resolved": "https://registry.npmjs.org/@codemirror/legacy-modes/-/legacy-modes-6.5.2.tgz",
+      "integrity": "sha512-/jJbwSTazlQEDOQw2FJ8LEEKVS72pU0lx6oM54kGpL8t/NJ2Jda3CZ4pcltiKTdqYSRk3ug1B3pil1gsjA6+8Q==",
+      "license": "MIT",
+      "dependencies": {
+        "@codemirror/language": "^6.0.0"
+      }
+    },
+    "node_modules/@codemirror/lint": {
+      "version": "6.9.5",
+      "resolved": "https://registry.npmjs.org/@codemirror/lint/-/lint-6.9.5.tgz",
+      "integrity": "sha512-GElsbU9G7QT9xXhpUg1zWGmftA/7jamh+7+ydKRuT0ORpWS3wOSP0yT1FOlIZa7mIJjpVPipErsyvVqB9cfTFA==",
+      "license": "MIT",
+      "dependencies": {
+        "@codemirror/state": "^6.0.0",
+        "@codemirror/view": "^6.35.0",
+        "crelt": "^1.0.5"
+      }
+    },
+    "node_modules/@codemirror/search": {
+      "version": "6.7.0",
+      "resolved": "https://registry.npmjs.org/@codemirror/search/-/search-6.7.0.tgz",
+      "integrity": "sha512-ZvGm99wc/s2cITtMT15LFdn8aH/aS+V+DqyGq/N5ZlV5vWtH+nILvC2nw0zX7ByNoHHDZ2IxxdW38O0tc5nVHg==",
+      "license": "MIT",
+      "dependencies": {
+        "@codemirror/state": "^6.0.0",
+        "@codemirror/view": "^6.37.0",
+        "crelt": "^1.0.5"
+      }
+    },
+    "node_modules/@codemirror/state": {
+      "version": "6.6.0",
+      "resolved": "https://registry.npmjs.org/@codemirror/state/-/state-6.6.0.tgz",
+      "integrity": "sha512-4nbvra5R5EtiCzr9BTHiTLc+MLXK2QGiAVYMyi8PkQd3SR+6ixar/Q/01Fa21TBIDOZXgeWV4WppsQolSreAPQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@marijn/find-cluster-break": "^1.0.0"
+      }
+    },
+    "node_modules/@codemirror/view": {
+      "version": "6.41.1",
+      "resolved": "https://registry.npmjs.org/@codemirror/view/-/view-6.41.1.tgz",
+      "integrity": "sha512-ToDnWKbBnke+ZLrP6vgTTDScGi5H37YYuZGniQaBzxMVdtCxMrslsmtnOvbPZk4RX9bvkQqnWR/WS/35tJA0qg==",
+      "license": "MIT",
+      "dependencies": {
+        "@codemirror/state": "^6.6.0",
+        "crelt": "^1.0.6",
+        "style-mod": "^4.1.0",
+        "w3c-keyname": "^2.2.4"
       }
     },
     "node_modules/@commonify/lowdb": {
@@ -1350,6 +1756,183 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@lezer/common": {
+      "version": "1.5.2",
+      "resolved": "https://registry.npmjs.org/@lezer/common/-/common-1.5.2.tgz",
+      "integrity": "sha512-sxQE460fPZyU3sdc8lafxiPwJHBzZRy/udNFynGQky1SePYBdhkBl1kOagA9uT3pxR8K09bOrmTUqA9wb/PjSQ==",
+      "license": "MIT"
+    },
+    "node_modules/@lezer/cpp": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@lezer/cpp/-/cpp-1.1.5.tgz",
+      "integrity": "sha512-DIhSXmYtJKLehrjzDFN+2cPt547ySQ41nA8yqcDf/GxMc+YM736xqltFkvADL2M0VebU5I+3+4ks2Vv+Kyq3Aw==",
+      "license": "MIT",
+      "dependencies": {
+        "@lezer/common": "^1.2.0",
+        "@lezer/highlight": "^1.0.0",
+        "@lezer/lr": "^1.0.0"
+      }
+    },
+    "node_modules/@lezer/css": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/@lezer/css/-/css-1.3.3.tgz",
+      "integrity": "sha512-RzBo8r+/6QJeow7aPHIpGVIH59xTcJXp399820gZoMo9noQDRVpJLheIBUicYwKcsbOYoBRoLZlf2720dG/4Tg==",
+      "license": "MIT",
+      "dependencies": {
+        "@lezer/common": "^1.2.0",
+        "@lezer/highlight": "^1.0.0",
+        "@lezer/lr": "^1.3.0"
+      }
+    },
+    "node_modules/@lezer/go": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@lezer/go/-/go-1.0.1.tgz",
+      "integrity": "sha512-xToRsYxwsgJNHTgNdStpcvmbVuKxTapV0dM0wey1geMMRc9aggoVyKgzYp41D2/vVOx+Ii4hmE206kvxIXBVXQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@lezer/common": "^1.2.0",
+        "@lezer/highlight": "^1.0.0",
+        "@lezer/lr": "^1.3.0"
+      }
+    },
+    "node_modules/@lezer/highlight": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/@lezer/highlight/-/highlight-1.2.3.tgz",
+      "integrity": "sha512-qXdH7UqTvGfdVBINrgKhDsVTJTxactNNxLk7+UMwZhU13lMHaOBlJe9Vqp907ya56Y3+ed2tlqzys7jDkTmW0g==",
+      "license": "MIT",
+      "dependencies": {
+        "@lezer/common": "^1.3.0"
+      }
+    },
+    "node_modules/@lezer/html": {
+      "version": "1.3.13",
+      "resolved": "https://registry.npmjs.org/@lezer/html/-/html-1.3.13.tgz",
+      "integrity": "sha512-oI7n6NJml729m7pjm9lvLvmXbdoMoi2f+1pwSDJkl9d68zGr7a9Btz8NdHTGQZtW2DA25ybeuv/SyDb9D5tseg==",
+      "license": "MIT",
+      "dependencies": {
+        "@lezer/common": "^1.2.0",
+        "@lezer/highlight": "^1.0.0",
+        "@lezer/lr": "^1.0.0"
+      }
+    },
+    "node_modules/@lezer/java": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/@lezer/java/-/java-1.1.3.tgz",
+      "integrity": "sha512-yHquUfujwg6Yu4Fd1GNHCvidIvJwi/1Xu2DaKl/pfWIA2c1oXkVvawH3NyXhCaFx4OdlYBVX5wvz2f7Aoa/4Xw==",
+      "license": "MIT",
+      "dependencies": {
+        "@lezer/common": "^1.2.0",
+        "@lezer/highlight": "^1.0.0",
+        "@lezer/lr": "^1.0.0"
+      }
+    },
+    "node_modules/@lezer/javascript": {
+      "version": "1.5.4",
+      "resolved": "https://registry.npmjs.org/@lezer/javascript/-/javascript-1.5.4.tgz",
+      "integrity": "sha512-vvYx3MhWqeZtGPwDStM2dwgljd5smolYD2lR2UyFcHfxbBQebqx8yjmFmxtJ/E6nN6u1D9srOiVWm3Rb4tmcUA==",
+      "license": "MIT",
+      "dependencies": {
+        "@lezer/common": "^1.2.0",
+        "@lezer/highlight": "^1.1.3",
+        "@lezer/lr": "^1.3.0"
+      }
+    },
+    "node_modules/@lezer/json": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@lezer/json/-/json-1.0.3.tgz",
+      "integrity": "sha512-BP9KzdF9Y35PDpv04r0VeSTKDeox5vVr3efE7eBbx3r4s3oNLfunchejZhjArmeieBH+nVOpgIiBJpEAv8ilqQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@lezer/common": "^1.2.0",
+        "@lezer/highlight": "^1.0.0",
+        "@lezer/lr": "^1.0.0"
+      }
+    },
+    "node_modules/@lezer/lr": {
+      "version": "1.4.10",
+      "resolved": "https://registry.npmjs.org/@lezer/lr/-/lr-1.4.10.tgz",
+      "integrity": "sha512-rnCpTIBafOx4mRp43xOxDJbFipJm/c0cia/V5TiGlhmMa+wsSdoGmUN3w5Bqrks/09Q/D4tNAmWaT8p6NRi77A==",
+      "license": "MIT",
+      "dependencies": {
+        "@lezer/common": "^1.0.0"
+      }
+    },
+    "node_modules/@lezer/markdown": {
+      "version": "1.6.3",
+      "resolved": "https://registry.npmjs.org/@lezer/markdown/-/markdown-1.6.3.tgz",
+      "integrity": "sha512-jpGm5Ps+XErS+xA4urw7ogEGkeZOahVQF21Z6oECF0sj+2liwZopd2+I8uH5I/vZsRuuze3OxBREIANLf6KKUw==",
+      "license": "MIT",
+      "dependencies": {
+        "@lezer/common": "^1.5.0",
+        "@lezer/highlight": "^1.0.0"
+      }
+    },
+    "node_modules/@lezer/php": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/@lezer/php/-/php-1.0.5.tgz",
+      "integrity": "sha512-W7asp9DhM6q0W6DYNwIkLSKOvxlXRrif+UXBMxzsJUuqmhE7oVU+gS3THO4S/Puh7Xzgm858UNaFi6dxTP8dJA==",
+      "license": "MIT",
+      "dependencies": {
+        "@lezer/common": "^1.2.0",
+        "@lezer/highlight": "^1.0.0",
+        "@lezer/lr": "^1.1.0"
+      }
+    },
+    "node_modules/@lezer/python": {
+      "version": "1.1.18",
+      "resolved": "https://registry.npmjs.org/@lezer/python/-/python-1.1.18.tgz",
+      "integrity": "sha512-31FiUrU7z9+d/ElGQLJFXl+dKOdx0jALlP3KEOsGTex8mvj+SoE1FgItcHWK/axkxCHGUSpqIHt6JAWfWu9Rhg==",
+      "license": "MIT",
+      "dependencies": {
+        "@lezer/common": "^1.2.0",
+        "@lezer/highlight": "^1.0.0",
+        "@lezer/lr": "^1.0.0"
+      }
+    },
+    "node_modules/@lezer/rust": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@lezer/rust/-/rust-1.0.2.tgz",
+      "integrity": "sha512-Lz5sIPBdF2FUXcWeCu1//ojFAZqzTQNRga0aYv6dYXqJqPfMdCAI0NzajWUd4Xijj1IKJLtjoXRPMvTKWBcqKg==",
+      "license": "MIT",
+      "dependencies": {
+        "@lezer/common": "^1.2.0",
+        "@lezer/highlight": "^1.0.0",
+        "@lezer/lr": "^1.0.0"
+      }
+    },
+    "node_modules/@lezer/sass": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@lezer/sass/-/sass-1.1.0.tgz",
+      "integrity": "sha512-3mMGdCTUZ/84ArHOuXWQr37pnf7f+Nw9ycPUeKX+wu19b7pSMcZGLbaXwvD2APMBDOGxPmpK/O6S1v1EvLoqgQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@lezer/common": "^1.2.0",
+        "@lezer/highlight": "^1.0.0",
+        "@lezer/lr": "^1.0.0"
+      }
+    },
+    "node_modules/@lezer/xml": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/@lezer/xml/-/xml-1.0.6.tgz",
+      "integrity": "sha512-CdDwirL0OEaStFue/66ZmFSeppuL6Dwjlk8qk153mSQwiSH/Dlri4GNymrNWnUmPl2Um7QfV1FO9KFUyX3Twww==",
+      "license": "MIT",
+      "dependencies": {
+        "@lezer/common": "^1.2.0",
+        "@lezer/highlight": "^1.0.0",
+        "@lezer/lr": "^1.0.0"
+      }
+    },
+    "node_modules/@lezer/yaml": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/@lezer/yaml/-/yaml-1.0.4.tgz",
+      "integrity": "sha512-2lrrHqxalACEbxIbsjhqGpSW8kWpUKuY6RHgnSAFZa6qK62wvnPxA8hGOwOoDbwHcOFs5M4o27mjGu+P7TvBmw==",
+      "license": "MIT",
+      "dependencies": {
+        "@lezer/common": "^1.2.0",
+        "@lezer/highlight": "^1.0.0",
+        "@lezer/lr": "^1.4.0"
+      }
+    },
     "node_modules/@malept/cross-spawn-promise": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/@malept/cross-spawn-promise/-/cross-spawn-promise-2.0.0.tgz",
@@ -1427,6 +2010,12 @@
       "engines": {
         "node": ">= 10.0.0"
       }
+    },
+    "node_modules/@marijn/find-cluster-break": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@marijn/find-cluster-break/-/find-cluster-break-1.0.2.tgz",
+      "integrity": "sha512-l0h88YhZFyKdXIFNfSWpyjStDjGHwZ/U7iobcK1cQQD8sejsONdQtTVU+1wVN1PBw40PiiHB1vA5S7VTfQiP9g==",
+      "license": "MIT"
     },
     "node_modules/@napi-rs/wasm-runtime": {
       "version": "1.1.4",
@@ -3628,6 +4217,12 @@
         "buffer": "^5.1.0"
       }
     },
+    "node_modules/crelt": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/crelt/-/crelt-1.0.6.tgz",
+      "integrity": "sha512-VQ2MBenTq1fWZUH9DJNGti7kKv6EeAuYr3cLwxUWhIu1baTaXh4Ib5W2CqHVqib4/MqbYGJqiL3Zb8GJZr3l4g==",
+      "license": "MIT"
+    },
     "node_modules/cross-spawn": {
       "version": "7.0.6",
       "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
@@ -4829,12 +5424,6 @@
         "node": ">=0.10.0"
       }
     },
-    "node_modules/eventemitter3": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-5.0.1.tgz",
-      "integrity": "sha512-GWkBvjiSZK87ELrYOSESUYeVIc9mvLLf/nXalMOS5dYrgZq9o5OVkbZAVM06CVxYsCwH9BDZFPlQTlPA1j4ahA==",
-      "license": "MIT"
-    },
     "node_modules/expect-type": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/expect-type/-/expect-type-1.3.0.tgz",
@@ -4890,12 +5479,6 @@
       "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
       "dev": true,
       "license": "MIT"
-    },
-    "node_modules/fast-diff": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/fast-diff/-/fast-diff-1.3.0.tgz",
-      "integrity": "sha512-VxPP4NqbUjj6MaAOafWeUn2cXWLcCtljklUtZf0Ind4XQ+QPtmA0b18zZy0jIQx+ExRVCR/ZQpBmik5lXshNsw==",
-      "license": "Apache-2.0"
     },
     "node_modules/fast-glob": {
       "version": "3.3.3",
@@ -6520,25 +7103,6 @@
       "integrity": "sha512-dMInicTPVE8d1e5otfwmmjlxkZoUpiVLwyeTdUsi/Caj/gfzzblBcCE5sRHV/AsjuCmxWrte2TNGSYuCeCq+0Q==",
       "license": "MIT"
     },
-    "node_modules/lodash-es": {
-      "version": "4.17.21",
-      "resolved": "https://registry.npmjs.org/lodash-es/-/lodash-es-4.17.21.tgz",
-      "integrity": "sha512-mKnC+QJ9pWVzv+C4/U3rRsHapFfHvQFoFB92e52xeyGMcX6/OlIl78je1u8vePzYZSkkogMPJ2yjxxsb89cxyw==",
-      "license": "MIT"
-    },
-    "node_modules/lodash.clonedeep": {
-      "version": "4.5.0",
-      "resolved": "https://registry.npmjs.org/lodash.clonedeep/-/lodash.clonedeep-4.5.0.tgz",
-      "integrity": "sha512-H5ZhCF25riFd9uB5UCkVKo61m3S/xZk1x4wA6yp/L3RFP6Z/eHH1ymQcGLo7J3GMPfm0V/7m1tryHuGVxpqEBQ==",
-      "license": "MIT"
-    },
-    "node_modules/lodash.isequal": {
-      "version": "4.5.0",
-      "resolved": "https://registry.npmjs.org/lodash.isequal/-/lodash.isequal-4.5.0.tgz",
-      "integrity": "sha512-pDo3lu8Jhfjqls6GkMgpahsF9kCyayhgykjyLMNFTKWrpVdAQtYyB4muAMWozBB4ig/dtWAmsMxLEI8wuz+DYQ==",
-      "deprecated": "This package is deprecated. Use require('node:util').isDeepStrictEqual instead.",
-      "license": "MIT"
-    },
     "node_modules/lodash.merge": {
       "version": "4.6.2",
       "resolved": "https://registry.npmjs.org/lodash.merge/-/lodash.merge-4.6.2.tgz",
@@ -7295,12 +7859,6 @@
       "dev": true,
       "license": "BlueOak-1.0.0"
     },
-    "node_modules/parchment": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/parchment/-/parchment-3.0.0.tgz",
-      "integrity": "sha512-HUrJFQ/StvgmXRcQ1ftY6VEZUq3jA2t9ncFN4F84J/vN0/FPpQF+8FKXb3l6fLces6q0uOHj6NJn+2xvZnxO6A==",
-      "license": "BSD-3-Clause"
-    },
     "node_modules/parent-module": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/parent-module/-/parent-module-1.0.1.tgz",
@@ -7871,35 +8429,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/quill": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/quill/-/quill-2.0.3.tgz",
-      "integrity": "sha512-xEYQBqfYx/sfb33VJiKnSJp8ehloavImQ2A6564GAbqG55PGw1dAWUn1MUbQB62t0azawUS2CZZhWCjO8gRvTw==",
-      "license": "BSD-3-Clause",
-      "dependencies": {
-        "eventemitter3": "^5.0.1",
-        "lodash-es": "^4.17.21",
-        "parchment": "^3.0.0",
-        "quill-delta": "^5.1.0"
-      },
-      "engines": {
-        "npm": ">=8.2.3"
-      }
-    },
-    "node_modules/quill-delta": {
-      "version": "5.1.0",
-      "resolved": "https://registry.npmjs.org/quill-delta/-/quill-delta-5.1.0.tgz",
-      "integrity": "sha512-X74oCeRI4/p0ucjb5Ma8adTXd9Scumz367kkMK5V/IatcX6A0vlgLgKbzXWy5nZmCGeNJm2oQX0d2Eqj+ZIlCA==",
-      "license": "MIT",
-      "dependencies": {
-        "fast-diff": "^1.3.0",
-        "lodash.clonedeep": "^4.5.0",
-        "lodash.isequal": "^4.5.0"
-      },
-      "engines": {
-        "node": ">= 12.0.0"
       }
     },
     "node_modules/react-is": {
@@ -8554,6 +9083,12 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
+    },
+    "node_modules/style-mod": {
+      "version": "4.1.3",
+      "resolved": "https://registry.npmjs.org/style-mod/-/style-mod-4.1.3.tgz",
+      "integrity": "sha512-i/n8VsZydrugj3Iuzll8+x/00GH2vnYsk1eomD8QiRrSAeW6ItbCQDtfXCeJHd0iwiNagqjQkvpvREEPtW3IoQ==",
+      "license": "MIT"
     },
     "node_modules/stylelint": {
       "version": "16.26.1",
@@ -9794,6 +10329,12 @@
       "dependencies": {
         "@jridgewell/sourcemap-codec": "^1.5.5"
       }
+    },
+    "node_modules/w3c-keyname": {
+      "version": "2.2.8",
+      "resolved": "https://registry.npmjs.org/w3c-keyname/-/w3c-keyname-2.2.8.tgz",
+      "integrity": "sha512-dpojBhNsCNN7T82Tm7k26A6G9ML3NkhDsnw9n/eoxSRlVBB4CEtIQ/KTCLI2Fwf3ataSXRhYFkQi3SlnFwPvPQ==",
+      "license": "MIT"
     },
     "node_modules/w3c-xmlserializer": {
       "version": "5.0.0",

--- a/package.json
+++ b/package.json
@@ -70,9 +70,14 @@
     "vitest": "^4.1.4"
   },
   "dependencies": {
+    "@codemirror/commands": "^6.10.3",
+    "@codemirror/lang-markdown": "^6.5.0",
+    "@codemirror/language-data": "^6.5.2",
+    "@codemirror/search": "^6.7.0",
+    "@codemirror/state": "^6.6.0",
+    "@codemirror/view": "^6.41.1",
     "@commonify/lowdb": "^3.0.0",
     "electron-log": "^5.4.3",
-    "lodash": "^4.18.1",
-    "quill": "^2.0.3"
+    "lodash": "^4.18.1"
   }
 }

--- a/src/components/Memo.svelte
+++ b/src/components/Memo.svelte
@@ -1,256 +1,103 @@
 <script>
-  import { onMount, createEventDispatcher } from "svelte";
-  import Quill from "quill";
-  import "../..//node_modules/quill/dist/quill.snow.css";
-  import { isEqual, debounce } from "lodash";
+  import { onMount } from "svelte";
+  import { EditorView, keymap } from "@codemirror/view";
+  import { EditorState } from "@codemirror/state";
+  import { markdown, markdownLanguage } from "@codemirror/lang-markdown";
+  import { syntaxHighlighting, defaultHighlightStyle } from "@codemirror/language";
+  import { languages } from "@codemirror/language-data";
+  import { history, defaultKeymap, historyKeymap } from "@codemirror/commands";
+  import { highlightSelectionMatches, searchKeymap } from "@codemirror/search";
 
   export let saveMemo;
   export let content = "";
   export let readOnly = false;
 
-  let editor;
-  // 編集中のフラグとカーソル位置を保存する変数
-  let isEditing = false;
-  let savedSelection = null;
-  let lastSavedContent = null;
-  let toolbarOptions = [
-    [{ font: [] }],
-    [{ header: [1, 2, false] }],
-    [{ color: [] }, { background: [] }], // dropdown with defaults from theme
-    ["bold", "italic", "underline", "strike"], // toggled buttons
-    ["blockquote", "code-block", { list: "ordered" }, { list: "bullet" }],
-    [{ script: "sub" }, { script: "super" }], // superscript/subscript
-    [{ indent: "-1" }, { indent: "+1" }], // outdent/indent
-    [{ align: [] }],
-    ["link", "image"],
-    ["clean"], // remove formatting button
-  ];
-  let quill = null;
+  let container;
+  let saveTimer;
 
-  // リンク処理のための変数
-  let isHandlingLink = false;
-  let errorMessage = null;
-
-  // イベントリスナーの参照を保持する変数
-  let linkClickListener;
-  let pasteListener;
-
-  function applyContent(nextContent) {
-    if (!quill) {
-      return;
-    }
-
-    if (!nextContent) {
-      // Use explicit empty Delta to reliably clear Quill content
-      quill.setContents([{ insert: "\n" }]);
-      return;
-    }
-
-    if (typeof nextContent === "string") {
-      quill.setText(nextContent);
-      return;
-    }
-
-    quill.setContents(nextContent);
-  }
-
-  // Quillのリンクツールチップを処理するための関数
-  function handleLinkTooltips() {
-    // イベントハンドラー関数を定義
-    const handleLinkClick = async (e) => {
-      // Visit (ql-preview) ボタンがクリックされた場合
-      if (e.target && e.target.classList.contains("ql-preview")) {
-        const href = e.target.getAttribute("href");
-        if (href && href.trim() !== "") {
-          // 既に処理中なら何もしない（二重実行防止）
-          if (isHandlingLink) return;
-
-          // クリックイベントのデフォルト動作を停止（内部ブラウザでの開封を防止）
-          e.preventDefault();
-          e.stopPropagation();
-
-          // Quillの標準ツールチップを適切に閉じる
-          if (quill && quill.theme && quill.theme.tooltip) {
-            quill.theme.tooltip.hide();
-          }
-
-          try {
-            isHandlingLink = true;
-            // 外部ブラウザでリンクを開く
-            await window.electronAPI.openExternalLink(href);
-          } catch {
-            errorMessage = "リンクを開けませんでした";
-          } finally {
-            isHandlingLink = false;
-          }
-        }
-      }
-    };
-
-    // 参照を保存してクリーンアップで使用できるようにする
-    linkClickListener = handleLinkClick;
-
-    // ドキュメント全体のクリックイベントリスナーを設定
-    document.addEventListener("click", linkClickListener, false);
-  }
-
-  function handlePastePreservingLeadingNewlines() {
-    const onPaste = (event) => {
-      if (readOnly || !quill) {
-        return;
-      }
-
-      const clipboardData = event.clipboardData;
-      const pastedText = clipboardData?.getData("text/plain");
-      const pastedHtml = clipboardData?.getData("text/html");
-      const hasRichContent = typeof pastedHtml === "string" && pastedHtml.trim() !== "";
-      const hasImageFile = Array.from(clipboardData?.items ?? []).some(
-        (item) =>
-          item.kind === "file" && typeof item.type === "string" && item.type.startsWith("image/")
-      );
-
-      if (hasRichContent || hasImageFile) {
-        return;
-      }
-
-      if (typeof pastedText !== "string" || !pastedText.startsWith("\n")) {
-        return;
-      }
-
-      event.preventDefault();
-      event.stopPropagation();
-
-      const selection = quill.getSelection(true) ?? {
-        index: quill.getLength(),
-        length: 0,
-      };
-
-      if (selection.length > 0) {
-        quill.deleteText(selection.index, selection.length, "user");
-      }
-
-      quill.insertText(selection.index, pastedText, "user");
-      quill.setSelection(selection.index + pastedText.length, 0, "silent");
-    };
-
-    pasteListener = onPaste;
-    quill.root.addEventListener("paste", pasteListener, true);
+  // Quill Delta (object) が残っている場合は JSON 文字列に変換してフォールバック表示
+  function toMarkdown(val) {
+    if (!val) return "";
+    if (typeof val === "string") return val;
+    return JSON.stringify(val, null, 2);
   }
 
   onMount(() => {
-    quill = new Quill(editor, {
-      theme: "snow",
-      modules: {
-        toolbar: readOnly ? false : toolbarOptions,
-        clipboard: {
-          matchVisual: false,
-        },
+    const theme = EditorView.theme({
+      "&": {
+        height: "100%",
+        backgroundColor: "var(--theme-color-Main-light)",
+        color: "var(--theme-color-Sub-light)",
+      },
+      ".cm-scroller": {
+        overflow: "auto",
+        fontFamily: "inherit",
+        fontSize: "0.9rem",
+        lineHeight: "1.7",
+      },
+      ".cm-content": {
+        padding: "1rem",
+        caretColor: "var(--theme-color-Sub-light)",
+        minHeight: "100%",
+      },
+      "&.cm-focused .cm-selectionBackground, .cm-selectionBackground": {
+        backgroundColor: "var(--theme-color-Accent-dark) !important",
+      },
+      ".cm-selectionMatch": {
+        backgroundColor: "var(--theme-color-Accent-main)",
+        opacity: "0.35",
+      },
+      ".cm-cursor, .cm-dropCursor": {
+        borderLeftColor: "var(--theme-color-Sub-light)",
+      },
+      ".cm-activeLine": {
+        backgroundColor: "rgba(255, 255, 255, 0.02)",
+      },
+      ".cm-gutters": {
+        display: "none",
       },
     });
 
-    applyContent(content);
-    quill.enable(!readOnly);
+    const baseExtensions = [
+      theme,
+      markdown({ base: markdownLanguage, codeLanguages: languages }),
+      syntaxHighlighting(defaultHighlightStyle),
+      highlightSelectionMatches(),
+      keymap.of([...defaultKeymap, ...searchKeymap]),
+      EditorView.lineWrapping,
+    ];
 
-    if (!readOnly) {
-      // テキスト変更のみを検知して保存処理を行う
-      quill.on("text-change", function (delta, oldDelta, source) {
-        if (source === "user") {
-          // 編集中フラグを設定
-          isEditing = true;
+    const extensions = readOnly
+      ? [...baseExtensions, EditorState.readOnly.of(true)]
+      : [
+          ...baseExtensions,
+          history(),
+          keymap.of(historyKeymap),
+          EditorView.updateListener.of((update) => {
+            if (update.docChanged) {
+              clearTimeout(saveTimer);
+              saveTimer = setTimeout(() => saveMemo(update.state.doc.toString()), 500);
+            }
+          }),
+        ];
 
-          // 現在のカーソル位置を取得
-          const currentSelection = quill.hasFocus() ? quill.getSelection() : null;
+    const view = new EditorView({
+      state: EditorState.create({
+        doc: toMarkdown(content),
+        extensions,
+      }),
+      parent: container,
+    });
 
-          // 内容を保存（カーソル位置も一緒に送信）
-          const contents = quill.getContents();
-          lastSavedContent = contents;
-
-          // カーソル位置情報も一緒に送信
-          if (currentSelection) {
-            saveMemo(contents, currentSelection);
-          } else {
-            saveMemo(contents);
-          }
-
-          // 編集フラグをリセット
-          setTimeout(() => {
-            isEditing = false;
-          }, 100);
-        }
-      });
-
-      // カーソル位置の変更のみを検出（保存は行わない）
-      quill.on("selection-change", function (range, oldRange, source) {
-        if (range && source === "user") {
-          // カーソル位置を保存（ローカルのみ）
-          savedSelection = {
-            index: range.index,
-            length: range.length,
-          };
-        }
-      });
-    }
-
-    // リンクツールチップの処理をセットアップ
-    handleLinkTooltips();
-    handlePastePreservingLeadingNewlines();
-
-    // クリーンアップ関数を返す
     return () => {
-      // コンポーネントがアンマウントされる時に必要なクリーンアップを行う
-
-      // イベントリスナーを削除
-      if (linkClickListener) {
-        document.removeEventListener("click", linkClickListener, false);
-        linkClickListener = null;
-      }
-      if (pasteListener && quill?.root) {
-        quill.root.removeEventListener("paste", pasteListener, true);
-        pasteListener = null;
-      }
-
-      // すべてのリソース解放
-      isEditing = false;
-      savedSelection = null;
-      lastSavedContent = null;
-      quill = null;
+      clearTimeout(saveTimer);
+      view.destroy();
     };
   });
-
-  // 外部から更新されたコンテンツとの同期（編集中は同期しない）
-  $: if (quill && !isEditing) {
-    // 空コンテンツへの切り替えは常に適用し、既存コンテンツが残らないようにする
-    const contentIsEmpty = !content;
-    const lastSavedIsEmpty = !lastSavedContent;
-    const needsUpdate =
-      contentIsEmpty !== lastSavedIsEmpty ||
-      (!contentIsEmpty && !isEqual(content, lastSavedContent));
-
-    if (needsUpdate) {
-      // 一時的に編集中フラグを立てる（再描画防止）
-      isEditing = true;
-
-      // コンテンツを更新
-      applyContent(content);
-      lastSavedContent = content;
-
-      // 外部更新後はカーソル位置を保存せずにシンプルに編集フラグのみリセット
-      setTimeout(() => {
-        // 編集フラグをリセット
-        isEditing = false;
-      }, 50);
-    }
-  }
 </script>
 
 <div class="wrapper">
-  {#if errorMessage}
-    <div class="error-banner" role="alert">
-      <span>{errorMessage}</span>
-      <button on:click={() => (errorMessage = null)}>×</button>
-    </div>
-  {/if}
-  <div bind:this={editor} class="editor" on:blur></div>
+  <div class="editor" bind:this={container}></div>
 </div>
 
 <style>
@@ -259,47 +106,13 @@
     flex-direction: column;
     flex: 1;
     height: 100%;
-    border: none !important;
-    color: var(--theme-color-Sub-light);
-    background-color: var(--theme-color-Main-dark);
-  }
-  .editor {
-    flex: 1;
-    overflow: auto;
-    display: flex;
-    flex-direction: column;
-    height: 100%;
+    overflow: hidden;
     background-color: var(--theme-color-Main-light);
   }
-  .error-banner {
-    display: flex;
-    align-items: center;
-    justify-content: space-between;
-    padding: 0.4rem 0.75rem;
-    background-color: #c0392b;
-    color: #fff;
-    font-size: 0.875rem;
-    flex-shrink: 0;
-  }
-  .error-banner button {
-    background: none;
-    border: none;
-    color: #fff;
-    cursor: pointer;
-    font-size: 1rem;
-    line-height: 1;
-    padding: 0 0.25rem;
-  }
-  :global(.ql-picker :not(.ql-active, :hover)) {
-    color: var(--theme-color-Sub-light) !important;
-  }
-  :global(.ql-picker-options) {
-    background-color: var(--theme-color-Main-light) !important;
-  }
-  :global(*:not(.ql-active, :hover) > svg > .ql-stroke) {
-    stroke: var(--theme-color-Sub-light) !important;
-  }
-  :global(*:not(.ql-active, :hover) > svg > .ql-fill) {
-    fill: var(--theme-color-Sub-light) !important;
+
+  .editor {
+    flex: 1;
+    height: 100%;
+    overflow: hidden;
   }
 </style>

--- a/src/components/Memo.svelte
+++ b/src/components/Memo.svelte
@@ -68,7 +68,7 @@
     ];
 
     const extensions = readOnly
-      ? [...baseExtensions, EditorState.readOnly.of(true)]
+      ? [...baseExtensions, EditorState.readOnly.of(true), EditorView.editable.of(false)]
       : [
           ...baseExtensions,
           history(),

--- a/src/components/MemoTab.svelte
+++ b/src/components/MemoTab.svelte
@@ -161,8 +161,7 @@
     {#if memo[selectedMemoIndex]}
       {#key `${$table_selected_id ?? "none"}:${selectedMemoIndex}`}
         <Memo
-          saveMemo={(editedContent, cursorPosition) =>
-            saveMemo(editedContent, selectedMemoIndex, cursorPosition)}
+          saveMemo={(editedContent) => saveMemo(editedContent, selectedMemoIndex)}
           content={editedContent}
         />
       {/key}

--- a/src/components/TaskDetail.svelte
+++ b/src/components/TaskDetail.svelte
@@ -44,27 +44,13 @@
     );
     return true;
   };
-  const saveMemo = (editedContent, selectedMemoIndex, cursorPosition = null) => {
-    // 保存処理を行うが、再描画をトリガーしないようにする
+  const saveMemo = (editedContent, selectedMemoIndex) => {
     const updatedMemo = [...node.data["memo"]];
-
-    // カーソル位置情報も含めて保存
-    if (cursorPosition) {
-      // コンテンツとカーソル位置の両方を更新
-      updatedMemo[selectedMemoIndex] = {
-        ...updatedMemo[selectedMemoIndex],
-        content: editedContent,
-        cursorPosition: cursorPosition,
-      };
-    } else {
-      // 後方互換性のためコンテンツのみ更新
-      updatedMemo[selectedMemoIndex].content = editedContent;
-    }
-
-    // 直接ノードのデータを更新（リアクティブな更新をトリガーしない方法）
+    updatedMemo[selectedMemoIndex] = {
+      ...updatedMemo[selectedMemoIndex],
+      content: editedContent,
+    };
     node.data["memo"] = updatedMemo;
-
-    // データストアの更新（debounceされる）
     changeDataDebounce(node, "memo", updatedMemo);
     return true;
   };

--- a/tests/component/Memo.test.js
+++ b/tests/component/Memo.test.js
@@ -1,220 +1,59 @@
-import { fireEvent, render, screen, waitFor } from "@testing-library/svelte";
-import { tick } from "svelte";
+import { render } from "@testing-library/svelte";
 import { vi } from "vitest";
-
-const quillInstances = [];
-
-vi.mock("quill", () => {
-  class MockQuill {
-    constructor() {
-      this.root = document.createElement("div");
-      this.theme = { tooltip: { hide: vi.fn() } };
-      this.on = vi.fn();
-      this.enable = vi.fn();
-      this.setContents = vi.fn();
-      this.setText = vi.fn();
-      this.getContents = vi.fn(() => ({ ops: [] }));
-      this.getLength = vi.fn(() => 0);
-      this.getSelection = vi.fn(() => null);
-      this.hasFocus = vi.fn(() => false);
-      this.setSelection = vi.fn();
-      this.deleteText = vi.fn();
-      this.insertText = vi.fn();
-      quillInstances.push(this);
-    }
-  }
-  return { default: MockQuill };
-});
 
 import Memo from "../../src/components/Memo.svelte";
 
-describe("Memo - link click handling", () => {
+describe("Memo (CodeMirror 6)", () => {
   let saveMemo;
 
   beforeEach(() => {
-    quillInstances.length = 0;
     saveMemo = vi.fn();
-    window.electronAPI = {
-      openExternalLink: vi.fn().mockResolvedValue(undefined),
-    };
   });
 
-  afterEach(() => {
-    delete window.electronAPI;
-    document.querySelectorAll(".ql-preview").forEach((el) => el.remove());
-  });
-
-  function addPreviewLink(href) {
-    const link = document.createElement("a");
-    link.className = "ql-preview";
-    link.setAttribute("href", href);
-    document.body.appendChild(link);
-    return link;
-  }
-
-  test("shows no error banner initially", () => {
+  test("renders the CM6 editor container", () => {
     render(Memo, { props: { saveMemo, content: "" } });
-    expect(screen.queryByRole("alert")).not.toBeInTheDocument();
+    expect(document.querySelector(".cm-editor")).toBeInTheDocument();
   });
 
-  test("shows error banner when openExternalLink rejects", async () => {
-    window.electronAPI.openExternalLink.mockRejectedValue(new Error("network error"));
+  test("displays initial string content in the editor", () => {
+    render(Memo, { props: { saveMemo, content: "hello world" } });
+    expect(document.querySelector(".cm-content")).toHaveTextContent("hello world");
+  });
+
+  test("handles empty content without error", () => {
     render(Memo, { props: { saveMemo, content: "" } });
-
-    const link = addPreviewLink("https://example.com");
-    await fireEvent.click(link);
-
-    await waitFor(() => {
-      expect(screen.getByRole("alert")).toBeInTheDocument();
-    });
-    expect(screen.getByRole("alert")).toHaveTextContent("リンクを開けませんでした");
+    expect(document.querySelector(".cm-editor")).toBeInTheDocument();
   });
 
-  test("dismisses error banner when × button is clicked", async () => {
-    window.electronAPI.openExternalLink.mockRejectedValue(new Error("failed"));
+  test("converts legacy Quill Delta object to JSON string", () => {
+    const delta = { ops: [{ insert: "hello" }] };
+    render(Memo, { props: { saveMemo, content: delta } });
+    expect(document.querySelector(".cm-content")).toHaveTextContent('"ops"');
+  });
+
+  test("converts null/undefined content to empty string", () => {
+    render(Memo, { props: { saveMemo, content: null } });
+    expect(document.querySelector(".cm-editor")).toBeInTheDocument();
+    expect(document.querySelector(".cm-content").textContent.trim()).toBe("");
+  });
+
+  test("editable by default: contenteditable is true", () => {
     render(Memo, { props: { saveMemo, content: "" } });
-
-    addPreviewLink("https://example.com");
-    await fireEvent.click(document.querySelector(".ql-preview"));
-    await waitFor(() => expect(screen.getByRole("alert")).toBeInTheDocument());
-
-    await fireEvent.click(screen.getByRole("button", { name: "×" }));
-    await tick();
-
-    expect(screen.queryByRole("alert")).not.toBeInTheDocument();
+    const content = document.querySelector(".cm-content");
+    expect(content).toHaveAttribute("contenteditable", "true");
   });
 
-  test("shows no error banner when openExternalLink resolves", async () => {
-    render(Memo, { props: { saveMemo, content: "" } });
-
-    const link = addPreviewLink("https://example.com");
-    await fireEvent.click(link);
-    await waitFor(() => expect(window.electronAPI.openExternalLink).toHaveBeenCalledTimes(1));
-
-    expect(screen.queryByRole("alert")).not.toBeInTheDocument();
+  test("readOnly: contenteditable is false", () => {
+    render(Memo, { props: { saveMemo, content: "read only text", readOnly: true } });
+    const content = document.querySelector(".cm-content");
+    expect(content).not.toHaveAttribute("contenteditable", "true");
   });
 
-  test("resets isHandlingLink after error, allowing subsequent clicks", async () => {
-    window.electronAPI.openExternalLink.mockRejectedValue(new Error("failed"));
-    render(Memo, { props: { saveMemo, content: "" } });
-
-    const link = addPreviewLink("https://example.com");
-
-    await fireEvent.click(link);
-    await waitFor(() => expect(window.electronAPI.openExternalLink).toHaveBeenCalledTimes(1));
-
-    // 2回目のクリックが処理される
-    window.electronAPI.openExternalLink.mockResolvedValue(undefined);
-    await fireEvent.click(link);
-    await waitFor(() => expect(window.electronAPI.openExternalLink).toHaveBeenCalledTimes(2));
-  });
-
-  test("ignores duplicate clicks while a link is being handled", async () => {
-    let resolveFn;
-    window.electronAPI.openExternalLink.mockImplementation(
-      () => new Promise((resolve) => (resolveFn = resolve))
-    );
-    render(Memo, { props: { saveMemo, content: "" } });
-
-    const link = addPreviewLink("https://example.com");
-
-    await fireEvent.click(link);
-    await tick();
-
-    // 1回目の処理中に2回目をクリック → 無視される
-    await fireEvent.click(link);
-    await tick();
-
-    resolveFn();
-    await tick();
-
-    expect(window.electronAPI.openExternalLink).toHaveBeenCalledTimes(1);
-  });
-
-  test("does not open link when href is empty", async () => {
-    render(Memo, { props: { saveMemo, content: "" } });
-
-    const link = addPreviewLink("");
-    await fireEvent.click(link);
-    await tick();
-
-    expect(window.electronAPI.openExternalLink).not.toHaveBeenCalled();
-  });
-
-  test("preserves leading newlines for plain-text paste", async () => {
-    render(Memo, { props: { saveMemo, content: "" } });
-    const quill = quillInstances.at(-1);
-    expect(quill).toBeDefined();
-
-    const pasteEvent = new Event("paste", { bubbles: true, cancelable: true });
-    Object.defineProperty(pasteEvent, "clipboardData", {
-      value: {
-        getData: (type) => (type === "text/plain" ? "\nhello" : ""),
-        items: [],
-      },
-      configurable: true,
-    });
-
-    quill.root.dispatchEvent(pasteEvent);
-
-    expect(quill.insertText).toHaveBeenCalledWith(0, "\nhello", "user");
-    expect(pasteEvent.defaultPrevented).toBe(true);
-  });
-
-  test("does not intercept paste when clipboard has rich HTML content", async () => {
-    render(Memo, { props: { saveMemo, content: "" } });
-    const quill = quillInstances.at(-1);
-
-    const pasteEvent = new Event("paste", { bubbles: true, cancelable: true });
-    Object.defineProperty(pasteEvent, "clipboardData", {
-      value: {
-        getData: (type) => (type === "text/plain" ? "\n" : "<p><img src='x'></p>"),
-        items: [],
-      },
-      configurable: true,
-    });
-
-    quill.root.dispatchEvent(pasteEvent);
-
-    expect(quill.insertText).not.toHaveBeenCalled();
-    expect(pasteEvent.defaultPrevented).toBe(false);
-  });
-
-  test("does not intercept paste when clipboard has image file items", async () => {
-    render(Memo, { props: { saveMemo, content: "" } });
-    const quill = quillInstances.at(-1);
-
-    const pasteEvent = new Event("paste", { bubbles: true, cancelable: true });
-    Object.defineProperty(pasteEvent, "clipboardData", {
-      value: {
-        getData: (type) => (type === "text/plain" ? "\n" : ""),
-        items: [{ kind: "file", type: "image/png" }],
-      },
-      configurable: true,
-    });
-
-    quill.root.dispatchEvent(pasteEvent);
-
-    expect(quill.insertText).not.toHaveBeenCalled();
-    expect(pasteEvent.defaultPrevented).toBe(false);
-  });
-
-  test("does not intercept paste while readOnly", async () => {
-    render(Memo, { props: { saveMemo, content: "", readOnly: true } });
-    const quill = quillInstances.at(-1);
-
-    const pasteEvent = new Event("paste", { bubbles: true, cancelable: true });
-    Object.defineProperty(pasteEvent, "clipboardData", {
-      value: {
-        getData: (type) => (type === "text/plain" ? "\nhello" : ""),
-        items: [],
-      },
-      configurable: true,
-    });
-
-    quill.root.dispatchEvent(pasteEvent);
-
-    expect(quill.insertText).not.toHaveBeenCalled();
-    expect(pasteEvent.defaultPrevented).toBe(false);
+  test("readOnly: saveMemo is never called", async () => {
+    vi.useFakeTimers();
+    render(Memo, { props: { saveMemo, content: "text", readOnly: true } });
+    vi.runAllTimers();
+    expect(saveMemo).not.toHaveBeenCalled();
+    vi.useRealTimers();
   });
 });


### PR DESCRIPTION
## Summary

- Quill.js を CodeMirror 6 に置換（`Memo.svelte` を全面書き直し）
- メモのコンテンツ型を Quill Delta オブジェクトから plain Markdown 文字列に変更
- 旧 Delta オブジェクトが残っている場合は JSON 文字列にフォールバック表示
- `quill` パッケージを削除、`@codemirror/*` 6 パッケージを追加

## 主な機能

- Markdown シンタックスハイライト（`@codemirror/lang-markdown` + `@codemirror/language-data`）
- コードブロック内の言語別ハイライト
- 選択範囲マッチハイライト（`@codemirror/search`）
- undo/redo（`@codemirror/commands`）
- `readOnly` モード対応（`contenteditable=false`）
- 500ms debounce で `saveMemo(text: string)` を呼び出し

## 今後の拡張ポイント（未実装）

- `[[link]]` 形式のタスク間リンク補完（`@codemirror/autocomplete`）
- インライン画像プレビュー（widget decoration + `localfile://` プロトコル）

## Test plan

- [ ] ユニットテスト・コンポーネントテストが全件通過することを確認
- [ ] メモの新規作成・編集・保存が正常に動作することを確認
- [ ] Markdown 記法（見出し・太字・コードブロック等）がハイライトされることを確認
- [ ] undo/redo（Ctrl+Z / Ctrl+Y）が動作することを確認
- [ ] 旧 db.json プロジェクトの Delta コンテンツが JSON 文字列で表示されることを確認

https://claude.ai/code/session_01XpvSnjiHSHdvJgGzFJ6DFK

---
_Generated by [Claude Code](https://claude.ai/code/session_01XpvSnjiHSHdvJgGzFJ6DFK)_