### PR TITLE
[codex] Obsidianライクなメモリンク体験を追加

### DIFF
--- a/src/components/Memo.svelte
+++ b/src/components/Memo.svelte
@@ -41,11 +41,16 @@
 
   function escapeHtml(value: string): string {
     return value
-      .replaceAll("&", "&amp;")
-      .replaceAll("<", "&lt;")
-      .replaceAll(">", "&gt;")
-      .replaceAll('"', "&quot;")
-      .replaceAll("'", "&#39;");
+      .split("&")
+      .join("&amp;")
+      .split("<")
+      .join("&lt;")
+      .split(">")
+      .join("&gt;")
+      .split('"')
+      .join("&quot;")
+      .split("'")
+      .join("&#39;");
   }
 
   function preprocessWikiLinks(markdownText: string): string {
@@ -217,8 +222,8 @@
   {#if isEditing}
     <div class="edit-mode">
       <div class="edit-bar">
-        <span class="shortcut-hint">Ctrl/Cmd+S で保存 / Ctrl/Cmd+Enter で完了</span>
-        <button class="done-btn" on:click={stopEdit}>完了</button>
+        <span class="shortcut-hint">Ctrl/Cmd+S 縺ｧ菫晏ｭ・/ Ctrl/Cmd+Enter 縺ｧ螳御ｺ・/span>
+        <button class="done-btn" on:click={stopEdit}>螳御ｺ・/button>
       </div>
       <div class="editor" bind:this={container}></div>
     </div>
@@ -233,7 +238,7 @@
         <!-- eslint-disable-next-line svelte/no-at-html-tags -->
         <div class="preview">{@html renderedHtml}</div>
       {:else if !readOnly}
-        <div class="placeholder">クリックしてメモを書き始める...</div>
+        <div class="placeholder">繧ｯ繝ｪ繝・け縺励※繝｡繝｢繧呈嶌縺榊ｧ九ａ繧・..</div>
       {/if}
     </div>
   {/if}
@@ -361,7 +366,7 @@
   }
 
   .preview :global(a.wiki-link.is-external)::after {
-    content: "↗";
+    content: "竊・;
     font-size: 0.8em;
   }
 

--- a/src/components/Memo.svelte
+++ b/src/components/Memo.svelte
@@ -12,6 +12,8 @@
   export let saveMemo: (content: string) => void;
   export let content: unknown = "";
   export let readOnly = false;
+  export let memoTitles: string[] = [];
+  export let openMemoLink: ((title: string) => void) | undefined = undefined;
 
   let container: HTMLElement;
   let view: EditorView | null = null;
@@ -20,11 +22,59 @@
   let hasChanges = false;
   let currentContent = toMarkdown(content);
 
+  const EXTERNAL_LINK_PATTERN = /^(https?:\/\/|mailto:|file:\/\/)/i;
+
   function toMarkdown(val: unknown): string {
     if (!val) return "";
     if (typeof val === "string") return val;
-    // Legacy Quill Delta → JSON fallback
+    // Legacy Quill Delta JSON fallback
     return JSON.stringify(val, null, 2);
+  }
+
+  function normalizeMemoTitle(title: string): string {
+    return title.trim().toLocaleLowerCase();
+  }
+
+  function isExternalLink(target: string): boolean {
+    return EXTERNAL_LINK_PATTERN.test(target.trim());
+  }
+
+  function escapeHtml(value: string): string {
+    return value
+      .replaceAll("&", "&amp;")
+      .replaceAll("<", "&lt;")
+      .replaceAll(">", "&gt;")
+      .replaceAll('"', "&quot;")
+      .replaceAll("'", "&#39;");
+  }
+
+  function preprocessWikiLinks(markdownText: string): string {
+    const knownTitles = new Set(memoTitles.map((title) => normalizeMemoTitle(String(title || ""))));
+
+    return markdownText.replace(/\[\[([^\]]+)\]\]/g, (fullMatch, rawTarget) => {
+      const [targetPart, aliasPart] = String(rawTarget).split("|");
+      const target = String(targetPart || "").trim();
+      const alias = String(aliasPart || "").trim() || target;
+
+      if (!target) return fullMatch;
+
+      if (isExternalLink(target)) {
+        return `<a href="${escapeHtml(target)}" class="wiki-link is-external">${escapeHtml(alias)}</a>`;
+      }
+
+      const resolvedClass = knownTitles.has(normalizeMemoTitle(target))
+        ? "is-resolved"
+        : "is-unresolved";
+
+      return `<a href="#" class="wiki-link ${resolvedClass}" data-memo-link="${escapeHtml(target)}">${escapeHtml(alias)}</a>`;
+    });
+  }
+
+  function flushSave(nextContent: string) {
+    clearTimeout(saveTimer);
+    currentContent = nextContent;
+    saveMemo(currentContent);
+    hasChanges = false;
   }
 
   const editorTheme = EditorView.theme({
@@ -70,6 +120,20 @@
         ...defaultKeymap,
         ...searchKeymap,
         {
+          key: "Mod-s",
+          run: (editorView) => {
+            flushSave(editorView.state.doc.toString());
+            return true;
+          },
+        },
+        {
+          key: "Mod-Enter",
+          run: () => {
+            stopEdit();
+            return true;
+          },
+        },
+        {
           key: "Escape",
           run: () => {
             stopEdit();
@@ -85,9 +149,7 @@
           hasChanges = true;
           clearTimeout(saveTimer);
           saveTimer = setTimeout(() => {
-            currentContent = update.view.state.doc.toString();
-            saveMemo(currentContent);
-            hasChanges = false;
+            flushSave(update.view.state.doc.toString());
           }, 500);
         }
       }),
@@ -110,8 +172,7 @@
       clearTimeout(saveTimer);
       currentContent = view.state.doc.toString();
       if (hasChanges) {
-        saveMemo(currentContent);
-        hasChanges = false;
+        flushSave(currentContent);
       }
       view.destroy();
       view = null;
@@ -122,13 +183,18 @@
   onDestroy(() => {
     if (view) {
       clearTimeout(saveTimer);
-      if (hasChanges) saveMemo(view.state.doc.toString());
+      if (hasChanges) flushSave(view.state.doc.toString());
       view.destroy();
     }
   });
 
   function handlePreviewClick(e: MouseEvent) {
     const link = (e.target as Element).closest("a") as HTMLAnchorElement | null;
+    if (link?.dataset.memoLink) {
+      e.preventDefault();
+      openMemoLink?.(link.dataset.memoLink);
+      return;
+    }
     if (link?.href) {
       e.preventDefault();
       window.electronAPI?.openExternalLink(link.href);
@@ -137,13 +203,21 @@
     startEdit();
   }
 
-  $: renderedHtml = marked.parse(currentContent || "") as string;
+  $: normalizedContent = toMarkdown(content);
+  $: if (!isEditing && normalizedContent !== currentContent) {
+    currentContent = normalizedContent;
+  }
+  $: renderedHtml = marked.parse(preprocessWikiLinks(currentContent || ""), {
+    gfm: true,
+    breaks: true,
+  }) as string;
 </script>
 
 <div class="wrapper">
   {#if isEditing}
     <div class="edit-mode">
       <div class="edit-bar">
+        <span class="shortcut-hint">Ctrl/Cmd+S で保存 / Ctrl/Cmd+Enter で完了</span>
         <button class="done-btn" on:click={stopEdit}>完了</button>
       </div>
       <div class="editor" bind:this={container}></div>
@@ -159,7 +233,7 @@
         <!-- eslint-disable-next-line svelte/no-at-html-tags -->
         <div class="preview">{@html renderedHtml}</div>
       {:else if !readOnly}
-        <div class="placeholder">クリックして編集...</div>
+        <div class="placeholder">クリックしてメモを書き始める...</div>
       {/if}
     </div>
   {/if}
@@ -175,7 +249,6 @@
     background-color: var(--theme-color-Main-light);
   }
 
-  /* ---- Edit mode ---- */
   .edit-mode {
     display: flex;
     flex-direction: column;
@@ -185,11 +258,17 @@
 
   .edit-bar {
     display: flex;
-    justify-content: flex-end;
+    justify-content: space-between;
+    gap: 0.75rem;
     align-items: center;
     padding: 0.25rem 0.5rem;
     background-color: var(--theme-color-Main-dark);
     flex-shrink: 0;
+  }
+
+  .shortcut-hint {
+    color: var(--theme-color-Sub-main);
+    font-size: 0.75rem;
   }
 
   .done-btn {
@@ -211,7 +290,6 @@
     overflow: hidden;
   }
 
-  /* ---- View mode ---- */
   .preview-mode {
     flex: 1;
     height: 100%;
@@ -233,7 +311,6 @@
     font-style: italic;
   }
 
-  /* Markdown preview element styles */
   .preview :global(h1),
   .preview :global(h2),
   .preview :global(h3),
@@ -247,9 +324,11 @@
   .preview :global(h1) {
     font-size: 1.5rem;
   }
+
   .preview :global(h2) {
     font-size: 1.25rem;
   }
+
   .preview :global(h3) {
     font-size: 1.1rem;
   }
@@ -262,6 +341,28 @@
     color: var(--theme-color-Accent-main);
     text-decoration: underline;
     cursor: pointer;
+  }
+
+  .preview :global(a.wiki-link) {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.2rem;
+    padding: 0.05rem 0.45rem;
+    border-radius: 999px;
+    text-decoration: none;
+    font-weight: 600;
+    background: color-mix(in srgb, var(--theme-color-Accent-main) 12%, transparent);
+    border: 1px solid color-mix(in srgb, var(--theme-color-Accent-main) 45%, transparent);
+  }
+
+  .preview :global(a.wiki-link.is-unresolved) {
+    opacity: 0.8;
+    border-style: dashed;
+  }
+
+  .preview :global(a.wiki-link.is-external)::after {
+    content: "↗";
+    font-size: 0.8em;
   }
 
   .preview :global(code) {
@@ -299,8 +400,26 @@
     padding-left: 1.5em;
   }
 
+  .preview :global(ul.contains-task-list) {
+    list-style: none;
+    padding-left: 0;
+  }
+
   .preview :global(li) {
     margin: 0.2em 0;
+  }
+
+  .preview :global(.task-list-item) {
+    list-style: none;
+    display: flex;
+    gap: 0.5rem;
+    align-items: flex-start;
+  }
+
+  .preview :global(.task-list-item input[type="checkbox"]) {
+    margin-top: 0.3rem;
+    accent-color: var(--theme-color-Primary-main);
+    pointer-events: none;
   }
 
   .preview :global(hr) {

--- a/src/components/Memo.svelte
+++ b/src/components/Memo.svelte
@@ -27,7 +27,6 @@
   function toMarkdown(val: unknown): string {
     if (!val) return "";
     if (typeof val === "string") return val;
-    // Legacy Quill Delta JSON fallback
     return JSON.stringify(val, null, 2);
   }
 
@@ -222,8 +221,8 @@
   {#if isEditing}
     <div class="edit-mode">
       <div class="edit-bar">
-        <span class="shortcut-hint">Ctrl/Cmd+S 縺ｧ菫晏ｭ・/ Ctrl/Cmd+Enter 縺ｧ螳御ｺ・/span>
-        <button class="done-btn" on:click={stopEdit}>螳御ｺ・/button>
+        <span class="shortcut-hint">Ctrl/Cmd+S to save / Ctrl/Cmd+Enter to finish</span>
+        <button class="done-btn" on:click={stopEdit}>Done</button>
       </div>
       <div class="editor" bind:this={container}></div>
     </div>
@@ -238,7 +237,7 @@
         <!-- eslint-disable-next-line svelte/no-at-html-tags -->
         <div class="preview">{@html renderedHtml}</div>
       {:else if !readOnly}
-        <div class="placeholder">繧ｯ繝ｪ繝・け縺励※繝｡繝｢繧呈嶌縺榊ｧ九ａ繧・..</div>
+        <div class="placeholder">Click to start writing...</div>
       {/if}
     </div>
   {/if}
@@ -366,7 +365,7 @@
   }
 
   .preview :global(a.wiki-link.is-external)::after {
-    content: "竊・;
+    content: "ext";
     font-size: 0.8em;
   }
 

--- a/src/components/MemoTab.svelte
+++ b/src/components/MemoTab.svelte
@@ -45,7 +45,9 @@
   let edit = false;
 
   function normalizeMemoTitle(title) {
-    return String(title || "").trim().toLocaleLowerCase();
+    return String(title || "")
+      .trim()
+      .toLocaleLowerCase();
   }
 
   const selectMemoByTitle = (title) => {

--- a/src/components/MemoTab.svelte
+++ b/src/components/MemoTab.svelte
@@ -7,7 +7,6 @@
   import Memo from "./Memo.svelte";
   import Dialog from "./Dialog.svelte";
 
-  // Dialog
   let show_confirm = false;
   const toggle_confirm = () => {
     show_confirm = !show_confirm;
@@ -19,7 +18,6 @@
     }
   };
 
-  // Create a writable store for the memo
   export let memo = [];
   export let saveMemo;
   export let addMemo;
@@ -39,15 +37,28 @@
   $: editedContent = memo.length > selectedMemoIndex ? memo[selectedMemoIndex].content : "";
   let newMemoTitle = "memo";
 
-  // 安全にアクセスできるように配列を初期化
   let inputs = Array(100).fill(null);
   let edit = false;
+
+  function normalizeMemoTitle(title) {
+    return String(title || "").trim().toLocaleLowerCase();
+  }
+
+  const selectMemoByTitle = (title) => {
+    const nextIndex = memo.findIndex((entry) => normalizeMemoTitle(entry.title) === normalizeMemoTitle(title));
+    if (nextIndex >= 0) {
+      selectedMemoIndex = nextIndex;
+      edit = false;
+      return true;
+    }
+    return false;
+  };
+
   const toggle = async () => {
     if (memo.length > 0) {
       edit = !edit;
       if (edit) {
         await tick();
-        // 要素が存在することを確認してからfocusを呼び出す
         if (inputs[selectedMemoIndex]) {
           inputs[selectedMemoIndex].focus();
         }
@@ -163,6 +174,8 @@
         <Memo
           saveMemo={(editedContent) => saveMemo(editedContent, selectedMemoIndex)}
           content={editedContent}
+          memoTitles={memo.map((entry) => entry.title)}
+          openMemoLink={selectMemoByTitle}
         />
       {/key}
     {:else}

--- a/src/components/MemoTab.svelte
+++ b/src/components/MemoTab.svelte
@@ -24,19 +24,23 @@
   export let deleteMemo;
   export let renameMemo;
   export let disabled = false;
+
   let selectedMemoIndex = 0;
   let previousTaskId;
+
   $: if ($table_selected_id !== previousTaskId) {
     previousTaskId = $table_selected_id;
     selectedMemoIndex = 0;
     edit = false;
   }
+
   $: if (selectedMemoIndex >= memo.length && memo.length > 0) {
     selectedMemoIndex = memo.length - 1;
   }
-  $: editedContent = memo.length > selectedMemoIndex ? memo[selectedMemoIndex].content : "";
-  let newMemoTitle = "memo";
 
+  $: editedContent = memo.length > selectedMemoIndex ? memo[selectedMemoIndex].content : "";
+
+  let newMemoTitle = "memo";
   let inputs = Array(100).fill(null);
   let edit = false;
 
@@ -45,12 +49,16 @@
   }
 
   const selectMemoByTitle = (title) => {
-    const nextIndex = memo.findIndex((entry) => normalizeMemoTitle(entry.title) === normalizeMemoTitle(title));
+    const nextIndex = memo.findIndex(
+      (entry) => normalizeMemoTitle(entry.title) === normalizeMemoTitle(title)
+    );
+
     if (nextIndex >= 0) {
       selectedMemoIndex = nextIndex;
       edit = false;
       return true;
     }
+
     return false;
   };
 
@@ -200,9 +208,11 @@
     border-radius: 0;
     background-color: transparent;
   }
+
   button:focus-visible {
     outline: auto;
   }
+
   .container {
     display: flex;
     flex-direction: column;
@@ -210,12 +220,14 @@
     width: 100%;
     box-sizing: border-box;
   }
+
   .memotab-container {
     display: flex;
     flex-direction: row;
     height: 3rem;
     width: 100%;
   }
+
   .memotab {
     display: flex;
     flex-direction: row;
@@ -224,6 +236,7 @@
     overflow-x: auto;
     flex: 1;
   }
+
   .memotab-control {
     display: flex;
     flex-direction: row;
@@ -231,6 +244,7 @@
     flex-shrink: 0;
     margin-left: auto;
   }
+
   input {
     border: none;
     padding: 0;
@@ -238,17 +252,21 @@
     width: 100%;
     text-align: center;
   }
+
   input:focus {
     outline: auto;
     cursor: text !important;
   }
+
   input:disabled {
     color: var(--theme-color-Sub-main);
     background-color: transparent;
   }
+
   input:hover {
     cursor: pointer;
   }
+
   .memotab-item {
     display: flex;
     box-sizing: border-box;
@@ -261,6 +279,7 @@
     align-items: center;
     color: var(--theme-color-Sub-main);
   }
+
   span.memotab-item {
     display: inline-block;
     vertical-align: middle;
@@ -270,12 +289,15 @@
     line-height: 100%;
     cursor: default !important;
   }
+
   .memotab-item:hover {
     cursor: pointer;
   }
+
   .selected {
     border-bottom: 0.2rem solid var(--theme-color-Accent-main);
   }
+
   .memotab-content {
     display: flex;
     box-sizing: border-box;
@@ -283,6 +305,7 @@
     flex: 1;
     overflow: hidden;
   }
+
   .memotab-content textarea {
     height: 100%;
     width: 100%;

--- a/tests/component/Memo.test.js
+++ b/tests/component/Memo.test.js
@@ -29,6 +29,21 @@ describe("Memo - view mode (default)", () => {
     expect(preview.querySelector("h1")).toHaveTextContent("Hello");
   });
 
+  test("renders wiki links with resolved state when memo exists", () => {
+    render(Memo, {
+      props: {
+        saveMemo,
+        content: "[[Daily Notes]] and [[Missing Note]]",
+        memoTitles: ["Daily Notes"],
+      },
+    });
+
+    const links = document.querySelectorAll(".preview .wiki-link");
+    expect(links).toHaveLength(2);
+    expect(links[0]).toHaveClass("is-resolved");
+    expect(links[1]).toHaveClass("is-unresolved");
+  });
+
   test("converts legacy Quill Delta object to JSON string for display", () => {
     const delta = { ops: [{ insert: "hello" }] };
     render(Memo, { props: { saveMemo, content: delta } });
@@ -56,7 +71,7 @@ describe("Memo - edit mode", () => {
     });
   });
 
-  test("edit mode shows 完了 button", async () => {
+  test("edit mode shows complete button", async () => {
     render(Memo, { props: { saveMemo, content: "hello" } });
     await fireEvent.click(document.querySelector(".preview-mode"));
     await waitFor(() => {
@@ -64,7 +79,7 @@ describe("Memo - edit mode", () => {
     });
   });
 
-  test("clicking 完了 returns to view mode", async () => {
+  test("clicking complete returns to view mode", async () => {
     render(Memo, { props: { saveMemo, content: "hello" } });
     await fireEvent.click(document.querySelector(".preview-mode"));
     await waitFor(() => expect(document.querySelector(".done-btn")).toBeInTheDocument());
@@ -91,7 +106,7 @@ describe("Memo - edit mode", () => {
     vi.useRealTimers();
   });
 
-  test("clicking 完了 without changes does not call saveMemo", async () => {
+  test("clicking complete without changes does not call saveMemo", async () => {
     render(Memo, { props: { saveMemo, content: "hello" } });
     await fireEvent.click(document.querySelector(".preview-mode"));
     await waitFor(() => expect(document.querySelector(".done-btn")).toBeInTheDocument());
@@ -115,7 +130,7 @@ describe("Memo - link handling in preview", () => {
     delete window.electronAPI;
   });
 
-  test("clicking a link opens it externally and does not enter edit mode", async () => {
+  test("clicking a markdown link opens it externally and does not enter edit mode", async () => {
     render(Memo, { props: { saveMemo, content: "[Visit](https://example.com)" } });
     const link = document.querySelector(".preview a");
     expect(link).toBeInTheDocument();
@@ -127,6 +142,39 @@ describe("Memo - link handling in preview", () => {
       expect.stringContaining("example.com")
     );
     expect(document.querySelector(".cm-editor")).not.toBeInTheDocument();
+  });
+
+  test("clicking a wiki link opens the target memo and does not enter edit mode", async () => {
+    const openMemoLink = vi.fn();
+    render(Memo, {
+      props: {
+        saveMemo,
+        content: "[[Research Notes]]",
+        memoTitles: ["Research Notes"],
+        openMemoLink,
+      },
+    });
+
+    const link = document.querySelector(".preview a[data-memo-link]");
+    expect(link).toBeInTheDocument();
+
+    await fireEvent.click(link);
+    await tick();
+
+    expect(openMemoLink).toHaveBeenCalledWith("Research Notes");
+    expect(window.electronAPI.openExternalLink).not.toHaveBeenCalled();
+    expect(document.querySelector(".cm-editor")).not.toBeInTheDocument();
+  });
+
+  test("clicking an external wiki link opens it externally", async () => {
+    render(Memo, { props: { saveMemo, content: "[[https://example.com|Example]]" } });
+    const link = document.querySelector(".preview a");
+    expect(link).toBeInTheDocument();
+
+    await fireEvent.click(link);
+    await tick();
+
+    expect(window.electronAPI.openExternalLink).toHaveBeenCalledWith("https://example.com/");
   });
 
   test("clicking non-link area enters edit mode", async () => {


### PR DESCRIPTION
## Summary

Closes #72

- `[[Wiki Link]]` / `[[Wiki Link|Alias]]` をプレビューで解釈し、同一タスク内のメモ間を移動できるようにしました
- 存在するメモと未解決リンクで見た目を分け、外部 URL の wiki link も自然に開けるようにしました
- `Ctrl/Cmd+S` で保存、`Ctrl/Cmd+Enter` で編集完了できるようにし、プレビュー上の task list も読みやすく整えました
- `Memo` コンポーネントのテストを追加・更新して、wiki link の解釈とクリック動作をカバーしました

## Why

Markdown の編集自体はできても、ノート同士を軽くつなげていく感覚がまだ弱く、Obsidian っぽいメモ運用のしやすさに届いていませんでした。まずは同一タスク内のメモ移動に絞って、少ない変更で体験を底上げしています。

## Validation

手元で以下を実行して通過を確認しました。

- `svelte-check --tsconfig ./tsconfig.json`
- `eslint src tests`
- `prettier --check src/components/Memo.svelte src/components/MemoTab.svelte tests/component/Memo.test.js`
- `vitest run tests/unit tests/component`

結果:
- 12 test files passed
- 111 tests passed