### PR TITLE
feat: add view/edit mode to Memo (marked preview + CM6 editor)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -16,7 +16,8 @@
         "@codemirror/view": "^6.41.1",
         "@commonify/lowdb": "^3.0.0",
         "electron-log": "^5.4.3",
-        "lodash": "^4.18.1"
+        "lodash": "^4.18.1",
+        "marked": "^18.0.2"
       },
       "devDependencies": {
         "@editorjs/editorjs": "^2.31.6",
@@ -7188,6 +7189,18 @@
       },
       "engines": {
         "node": "^18.17.0 || >=20.5.0"
+      }
+    },
+    "node_modules/marked": {
+      "version": "18.0.2",
+      "resolved": "https://registry.npmjs.org/marked/-/marked-18.0.2.tgz",
+      "integrity": "sha512-NsmlUYBS/Zg57rgDWMYdnre6OTj4e+qq/JS2ot3KrYLSoHLw+sDu0Nm1ZGpRgYAq6c+b1ekaY5NzVchMCQnzcg==",
+      "license": "MIT",
+      "bin": {
+        "marked": "bin/marked.js"
+      },
+      "engines": {
+        "node": ">= 20"
       }
     },
     "node_modules/matcher": {

--- a/package.json
+++ b/package.json
@@ -78,6 +78,7 @@
     "@codemirror/view": "^6.41.1",
     "@commonify/lowdb": "^3.0.0",
     "electron-log": "^5.4.3",
-    "lodash": "^4.18.1"
+    "lodash": "^4.18.1",
+    "marked": "^18.0.2"
   }
 }

--- a/src/components/Memo.svelte
+++ b/src/components/Memo.svelte
@@ -69,7 +69,13 @@
       keymap.of([
         ...defaultKeymap,
         ...searchKeymap,
-        { key: "Escape", run: () => { stopEdit(); return true; } },
+        {
+          key: "Escape",
+          run: () => {
+            stopEdit();
+            return true;
+          },
+        },
       ]),
       keymap.of(historyKeymap),
       EditorView.lineWrapping,
@@ -238,9 +244,15 @@
     color: var(--theme-color-Sub-light);
   }
 
-  .preview :global(h1) { font-size: 1.5rem; }
-  .preview :global(h2) { font-size: 1.25rem; }
-  .preview :global(h3) { font-size: 1.1rem; }
+  .preview :global(h1) {
+    font-size: 1.5rem;
+  }
+  .preview :global(h2) {
+    font-size: 1.25rem;
+  }
+  .preview :global(h3) {
+    font-size: 1.1rem;
+  }
 
   .preview :global(p) {
     margin: 0.5em 0;

--- a/src/components/Memo.svelte
+++ b/src/components/Memo.svelte
@@ -1,5 +1,5 @@
-<script>
-  import { onMount } from "svelte";
+<script lang="ts">
+  import { tick, onDestroy } from "svelte";
   import { EditorView, keymap } from "@codemirror/view";
   import { EditorState } from "@codemirror/state";
   import { markdown, markdownLanguage } from "@codemirror/lang-markdown";
@@ -7,97 +7,156 @@
   import { languages } from "@codemirror/language-data";
   import { history, defaultKeymap, historyKeymap } from "@codemirror/commands";
   import { highlightSelectionMatches, searchKeymap } from "@codemirror/search";
+  import { marked } from "marked";
 
-  export let saveMemo;
-  export let content = "";
+  export let saveMemo: (content: string) => void;
+  export let content: unknown = "";
   export let readOnly = false;
 
-  let container;
-  let saveTimer;
+  let container: HTMLElement;
+  let view: EditorView | null = null;
+  let saveTimer: ReturnType<typeof setTimeout>;
+  let isEditing = false;
+  let hasChanges = false;
+  let currentContent = toMarkdown(content);
 
-  // Quill Delta (object) が残っている場合は JSON 文字列に変換してフォールバック表示
-  function toMarkdown(val) {
+  function toMarkdown(val: unknown): string {
     if (!val) return "";
     if (typeof val === "string") return val;
+    // Legacy Quill Delta → JSON fallback
     return JSON.stringify(val, null, 2);
   }
 
-  onMount(() => {
-    const theme = EditorView.theme({
-      "&": {
-        height: "100%",
-        backgroundColor: "var(--theme-color-Main-light)",
-        color: "var(--theme-color-Sub-light)",
-      },
-      ".cm-scroller": {
-        overflow: "auto",
-        fontFamily: "inherit",
-        fontSize: "0.9rem",
-        lineHeight: "1.7",
-      },
-      ".cm-content": {
-        padding: "1rem",
-        caretColor: "var(--theme-color-Sub-light)",
-        minHeight: "100%",
-      },
-      "&.cm-focused .cm-selectionBackground, .cm-selectionBackground": {
-        backgroundColor: "var(--theme-color-Accent-dark) !important",
-      },
-      ".cm-selectionMatch": {
-        backgroundColor: "var(--theme-color-Accent-main)",
-        opacity: "0.35",
-      },
-      ".cm-cursor, .cm-dropCursor": {
-        borderLeftColor: "var(--theme-color-Sub-light)",
-      },
-      ".cm-activeLine": {
-        backgroundColor: "rgba(255, 255, 255, 0.02)",
-      },
-      ".cm-gutters": {
-        display: "none",
-      },
-    });
+  const editorTheme = EditorView.theme({
+    "&": {
+      height: "100%",
+      backgroundColor: "var(--theme-color-Main-light)",
+      color: "var(--theme-color-Sub-light)",
+    },
+    ".cm-scroller": {
+      overflow: "auto",
+      fontFamily: "inherit",
+      fontSize: "0.9rem",
+      lineHeight: "1.7",
+    },
+    ".cm-content": {
+      padding: "1rem",
+      caretColor: "var(--theme-color-Sub-light)",
+      minHeight: "100%",
+    },
+    "&.cm-focused .cm-selectionBackground, .cm-selectionBackground": {
+      backgroundColor: "var(--theme-color-Accent-dark) !important",
+    },
+    ".cm-selectionMatch": {
+      backgroundColor: "var(--theme-color-Accent-main)",
+      opacity: "0.35",
+    },
+    ".cm-cursor, .cm-dropCursor": {
+      borderLeftColor: "var(--theme-color-Sub-light)",
+    },
+    ".cm-activeLine": {
+      backgroundColor: "rgba(255, 255, 255, 0.02)",
+    },
+    ".cm-gutters": { display: "none" },
+  });
 
-    const baseExtensions = [
-      theme,
+  function buildExtensions() {
+    return [
+      editorTheme,
       markdown({ base: markdownLanguage, codeLanguages: languages }),
       syntaxHighlighting(defaultHighlightStyle),
       highlightSelectionMatches(),
-      keymap.of([...defaultKeymap, ...searchKeymap]),
+      keymap.of([
+        ...defaultKeymap,
+        ...searchKeymap,
+        { key: "Escape", run: () => { stopEdit(); return true; } },
+      ]),
+      keymap.of(historyKeymap),
       EditorView.lineWrapping,
-    ];
-
-    const extensions = readOnly
-      ? [...baseExtensions, EditorState.readOnly.of(true), EditorView.editable.of(false)]
-      : [
-          ...baseExtensions,
-          history(),
-          keymap.of(historyKeymap),
-          EditorView.updateListener.of((update) => {
-            if (update.docChanged) {
-              clearTimeout(saveTimer);
-              saveTimer = setTimeout(() => saveMemo(update.state.doc.toString()), 500);
-            }
-          }),
-        ];
-
-    const view = new EditorView({
-      state: EditorState.create({
-        doc: toMarkdown(content),
-        extensions,
+      history(),
+      EditorView.updateListener.of((update) => {
+        if (update.docChanged) {
+          hasChanges = true;
+          clearTimeout(saveTimer);
+          saveTimer = setTimeout(() => {
+            currentContent = update.view.state.doc.toString();
+            saveMemo(currentContent);
+            hasChanges = false;
+          }, 500);
+        }
       }),
+    ];
+  }
+
+  async function startEdit() {
+    if (readOnly) return;
+    isEditing = true;
+    await tick();
+    view = new EditorView({
+      state: EditorState.create({ doc: currentContent, extensions: buildExtensions() }),
       parent: container,
     });
+    view.focus();
+  }
 
-    return () => {
+  function stopEdit() {
+    if (view) {
       clearTimeout(saveTimer);
+      currentContent = view.state.doc.toString();
+      if (hasChanges) {
+        saveMemo(currentContent);
+        hasChanges = false;
+      }
       view.destroy();
-    };
+      view = null;
+    }
+    isEditing = false;
+  }
+
+  onDestroy(() => {
+    if (view) {
+      clearTimeout(saveTimer);
+      if (hasChanges) saveMemo(view.state.doc.toString());
+      view.destroy();
+    }
   });
+
+  function handlePreviewClick(e: MouseEvent) {
+    const link = (e.target as Element).closest("a") as HTMLAnchorElement | null;
+    if (link?.href) {
+      e.preventDefault();
+      window.electronAPI?.openExternalLink(link.href);
+      return;
+    }
+    startEdit();
+  }
+
+  $: renderedHtml = marked.parse(currentContent || "") as string;
 </script>
 
 <div class="wrapper">
-  <div class="editor" bind:this={container}></div>
+  {#if isEditing}
+    <div class="edit-mode">
+      <div class="edit-bar">
+        <button class="done-btn" on:click={stopEdit}>完了</button>
+      </div>
+      <div class="editor" bind:this={container}></div>
+    </div>
+  {:else}
+    <!-- svelte-ignore a11y-no-static-element-interactions -->
+    <div
+      class="preview-mode"
+      on:click={handlePreviewClick}
+      on:keydown={(e) => e.key === "Enter" && startEdit()}
+    >
+      {#if currentContent.trim()}
+        <!-- ローカルコンテンツのみのためサニタイズ不要 -->
+        <div class="preview">{@html renderedHtml}</div>
+      {:else if !readOnly}
+        <div class="placeholder">クリックして編集...</div>
+      {/if}
+    </div>
+  {/if}
 </div>
 
 <style>
@@ -110,9 +169,148 @@
     background-color: var(--theme-color-Main-light);
   }
 
-  .editor {
-    flex: 1;
+  /* ---- Edit mode ---- */
+  .edit-mode {
+    display: flex;
+    flex-direction: column;
     height: 100%;
     overflow: hidden;
+  }
+
+  .edit-bar {
+    display: flex;
+    justify-content: flex-end;
+    align-items: center;
+    padding: 0.25rem 0.5rem;
+    background-color: var(--theme-color-Main-dark);
+    flex-shrink: 0;
+  }
+
+  .done-btn {
+    padding: 0.2rem 0.75rem;
+    font-size: 0.8rem;
+    background-color: var(--theme-color-Primary-main);
+    color: var(--theme-color-Main-dark);
+    border: none;
+    border-radius: 4px;
+    cursor: pointer;
+  }
+
+  .done-btn:hover {
+    background-color: var(--theme-color-Primary-dark);
+  }
+
+  .editor {
+    flex: 1;
+    overflow: hidden;
+  }
+
+  /* ---- View mode ---- */
+  .preview-mode {
+    flex: 1;
+    height: 100%;
+    overflow: auto;
+    cursor: text;
+  }
+
+  .preview {
+    padding: 1rem;
+    color: var(--theme-color-Sub-light);
+    font-size: 0.9rem;
+    line-height: 1.7;
+  }
+
+  .placeholder {
+    padding: 1rem;
+    color: var(--theme-color-Sub-main);
+    font-size: 0.9rem;
+    font-style: italic;
+  }
+
+  /* Markdown preview element styles */
+  .preview :global(h1),
+  .preview :global(h2),
+  .preview :global(h3),
+  .preview :global(h4) {
+    margin: 0.75em 0 0.4em;
+    font-weight: bold;
+    line-height: 1.3;
+    color: var(--theme-color-Sub-light);
+  }
+
+  .preview :global(h1) { font-size: 1.5rem; }
+  .preview :global(h2) { font-size: 1.25rem; }
+  .preview :global(h3) { font-size: 1.1rem; }
+
+  .preview :global(p) {
+    margin: 0.5em 0;
+  }
+
+  .preview :global(a) {
+    color: var(--theme-color-Accent-main);
+    text-decoration: underline;
+    cursor: pointer;
+  }
+
+  .preview :global(code) {
+    font-family: monospace;
+    font-size: 0.85em;
+    background-color: var(--theme-color-Main-dark);
+    padding: 0.1em 0.3em;
+    border-radius: 3px;
+  }
+
+  .preview :global(pre) {
+    background-color: var(--theme-color-Main-dark);
+    padding: 0.75rem 1rem;
+    border-radius: 4px;
+    overflow-x: auto;
+    margin: 0.5em 0;
+  }
+
+  .preview :global(pre code) {
+    background: none;
+    padding: 0;
+    font-size: 0.85rem;
+  }
+
+  .preview :global(blockquote) {
+    border-left: 3px solid var(--theme-color-Sub-dark);
+    margin: 0.5em 0;
+    padding: 0.25em 0.75em;
+    color: var(--theme-color-Sub-main);
+  }
+
+  .preview :global(ul),
+  .preview :global(ol) {
+    margin: 0.5em 0;
+    padding-left: 1.5em;
+  }
+
+  .preview :global(li) {
+    margin: 0.2em 0;
+  }
+
+  .preview :global(hr) {
+    border: none;
+    border-top: 1px solid var(--theme-color-Sub-dark);
+    margin: 1em 0;
+  }
+
+  .preview :global(table) {
+    border-collapse: collapse;
+    width: 100%;
+    margin: 0.5em 0;
+    font-size: 0.9rem;
+  }
+
+  .preview :global(th),
+  .preview :global(td) {
+    border: 1px solid var(--theme-color-Sub-dark);
+    padding: 0.3em 0.6em;
+  }
+
+  .preview :global(th) {
+    background-color: var(--theme-color-Main-dark);
   }
 </style>

--- a/src/components/Memo.svelte
+++ b/src/components/Memo.svelte
@@ -150,7 +150,7 @@
       on:keydown={(e) => e.key === "Enter" && startEdit()}
     >
       {#if currentContent.trim()}
-        <!-- ローカルコンテンツのみのためサニタイズ不要 -->
+        <!-- eslint-disable-next-line svelte/no-at-html-tags -->
         <div class="preview">{@html renderedHtml}</div>
       {:else if !readOnly}
         <div class="placeholder">クリックして編集...</div>

--- a/tests/component/Memo.test.js
+++ b/tests/component/Memo.test.js
@@ -1,55 +1,89 @@
-import { render } from "@testing-library/svelte";
+import { fireEvent, render, waitFor } from "@testing-library/svelte";
+import { tick } from "svelte";
 import { vi } from "vitest";
 
 import Memo from "../../src/components/Memo.svelte";
 
-describe("Memo (CodeMirror 6)", () => {
+describe("Memo - view mode (default)", () => {
   let saveMemo;
 
   beforeEach(() => {
     saveMemo = vi.fn();
   });
 
-  test("renders the CM6 editor container", () => {
+  test("renders in view mode by default (no CM6 editor)", () => {
     render(Memo, { props: { saveMemo, content: "" } });
-    expect(document.querySelector(".cm-editor")).toBeInTheDocument();
+    expect(document.querySelector(".cm-editor")).not.toBeInTheDocument();
+    expect(document.querySelector(".preview-mode")).toBeInTheDocument();
   });
 
-  test("displays initial string content in the editor", () => {
-    render(Memo, { props: { saveMemo, content: "hello world" } });
-    expect(document.querySelector(".cm-content")).toHaveTextContent("hello world");
-  });
-
-  test("handles empty content without error", () => {
+  test("shows placeholder when content is empty", () => {
     render(Memo, { props: { saveMemo, content: "" } });
-    expect(document.querySelector(".cm-editor")).toBeInTheDocument();
+    expect(document.querySelector(".placeholder")).toBeInTheDocument();
   });
 
-  test("converts legacy Quill Delta object to JSON string", () => {
+  test("renders markdown content as HTML in view mode", () => {
+    render(Memo, { props: { saveMemo, content: "# Hello\n\nWorld" } });
+    const preview = document.querySelector(".preview");
+    expect(preview).toBeInTheDocument();
+    expect(preview.querySelector("h1")).toHaveTextContent("Hello");
+  });
+
+  test("converts legacy Quill Delta object to JSON string for display", () => {
     const delta = { ops: [{ insert: "hello" }] };
     render(Memo, { props: { saveMemo, content: delta } });
-    expect(document.querySelector(".cm-content")).toHaveTextContent('"ops"');
+    expect(document.querySelector(".preview")).toBeInTheDocument();
   });
 
-  test("converts null/undefined content to empty string", () => {
-    render(Memo, { props: { saveMemo, content: null } });
-    expect(document.querySelector(".cm-editor")).toBeInTheDocument();
-    expect(document.querySelector(".cm-content").textContent.trim()).toBe("");
+  test("readOnly: no placeholder shown when empty", () => {
+    render(Memo, { props: { saveMemo, content: "", readOnly: true } });
+    expect(document.querySelector(".placeholder")).not.toBeInTheDocument();
+  });
+});
+
+describe("Memo - edit mode", () => {
+  let saveMemo;
+
+  beforeEach(() => {
+    saveMemo = vi.fn();
   });
 
-  test("editable by default: contenteditable is true", () => {
-    render(Memo, { props: { saveMemo, content: "" } });
-    const content = document.querySelector(".cm-content");
-    expect(content).toHaveAttribute("contenteditable", "true");
+  test("clicking preview enters edit mode and shows CM6 editor", async () => {
+    render(Memo, { props: { saveMemo, content: "hello" } });
+    await fireEvent.click(document.querySelector(".preview-mode"));
+    await waitFor(() => {
+      expect(document.querySelector(".cm-editor")).toBeInTheDocument();
+    });
   });
 
-  test("readOnly: contenteditable is false", () => {
-    render(Memo, { props: { saveMemo, content: "read only text", readOnly: true } });
-    const content = document.querySelector(".cm-content");
-    expect(content).not.toHaveAttribute("contenteditable", "true");
+  test("edit mode shows 完了 button", async () => {
+    render(Memo, { props: { saveMemo, content: "hello" } });
+    await fireEvent.click(document.querySelector(".preview-mode"));
+    await waitFor(() => {
+      expect(document.querySelector(".done-btn")).toBeInTheDocument();
+    });
   });
 
-  test("readOnly: saveMemo is never called", async () => {
+  test("clicking 完了 returns to view mode", async () => {
+    render(Memo, { props: { saveMemo, content: "hello" } });
+    await fireEvent.click(document.querySelector(".preview-mode"));
+    await waitFor(() => expect(document.querySelector(".done-btn")).toBeInTheDocument());
+
+    await fireEvent.click(document.querySelector(".done-btn"));
+    await tick();
+
+    expect(document.querySelector(".cm-editor")).not.toBeInTheDocument();
+    expect(document.querySelector(".preview-mode")).toBeInTheDocument();
+  });
+
+  test("readOnly: clicking does not enter edit mode", async () => {
+    render(Memo, { props: { saveMemo, content: "hello", readOnly: true } });
+    await fireEvent.click(document.querySelector(".preview-mode"));
+    await tick();
+    expect(document.querySelector(".cm-editor")).not.toBeInTheDocument();
+  });
+
+  test("saveMemo is not called in readOnly mode", async () => {
     vi.useFakeTimers();
     render(Memo, { props: { saveMemo, content: "text", readOnly: true } });
     vi.runAllTimers();

--- a/tests/component/Memo.test.js
+++ b/tests/component/Memo.test.js
@@ -90,4 +90,50 @@ describe("Memo - edit mode", () => {
     expect(saveMemo).not.toHaveBeenCalled();
     vi.useRealTimers();
   });
+
+  test("clicking 完了 without changes does not call saveMemo", async () => {
+    render(Memo, { props: { saveMemo, content: "hello" } });
+    await fireEvent.click(document.querySelector(".preview-mode"));
+    await waitFor(() => expect(document.querySelector(".done-btn")).toBeInTheDocument());
+
+    await fireEvent.click(document.querySelector(".done-btn"));
+    await tick();
+
+    expect(saveMemo).not.toHaveBeenCalled();
+  });
+});
+
+describe("Memo - link handling in preview", () => {
+  let saveMemo;
+
+  beforeEach(() => {
+    saveMemo = vi.fn();
+    window.electronAPI = { openExternalLink: vi.fn() };
+  });
+
+  afterEach(() => {
+    delete window.electronAPI;
+  });
+
+  test("clicking a link opens it externally and does not enter edit mode", async () => {
+    render(Memo, { props: { saveMemo, content: "[Visit](https://example.com)" } });
+    const link = document.querySelector(".preview a");
+    expect(link).toBeInTheDocument();
+
+    await fireEvent.click(link);
+    await tick();
+
+    expect(window.electronAPI.openExternalLink).toHaveBeenCalledWith(
+      expect.stringContaining("example.com")
+    );
+    expect(document.querySelector(".cm-editor")).not.toBeInTheDocument();
+  });
+
+  test("clicking non-link area enters edit mode", async () => {
+    render(Memo, { props: { saveMemo, content: "plain text" } });
+    await fireEvent.click(document.querySelector(".preview-mode"));
+    await waitFor(() => {
+      expect(document.querySelector(".cm-editor")).toBeInTheDocument();
+    });
+  });
 });


### PR DESCRIPTION
## Summary

closes #58

- デフォルトは **表示モード**：`marked` で Markdown を HTML レンダリング
- プレビューをクリックすると **編集モード**（CM6 エディタ）に切り替わる
- 「完了」ボタンまたは Escape キーで表示モードに戻り即時保存
- プレビュー内のリンクは `electronAPI.openExternalLink` で外部ブラウザを開く（編集モードには入らない）
- コンポーネント破棄時に未保存の変更を自動フラッシュ
- `marked` パッケージを追加

## Preview styling

見出し・コードブロック・リスト・表・引用・リンクをテーマの CSS 変数でスタイリング。

## Test plan

- [ ] メモが表示モードで開くことを確認
- [ ] クリックで CM6 エディタに切り替わることを確認
- [ ] 「完了」ボタンで保存・表示モードに戻ることを確認
- [ ] Escape キーで表示モードに戻ることを確認
- [ ] Markdown（見出し・コードブロック・リスト等）が正しくレンダリングされることを確認
- [ ] リンククリックで外部ブラウザが開くことを確認
- [ ] 全コンポーネントテストが通過することを確認

https://claude.ai/code/session_01XpvSnjiHSHdvJgGzFJ6DFK

---
_Generated by [Claude Code](https://claude.ai/code/session_01XpvSnjiHSHdvJgGzFJ6DFK)_