### PR TITLE
feat: タスクディレクトリ・メモファイルを UUID ベース命名に変更

### DIFF
--- a/electron/workspace.js
+++ b/electron/workspace.js
@@ -196,10 +196,7 @@ function writeTask(projectDir, task, taskDirs) {
   for (const f of existing) fs.unlinkSync(path.join(taskDir, f));
   for (const memo of task.memos || []) {
     const id = memo.id || crypto.randomUUID();
-    fs.writeFileSync(
-      path.join(taskDir, `${id}.md`),
-      stringifyFrontmatter({ id }, memo.content)
-    );
+    fs.writeFileSync(path.join(taskDir, `${id}.md`), stringifyFrontmatter({ id }, memo.content));
   }
 }
 

--- a/electron/workspace.js
+++ b/electron/workspace.js
@@ -1,3 +1,4 @@
+const crypto = require("crypto");
 const fs = require("fs");
 const path = require("path");
 
@@ -79,10 +80,12 @@ function readMemos(taskDir) {
     .filter((f) => f.endsWith(".md") && f !== "_index.md")
     .sort();
   for (const file of files) {
-    const content = fs.readFileSync(path.join(taskDir, file), "utf8");
-    const headingMatch = content.match(/^#\s+(.+)/m);
+    const raw = fs.readFileSync(path.join(taskDir, file), "utf8");
+    const { data, body } = parseFrontmatter(raw);
+    const id = data.id || crypto.randomUUID();
+    const headingMatch = body.match(/^#\s+(.+)/m);
     const title = headingMatch ? headingMatch[1].trim() : file.replace(/\.md$/, "");
-    memos.push({ title, content: content.trim() });
+    memos.push({ id, title, content: body.trim() });
   }
   return memos;
 }
@@ -176,7 +179,7 @@ function writeTask(projectDir, task, taskDirs) {
 
   let dirName = taskDirs.get(task.id);
   if (!dirName) {
-    dirName = uniqueName(projectDir, slugify(task.name));
+    dirName = task.id;
     taskDirs.set(task.id, dirName);
   }
   const taskDir = path.join(projectDir, dirName);
@@ -192,9 +195,11 @@ function writeTask(projectDir, task, taskDirs) {
   const existing = fs.readdirSync(taskDir).filter((f) => f.endsWith(".md") && f !== "_index.md");
   for (const f of existing) fs.unlinkSync(path.join(taskDir, f));
   for (const memo of task.memos || []) {
-    const base = `${slugify(memo.title) || "memo"}.md`;
-    const fileName = uniqueName(taskDir, base);
-    fs.writeFileSync(path.join(taskDir, fileName), memo.content + "\n");
+    const id = memo.id || crypto.randomUUID();
+    fs.writeFileSync(
+      path.join(taskDir, `${id}.md`),
+      stringifyFrontmatter({ id }, memo.content)
+    );
   }
 }
 
@@ -330,7 +335,7 @@ function migrateProjectData(workspacePath, projectData) {
         // Quill Delta or other object → preserve as JSON fenced block
         content = `# ${m.title || "Memo"}\n\n\`\`\`json\n${JSON.stringify(m.content, null, 2)}\n\`\`\``;
       }
-      return { title: String(m.title || "Memo"), content };
+      return { id: crypto.randomUUID(), title: String(m.title || "Memo"), content };
     });
 
     tasks.push({

--- a/src/common/tree_control.ts
+++ b/src/common/tree_control.ts
@@ -3,6 +3,7 @@ import { uuidV4 } from "./uuid";
 export type TaskStatus = "Open" | "Pending" | "In Progress" | "Completed" | "Canceled";
 
 export interface MemoEntry {
+  id: string;
   title: string;
   content: unknown;
 }

--- a/src/common/workspace_tree.ts
+++ b/src/common/workspace_tree.ts
@@ -37,7 +37,7 @@ export function workspaceToProjectData(
         name: task.name,
         status: task.status,
         "due date": task.dueDate as `${string}-${string}-${string}` | undefined,
-        memo: task.memos.map((m) => ({ title: m.title, content: m.content })),
+        memo: task.memos.map((m) => ({ id: m.id, title: m.title, content: m.content })),
       },
       children: childIds.map((cid) => buildNode(cid)),
     };

--- a/src/components/MemoTab.svelte
+++ b/src/components/MemoTab.svelte
@@ -62,7 +62,7 @@
       {#if memo.length == 0}
         <span class="memotab-item">{"Tabs here"}</span>
       {:else}
-        {#each memo as memo, i (i)}
+        {#each memo as memo, i (memo.id)}
           <button
             use:ripple={{ duration: 350, color: "var(--theme-color-Sub-main)" }}
             class="memotab-item"

--- a/src/components/TaskDetail.svelte
+++ b/src/components/TaskDetail.svelte
@@ -1,5 +1,6 @@
 <script>
   import { getNode, updateNodeDataById } from "../common/tree_control.ts";
+  import { uuidV4 } from "../common/uuid";
   import { tree_data, table_selected_id, cancelPendingOperations } from "../stores.ts";
   import { debounce } from "lodash";
   import { onDestroy } from "svelte";
@@ -31,7 +32,7 @@
   });
   const addMemo = (newMemoTitle) => {
     if (newMemoTitle) {
-      let newMemo = { title: newMemoTitle, content: "" };
+      let newMemo = { id: uuidV4(), title: newMemoTitle, content: "" };
       changeData(node, "memo", [...node.data.memo, newMemo]);
       return true;
     }

--- a/src/types/workspace.ts
+++ b/src/types/workspace.ts
@@ -1,6 +1,7 @@
 export type WorkspaceTaskStatus = "Open" | "Pending" | "In Progress" | "Completed" | "Canceled";
 
 export interface WorkspaceMemo {
+  id: string;
   title: string;
   content: string; // Markdown
 }

--- a/tests/component/TaskDetail.test.js
+++ b/tests/component/TaskDetail.test.js
@@ -44,7 +44,7 @@ function createProjectData() {
             name: "Second Task",
             status: "Pending",
             "due date": undefined,
-            memo: [{ title: "review", content: "" }],
+            memo: [{ id: "memo-review", title: "review", content: "" }],
           },
           children: [],
         },
@@ -74,12 +74,14 @@ describe("TaskDetail", () => {
     await tick();
 
     expect(screen.getByDisplayValue("memo")).toBeInTheDocument();
-    expect(get(tree_data).data.children[0].data.memo).toEqual([{ title: "memo", content: "" }]);
+    expect(get(tree_data).data.children[0].data.memo).toEqual([
+      expect.objectContaining({ title: "memo", content: "" }),
+    ]);
   });
 
   test("deletes the selected memo after confirmation", async () => {
     const project = createProjectData();
-    project.data.children[0].data.memo = [{ title: "draft", content: "" }];
+    project.data.children[0].data.memo = [{ id: "memo-draft", title: "draft", content: "" }];
     tree_data.set(project);
     table_selected_id.set("task-1");
 
@@ -101,8 +103,8 @@ describe("TaskDetail", () => {
   test("resets the selected memo tab when the selected task changes", async () => {
     const project = createProjectData();
     project.data.children[0].data.memo = [
-      { title: "draft", content: "" },
-      { title: "notes", content: "" },
+      { id: "memo-draft", title: "draft", content: "" },
+      { id: "memo-notes", title: "notes", content: "" },
     ];
     tree_data.set(project);
     table_selected_id.set("task-1");
@@ -120,7 +122,9 @@ describe("TaskDetail", () => {
 
   test("shows empty content after switching from existing memo to new empty memo and back", async () => {
     const project = createProjectData();
-    project.data.children[0].data.memo = [{ title: "existing", content: "some content" }];
+    project.data.children[0].data.memo = [
+      { id: "memo-existing", title: "existing", content: "some content" },
+    ];
     tree_data.set(project);
     table_selected_id.set("task-1");
 

--- a/tests/unit/workspace.test.js
+++ b/tests/unit/workspace.test.js
@@ -240,10 +240,15 @@ describe("file system operations", () => {
       status: "In Progress",
       dueDate: "2026-06-01",
       parents: ["root-id"],
-      memos: [{ title: "Notes", content: "# Notes\n\nSome content" }],
+      memos: [{ id: "memo-uuid-1", title: "Notes", content: "# Notes\n\nSome content" }],
       createdAt: "2026-04-24",
     };
     writeTask(projectDir, task, taskDirs);
+
+    // Task directory should be named after task.id (UUID)
+    expect(fs.existsSync(path.join(projectDir, "task-1"))).toBe(true);
+    // Memo file should be named after memo.id
+    expect(fs.existsSync(path.join(projectDir, "task-1", "memo-uuid-1.md"))).toBe(true);
 
     const { tasks } = readProject(projectDir);
     const loaded = tasks.get("task-1");
@@ -253,7 +258,26 @@ describe("file system operations", () => {
     expect(loaded.dueDate).toBe("2026-06-01");
     expect(loaded.parents).toEqual(["root-id"]);
     expect(loaded.memos).toHaveLength(1);
+    expect(loaded.memos[0].id).toBe("memo-uuid-1");
     expect(loaded.memos[0].title).toBe("Notes");
+  });
+
+  it("readMemos assigns a generated id to legacy memo files without frontmatter", () => {
+    const { projectDir } = createProject(tmpDir, "Proj", "root-id");
+    const taskDirs = new Map([["root-id", "_project"]]);
+    const task = { id: "task-legacy", name: "Legacy", status: "Open", parents: ["root-id"], memos: [], createdAt: "2026-04-24" };
+    writeTask(projectDir, task, taskDirs);
+
+    // Write an old-format memo file directly (no frontmatter)
+    const taskDir = path.join(projectDir, "task-legacy");
+    fs.writeFileSync(path.join(taskDir, "old-memo.md"), "# Old Memo\n\nLegacy content");
+
+    const { tasks } = readProject(projectDir);
+    const loaded = tasks.get("task-legacy");
+    expect(loaded.memos).toHaveLength(1);
+    expect(loaded.memos[0].title).toBe("Old Memo");
+    expect(typeof loaded.memos[0].id).toBe("string");
+    expect(loaded.memos[0].id.length).toBeGreaterThan(0);
   });
 
   it("deleteTaskDir removes the task directory", () => {

--- a/tests/unit/workspace.test.js
+++ b/tests/unit/workspace.test.js
@@ -265,7 +265,14 @@ describe("file system operations", () => {
   it("readMemos assigns a generated id to legacy memo files without frontmatter", () => {
     const { projectDir } = createProject(tmpDir, "Proj", "root-id");
     const taskDirs = new Map([["root-id", "_project"]]);
-    const task = { id: "task-legacy", name: "Legacy", status: "Open", parents: ["root-id"], memos: [], createdAt: "2026-04-24" };
+    const task = {
+      id: "task-legacy",
+      name: "Legacy",
+      status: "Open",
+      parents: ["root-id"],
+      memos: [],
+      createdAt: "2026-04-24",
+    };
     writeTask(projectDir, task, taskDirs);
 
     // Write an old-format memo file directly (no frontmatter)


### PR DESCRIPTION
タスクディレクトリ名を slugify(task.name) から task.id（UUID）に、
メモファイル名を slugify(memo.title).md から memo.id.md に変更。
論文 CORPUS2SKILL の設計原則「ID と表示ラベルを分離し、
ファイル名には安定した ID を使う」に合わせた対応。

- 同名タスク・同名メモを無制限に作成可能になる
- リネームしてもファイル名が変わらない
- メモに id フィールドを追加（WorkspaceMemo, MemoEntry）
- memo.id を YAML frontmatter に保存し readMemos で復元
- 旧形式（frontmatter なし）は次回保存時に自動移行
- 既存タスクのディレクトリ名は変わらず後方互換を維持

Closes #69

https://claude.ai/code/session_01T3vf5StKM9ViRLrwbammZ4