### PR TITLE
[codex] Markdownメモの画像貼り付けを追加

### DIFF
--- a/electron/index.js
+++ b/electron/index.js
@@ -1,5 +1,5 @@
 const _ = require("lodash");
-const { app, BrowserWindow, ipcMain, shell, WebContents, dialog } = require("electron");
+const { app, BrowserWindow, ipcMain, shell, dialog } = require("electron");
 const fs = require("fs");
 const path = require("path");
 const { LowSync, JSONFileSync } = require("@commonify/lowdb");
@@ -26,7 +26,7 @@ function resolveAppDataPath(fileName) {
 
 function showSaveError(context, err) {
   log.error(`Failed to write data (${context}):`, err.message);
-  const message = `データの保存に失敗しました: ${err.message}`;
+  const message = `Failed to save data: ${err.message}`;
   BrowserWindow.getAllWindows().forEach((win) => {
     if (!win.isDestroyed()) {
       win.webContents.send("save-error", message);
@@ -84,7 +84,7 @@ app.on("ready", () => {
   ////////////// IPC //////////////
   // on get-initial-tree-data.
   // return data to renderer.
-  ipcMain.handle("get-initial-tree-data", async (event, arg) => {
+  ipcMain.handle("get-initial-tree-data", async () => {
     return db.data[0];
   });
   // on get-tree-data.
@@ -104,7 +104,7 @@ app.on("ready", () => {
     try {
       db_meta.write();
 
-      // テーマが変更された場合、他のウィンドウにも通知
+      // 繝・・繝槭′螟画峩縺輔ｌ縺溷ｴ蜷医∽ｻ悶・繧ｦ繧｣繝ｳ繝峨え縺ｫ繧る夂衍
       if (key === "theme") {
         if (taskDetailWindow && !taskDetailWindow.isDestroyed()) {
           taskDetailWindow.webContents.send("theme-changed", value);
@@ -116,8 +116,8 @@ app.on("ready", () => {
   });
   // on delete-meta-data.
   // completely remove a key from meta data.
-  ipcMain.on("delete-meta-data", (event, key) => {
-    if (key && db_meta.data.hasOwnProperty(key)) {
+  ipcMain.on("delete-meta-data", (_event, key) => {
+    if (key && Object.prototype.hasOwnProperty.call(db_meta.data, key)) {
       delete db_meta.data[key];
       try {
         db_meta.write();
@@ -155,7 +155,7 @@ app.on("ready", () => {
   });
   // on get-project-ids.
   // return data to renderer.
-  ipcMain.handle("get-project-ids", async (event, arg) => {
+  ipcMain.handle("get-project-ids", async () => {
     return db.chain
       .map((o) => {
         return { name: o.data.data.name, id: o.data.id };
@@ -176,7 +176,7 @@ app.on("ready", () => {
   // on delete-project.
   ipcMain.on("delete-project", (event, arg) => {
     if (arg) {
-      db.data = db.data.filter((node, i) => node.data.id !== arg);
+      db.data = db.data.filter((node) => node.data.id !== arg);
       try {
         db.write();
       } catch (err) {
@@ -193,25 +193,23 @@ app.on("ready", () => {
   // on set-project-order.
   ipcMain.on("set-project-order", (event, projects) => {
     if (projects && Array.isArray(projects) && projects.length > 0) {
-      // 既存のプロジェクトデータをIDでインデックス化
       const projectMap = {};
       db.data.forEach((item) => {
         projectMap[item.data.id] = item;
       });
 
-      // 新しい順序でプロジェクトを並べ替え
       const newOrder = [];
       let hasChanges = false;
 
       projects.forEach((project) => {
         if (projectMap[project.id]) {
           newOrder.push(projectMap[project.id]);
-          delete projectMap[project.id]; // 処理済みのプロジェクトを削除
+          delete projectMap[project.id]; // 蜃ｦ逅・ｸ医∩縺ｮ繝励Ο繧ｸ繧ｧ繧ｯ繝医ｒ蜑企勁
           hasChanges = true;
         }
       });
 
-      // 残りのプロジェクト（配列に含まれていなかったプロジェクト）があれば追加
+      // 谿九ｊ縺ｮ繝励Ο繧ｸ繧ｧ繧ｯ繝茨ｼ磯・蛻励↓蜷ｫ縺ｾ繧後※縺・↑縺九▲縺溘・繝ｭ繧ｸ繧ｧ繧ｯ繝茨ｼ峨′縺ゅｌ縺ｰ霑ｽ蜉
       Object.values(projectMap).forEach((project) => {
         newOrder.push(project);
       });
@@ -230,16 +228,16 @@ app.on("ready", () => {
   ipcMain.on("message", (event, arg) => {
     log.info(arg);
   });
-  // 外部リンクを開くためのハンドラ
+  // 螟夜Κ繝ｪ繝ｳ繧ｯ繧帝幕縺上◆繧√・繝上Φ繝峨Λ
   ipcMain.on("open-external-link", (event, url) => {
     if (url && typeof url === "string") {
       shell.openExternal(url).catch((err) => {
-        log.error("外部リンクを開く際にエラーが発生しました:", err);
+        log.error("Failed to open external link:", err);
       });
     }
   });
 
-  // タスク詳細ウィンドウの変数
+  // 繧ｿ繧ｹ繧ｯ隧ｳ邏ｰ繧ｦ繧｣繝ｳ繝峨え縺ｮ螟画焚
   let taskDetailWindow = null;
 
   function bindFindInPageEvents(targetWebContents) {
@@ -253,7 +251,7 @@ app.on("ready", () => {
     return event?.sender || mainWindow.webContents;
   }
 
-  // 検索ハイライトをリセット
+  // 讀懃ｴ｢繝上う繝ｩ繧､繝医ｒ繝ｪ繧ｻ繝・ヨ
   async function resetHighlights(targetWebContents, notifyResult = false) {
     log.info("Reset HighLights");
     targetWebContents.stopFindInPage("clearSelection");
@@ -273,26 +271,23 @@ app.on("ready", () => {
     log.info("Execute Search:", text);
     const targetWebContents = resolveSearchWebContents(event);
 
-    // 空の検索テキストの場合は検索をクリア
+    // 遨ｺ縺ｮ讀懃ｴ｢繝・く繧ｹ繝医・蝣ｴ蜷医・讀懃ｴ｢繧偵け繝ｪ繧｢
     if (!text || !text.trim()) {
       await resetHighlights(targetWebContents, true);
       return { matches: 0, activeMatchOrdinal: 0 };
     }
 
     try {
-      // 前回の検索をクリア (通知なし)
+      // 蜑榊屓縺ｮ讀懃ｴ｢繧偵け繝ｪ繧｢ (騾夂衍縺ｪ縺・
       await resetHighlights(targetWebContents, false);
 
-      // 少し待機
       await new Promise((resolve) => setTimeout(resolve, 200));
 
-      // 検索実行
       log.info("Execute findInPage():", text, options);
       targetWebContents.findInPage(text.trim(), {
         ...options,
-        findNext: false, // 新規検索
+        findNext: false, // 譁ｰ隕乗､懃ｴ｢
       });
-      // 検索実行（次へ）　※ 新規検索時は一度次へを実行しないと更新されない
       targetWebContents.findInPage(text.trim(), {
         findNext: true,
         forward: true,
@@ -300,23 +295,21 @@ app.on("ready", () => {
 
       return;
     } catch (error) {
-      log.error("検索エラー:", error);
+      log.error("Search error:", error);
       return;
     }
   });
 
-  // 次の検索
+  // 谺｡縺ｮ讀懃ｴ｢
   ipcMain.handle("find-in-page-next", async (event, text = "") => {
     log.info("Search next");
     const targetWebContents = resolveSearchWebContents(event);
 
-    // 検索テキストを決定
     if (!text || !text.trim()) {
       return;
     }
 
     try {
-      // 次の検索を実行
       targetWebContents.findInPage(text.trim(), {
         findNext: true,
         forward: true,
@@ -324,23 +317,21 @@ app.on("ready", () => {
 
       return;
     } catch (error) {
-      log.error("次の検索エラー:", error);
+      log.error("谺｡縺ｮSearch error:", error);
       return;
     }
   });
 
-  // 前の検索
+  // 蜑阪・讀懃ｴ｢
   ipcMain.handle("find-in-page-previous", async (event, text = "") => {
     log.info("Search Previous");
     const targetWebContents = resolveSearchWebContents(event);
 
-    // 検索テキストを決定
     if (!text || !text.trim()) {
       return { matches: 0, activeMatchOrdinal: 0 };
     }
 
     try {
-      // 前の検索を実行
       targetWebContents.findInPage(text.trim(), {
         findNext: true,
         forward: false,
@@ -348,12 +339,12 @@ app.on("ready", () => {
 
       return;
     } catch (error) {
-      log.error("前の検索エラー:", error);
+      log.error("蜑阪・Search error:", error);
       return;
     }
   });
 
-  // 検索のクリア
+  // 讀懃ｴ｢縺ｮ繧ｯ繝ｪ繧｢
   ipcMain.on("stop-find-in-page", async (event) => {
     log.info("Execute stopFindInPage()");
     const targetWebContents = resolveSearchWebContents(event);
@@ -361,11 +352,11 @@ app.on("ready", () => {
     try {
       await resetHighlights(targetWebContents, true);
     } catch (error) {
-      log.error("検索クリアエラー:", error);
+      log.error("Search reset error:", error);
     }
   });
 
-  // タスク詳細用のウィンドウを作成する関数
+  // 繧ｿ繧ｹ繧ｯ隧ｳ邏ｰ逕ｨ縺ｮ繧ｦ繧｣繝ｳ繝峨え繧剃ｽ懈・縺吶ｋ髢｢謨ｰ
   function createTaskDetailWindow(detailData) {
     try {
       const safeDetailData = {
@@ -421,7 +412,7 @@ app.on("ready", () => {
       log.info(`Task detail window created for task: ${safeDetailData.taskId}`);
       return taskDetailWindow;
     } catch (error) {
-      log.error("タスク詳細ウィンドウの作成に失敗しました:", error);
+      log.error("Failed to create task detail window:", error);
       return null;
     }
   }
@@ -436,8 +427,7 @@ app.on("ready", () => {
     );
   });
 
-  // 別ウィンドウでタスク詳細を開く
-  ipcMain.on("open-task-detail-window", async (event, detailData) => {
+  ipcMain.on("open-task-detail-window", async (_event, detailData) => {
     try {
       global.currentTaskDetailWindowData = detailData;
       const window = createTaskDetailWindow(detailData);
@@ -450,7 +440,7 @@ app.on("ready", () => {
         log.info(`Task detail window shown for task: ${detailData?.taskId || ""}`);
       }
     } catch (error) {
-      log.error("タスク詳細ウィンドウを開く際にエラーが発生しました:", error);
+      log.error("Failed to open task detail window:", error);
     }
   });
 
@@ -469,13 +459,12 @@ app.on("ready", () => {
     }
   });
 
-  // 検索ウィンドウからテーマ情報を要求された場合
-  ipcMain.handle("get-current-theme", async (event) => {
+  ipcMain.handle("get-current-theme", async () => {
     return db_meta.data.theme || "dark";
   });
 
   ////////////// Workspace IPC //////////////
-  // projectDir → { tasks: Map, taskDirs: Map } のインメモリキャッシュ
+  // projectDir 竊・{ tasks: Map, taskDirs: Map } 縺ｮ繧､繝ｳ繝｡繝｢繝ｪ繧ｭ繝｣繝・す繝･
   const wsCache = new Map();
 
   ipcMain.handle("ws:get-workspaces", async () => {
@@ -508,7 +497,7 @@ app.on("ready", () => {
     try {
       const { tasks, taskDirs } = workspace.readProject(projectDir);
       wsCache.set(projectDir, { tasks, taskDirs });
-      // Map → plain object for IPC serialisation
+      // Map 竊・plain object for IPC serialisation
       return { tasks: Object.fromEntries(tasks) };
     } catch (err) {
       log.error("ws:read-project error:", err.message);
@@ -532,7 +521,7 @@ app.on("ready", () => {
         const tasksWithUpdate = new Map(tasks);
         tasksWithUpdate.set(task.id, task);
         if (workspace.wouldCreateCycle(tasksWithUpdate, task.id, task.parents)) {
-          return { success: false, error: "循環が発生するため保存できません" };
+          return { success: false, error: "Cannot save because this would create a cycle" };
         }
       }
 
@@ -544,6 +533,32 @@ app.on("ready", () => {
       return { success: false, error: err.message };
     }
   });
+
+  ipcMain.handle(
+    "ws:save-memo-image",
+    async (event, { projectDir, taskId, bytes, mimeType = "image/png" }) => {
+      try {
+        let cached = wsCache.get(projectDir);
+        if (!cached) {
+          const { tasks, taskDirs } = workspace.readProject(projectDir);
+          cached = { tasks, taskDirs };
+          wsCache.set(projectDir, cached);
+        }
+
+        const result = workspace.saveMemoImage(
+          projectDir,
+          cached.taskDirs,
+          taskId,
+          bytes,
+          mimeType
+        );
+        return { success: true, path: result.relativePath };
+      } catch (err) {
+        log.error("ws:save-memo-image error:", err.message);
+        return { success: false, error: err.message };
+      }
+    }
+  );
 
   ipcMain.handle("ws:delete-task", async (event, { projectDir, taskId }) => {
     try {
@@ -560,7 +575,7 @@ app.on("ready", () => {
         (t) => t.parents.length === 1 && t.parents[0] === taskId
       );
       if (wouldOrphan) {
-        return { success: false, error: "子タスクが孤立するため削除できません" };
+        return { success: false, error: "Cannot delete because this would orphan child tasks" };
       }
 
       workspace.deleteTaskDir(projectDir, taskDirs, taskId);
@@ -575,7 +590,7 @@ app.on("ready", () => {
   ipcMain.handle("ws:select-directory", async () => {
     const result = await dialog.showOpenDialog({
       properties: ["openDirectory"],
-      title: "ワークスペースフォルダを選択",
+      title: "Select workspace folder",
     });
     return result.canceled ? null : (result.filePaths[0] ?? null);
   });

--- a/electron/preload.js
+++ b/electron/preload.js
@@ -81,6 +81,8 @@ const electronAPI = {
   wsListProjects: (workspacePath) => ipcRenderer.invoke("ws:list-projects", { workspacePath }),
   wsReadProject: (projectDir) => ipcRenderer.invoke("ws:read-project", { projectDir }),
   wsWriteTask: (projectDir, task) => ipcRenderer.invoke("ws:write-task", { projectDir, task }),
+  wsSaveMemoImage: (projectDir, taskId, bytes, mimeType) =>
+    ipcRenderer.invoke("ws:save-memo-image", { projectDir, taskId, bytes, mimeType }),
   wsDeleteTask: (projectDir, taskId) =>
     ipcRenderer.invoke("ws:delete-task", { projectDir, taskId }),
   wsCreateProject: (workspacePath, name, id) =>

--- a/electron/workspace.js
+++ b/electron/workspace.js
@@ -8,7 +8,9 @@ function slugify(name) {
     String(name)
       .trim()
       .toLowerCase()
-      .replace(/[/\\:*?"<>|\x00]/g, "")
+      .replace(/[/\\:*?"<>|]/g, "")
+      .split("\0")
+      .join("")
       .replace(/\s+/g, "-")
       .replace(/^-+|-+$/g, "")
       .slice(0, 64) || "task"
@@ -21,6 +23,25 @@ function uniqueName(parentDir, baseName) {
   let i = 2;
   while (fs.existsSync(path.join(parentDir, `${baseName}-${i}`))) i++;
   return `${baseName}-${i}`;
+}
+
+function extensionFromMimeType(mimeType) {
+  switch (String(mimeType || "").toLowerCase()) {
+    case "image/png":
+      return "png";
+    case "image/jpeg":
+      return "jpg";
+    case "image/gif":
+      return "gif";
+    case "image/webp":
+      return "webp";
+    case "image/bmp":
+      return "bmp";
+    case "image/svg+xml":
+      return "svg";
+    default:
+      return "png";
+  }
 }
 
 /**
@@ -37,7 +58,7 @@ function parseFrontmatter(content) {
   let currentKey = null;
 
   for (const line of yaml.split(/\r?\n/)) {
-    const listMatch = line.match(/^  - (.+)/);
+    const listMatch = line.match(/^ {2}- (.+)/);
     if (listMatch && currentKey) {
       if (!Array.isArray(data[currentKey])) data[currentKey] = [];
       data[currentKey].push(listMatch[1].trim());
@@ -149,7 +170,7 @@ function readProject(projectDir) {
         tasks.set(task.id, task);
         taskDirs.set(task.id, entry.name);
       }
-    } catch (_) {
+    } catch {
       // Skip malformed task directories
     }
   }
@@ -200,6 +221,30 @@ function writeTask(projectDir, task, taskDirs) {
   }
 }
 
+function saveMemoImage(projectDir, taskDirs, taskId, bytes, mimeType) {
+  const dirName = taskDirs.get(taskId);
+  if (!dirName) {
+    throw new Error("Task directory was not found");
+  }
+
+  const targetDir = dirName === "_project" ? projectDir : path.join(projectDir, dirName);
+  const assetsDir = path.join(targetDir, "assets");
+  fs.mkdirSync(assetsDir, { recursive: true });
+
+  const extension = extensionFromMimeType(mimeType);
+  const fileName = `pasted-${Date.now()}-${crypto.randomUUID().slice(0, 8)}.${extension}`;
+  const assetPath = path.join(assetsDir, fileName);
+  const buffer = Buffer.isBuffer(bytes) ? bytes : Buffer.from(bytes);
+
+  fs.writeFileSync(assetPath, buffer);
+
+  return {
+    fileName,
+    relativePath: `./assets/${fileName}`,
+    assetPath,
+  };
+}
+
 /**
  * Delete a task's directory (and its files).
  * The root task (_project) cannot be deleted here.
@@ -246,7 +291,9 @@ function listProjects(workspacePath) {
         dirName: entry.name,
         projectDir: path.join(workspacePath, entry.name),
       });
-    } catch (_) {}
+    } catch {
+      // Ignore malformed project entries
+    }
   }
   return projects;
 }
@@ -270,7 +317,7 @@ function wouldCreateCycle(tasks, taskId, newParents) {
     }
   }
 
-  // BFS from taskId following children. If any newParent is reachable → cycle.
+  // BFS from taskId following children. If any newParent is reachable, a cycle exists.
   const visited = new Set();
   const queue = [taskId];
   while (queue.length > 0) {
@@ -329,7 +376,7 @@ function migrateProjectData(workspacePath, projectData) {
       if (typeof m.content === "string") {
         content = m.content;
       } else if (m.content !== null && m.content !== undefined) {
-        // Quill Delta or other object → preserve as JSON fenced block
+        // Preserve legacy Quill Delta objects as JSON fenced blocks.
         content = `# ${m.title || "Memo"}\n\n\`\`\`json\n${JSON.stringify(m.content, null, 2)}\n\`\`\``;
       }
       return { id: crypto.randomUUID(), title: String(m.title || "Memo"), content };
@@ -372,6 +419,7 @@ module.exports = {
   stringifyFrontmatter,
   readProject,
   writeTask,
+  saveMemoImage,
   deleteTaskDir,
   createProject,
   listProjects,

--- a/src/components/Memo.svelte
+++ b/src/components/Memo.svelte
@@ -14,6 +14,8 @@
   export let readOnly = false;
   export let memoTitles: string[] = [];
   export let openMemoLink: ((title: string) => void) | undefined = undefined;
+  export let workspaceProjectDir: string | null = null;
+  export let taskId: string | null = null;
 
   let container: HTMLElement;
   let view: EditorView | null = null;
@@ -79,6 +81,46 @@
     currentContent = nextContent;
     saveMemo(currentContent);
     hasChanges = false;
+  }
+
+  function canSavePastedImages(): boolean {
+    return Boolean(workspaceProjectDir && taskId && window.electronAPI?.wsSaveMemoImage);
+  }
+
+  async function persistPastedImage(file: File): Promise<string | null> {
+    if (!workspaceProjectDir || !taskId || !window.electronAPI?.wsSaveMemoImage) {
+      return null;
+    }
+
+    const bytes = new Uint8Array(await file.arrayBuffer());
+    const result = await window.electronAPI.wsSaveMemoImage(
+      workspaceProjectDir,
+      taskId,
+      bytes,
+      file.type || "image/png"
+    );
+
+    return result.success ? (result.path ?? null) : null;
+  }
+
+  function buildImageMarkdown(relativePath: string, label = ""): string {
+    const alt = label.replace(/\.[^.]+$/, "").trim();
+    return alt ? `![${alt}](${relativePath})` : `![](${relativePath})`;
+  }
+
+  function insertTextAtSelection(editorView: EditorView, text: string) {
+    const range = editorView.state.selection.main;
+    editorView.dispatch({
+      changes: {
+        from: range.from,
+        to: range.to,
+        insert: text,
+      },
+      selection: {
+        anchor: range.from + text.length,
+      },
+      scrollIntoView: true,
+    });
   }
 
   const editorTheme = EditorView.theme({
@@ -148,6 +190,39 @@
       keymap.of(historyKeymap),
       EditorView.lineWrapping,
       history(),
+      EditorView.domEventHandlers({
+        paste(event, editorView) {
+          const imageItem = Array.from(event.clipboardData?.items ?? []).find((item) =>
+            item.type.startsWith("image/")
+          );
+
+          if (!imageItem || !canSavePastedImages()) {
+            return false;
+          }
+
+          const file = imageItem.getAsFile();
+          if (!file) {
+            return false;
+          }
+
+          event.preventDefault();
+          void (async () => {
+            const savedPath = await persistPastedImage(file);
+            if (!savedPath) {
+              return;
+            }
+
+            const prefix = editorView.state.doc.length === 0 ? "" : "\n";
+            const suffix = "\n";
+            insertTextAtSelection(
+              editorView,
+              `${prefix}${buildImageMarkdown(savedPath, file.name || "Pasted image")}${suffix}`
+            );
+          })();
+
+          return true;
+        },
+      }),
       EditorView.updateListener.of((update) => {
         if (update.docChanged) {
           hasChanges = true;

--- a/src/components/MemoTab.svelte
+++ b/src/components/MemoTab.svelte
@@ -24,6 +24,8 @@
   export let deleteMemo;
   export let renameMemo;
   export let disabled = false;
+  export let workspaceProjectDir = null;
+  export let taskId = null;
 
   let selectedMemoIndex = 0;
   let previousTaskId;
@@ -192,6 +194,8 @@
           content={editedContent}
           memoTitles={memo.map((entry) => entry.title)}
           openMemoLink={selectMemoByTitle}
+          {workspaceProjectDir}
+          {taskId}
         />
       {/key}
     {:else}

--- a/src/components/TaskDetail.svelte
+++ b/src/components/TaskDetail.svelte
@@ -1,7 +1,13 @@
 <script>
   import { getNode, updateNodeDataById } from "../common/tree_control.ts";
   import { uuidV4 } from "../common/uuid";
-  import { tree_data, table_selected_id, cancelPendingOperations } from "../stores.ts";
+  import {
+    tree_data,
+    table_selected_id,
+    cancelPendingOperations,
+    selected_type,
+    workspace_store,
+  } from "../stores.ts";
   import { debounce } from "lodash";
   import { onDestroy } from "svelte";
   import MemoTab from "./MemoTab.svelte";
@@ -11,6 +17,8 @@
     $table_selected_id && $tree_data ? getNode($table_selected_id, $tree_data.data) : undefined;
   $: name = node ? node.data["name"] : "Select Task";
   $: memo = node ? node.data["memo"] : [];
+  $: workspaceProjectDir =
+    $selected_type === "WorkspaceProject" ? $workspace_store.activeProjectDir : null;
   const changeData = (node, key, value) => {
     if (!node) {
       return;
@@ -68,7 +76,15 @@
 <div class="container">
   <div class="memotab-container">
     {#if is_selected}
-      <MemoTab {memo} {saveMemo} {addMemo} {deleteMemo} {renameMemo} />
+      <MemoTab
+        {memo}
+        {saveMemo}
+        {addMemo}
+        {deleteMemo}
+        {renameMemo}
+        {workspaceProjectDir}
+        taskId={$table_selected_id ?? null}
+      />
     {:else}
       <h1 style="color:var(--theme-color-Sub-main); display:flex; justify-content:center">
         No data.

--- a/src/types/app.ts
+++ b/src/types/app.ts
@@ -64,6 +64,12 @@ export interface ElectronAPI {
     projectDir: string,
     task: WorkspaceTask
   ) => Promise<{ success: boolean; error?: string }>;
+  wsSaveMemoImage: (
+    projectDir: string,
+    taskId: string,
+    bytes: Uint8Array,
+    mimeType?: string
+  ) => Promise<{ success: boolean; path?: string; error?: string }>;
   wsDeleteTask: (
     projectDir: string,
     taskId: string

--- a/tests/component/Memo.test.js
+++ b/tests/component/Memo.test.js
@@ -61,6 +61,11 @@ describe("Memo - edit mode", () => {
 
   beforeEach(() => {
     saveMemo = vi.fn();
+    window.electronAPI = { wsSaveMemoImage: vi.fn() };
+  });
+
+  afterEach(() => {
+    delete window.electronAPI;
   });
 
   test("clicking preview enters edit mode and shows CM6 editor", async () => {
@@ -115,6 +120,61 @@ describe("Memo - edit mode", () => {
     await tick();
 
     expect(saveMemo).not.toHaveBeenCalled();
+  });
+
+  test("pasting an image in workspace mode saves it and inserts markdown", async () => {
+    window.electronAPI.wsSaveMemoImage.mockResolvedValue({
+      success: true,
+      path: "./assets/pasted-image.png",
+    });
+    const originalGetClientRects = Range.prototype.getClientRects;
+    Range.prototype.getClientRects = () => [];
+
+    render(Memo, {
+      props: {
+        saveMemo,
+        content: "",
+        workspaceProjectDir: "C:\\project",
+        taskId: "task-1",
+      },
+    });
+
+    await fireEvent.click(document.querySelector(".preview-mode"));
+    await waitFor(() => {
+      expect(document.querySelector(".cm-editor")).toBeInTheDocument();
+    });
+
+    const file = new File(["image-bytes"], "pasted-image.png", { type: "image/png" });
+    const pasteEvent = new Event("paste", { bubbles: true, cancelable: true });
+    Object.defineProperty(pasteEvent, "clipboardData", {
+      value: {
+        items: [
+          {
+            type: "image/png",
+            getAsFile: () => file,
+          },
+        ],
+      },
+    });
+
+    document.querySelector(".cm-content").dispatchEvent(pasteEvent);
+
+    await waitFor(() => {
+      expect(window.electronAPI.wsSaveMemoImage).toHaveBeenCalledWith(
+        "C:\\project",
+        "task-1",
+        expect.any(Uint8Array),
+        "image/png"
+      );
+    });
+
+    await waitFor(() => {
+      expect(document.querySelector(".cm-content").textContent).toContain(
+        "![pasted-image](./assets/pasted-image.png)"
+      );
+    });
+
+    Range.prototype.getClientRects = originalGetClientRects;
   });
 });
 

--- a/tests/unit/workspace.test.js
+++ b/tests/unit/workspace.test.js
@@ -11,6 +11,7 @@ import {
   createProject,
   readProject,
   writeTask,
+  saveMemoImage,
   deleteTaskDir,
   listProjects,
   migrateProjectData,
@@ -306,6 +307,32 @@ describe("file system operations", () => {
     deleteTaskDir(projectDir, taskDirs, "task-del");
     expect(fs.existsSync(path.join(projectDir, dirName))).toBe(false);
     expect(taskDirs.has("task-del")).toBe(false);
+  });
+
+  it("saveMemoImage writes pasted images into task assets and returns a relative path", () => {
+    const { projectDir } = createProject(tmpDir, "Proj", "root-id");
+    const taskDirs = new Map([["root-id", "_project"]]);
+    const task = {
+      id: "task-assets",
+      name: "Assets",
+      status: "Open",
+      parents: ["root-id"],
+      memos: [],
+      createdAt: "2026-04-24",
+    };
+    writeTask(projectDir, task, taskDirs);
+
+    const result = saveMemoImage(
+      projectDir,
+      taskDirs,
+      "task-assets",
+      Uint8Array.from([137, 80, 78, 71]),
+      "image/png"
+    );
+
+    expect(result.relativePath).toMatch(/^\.\/assets\/pasted-.+\.png$/);
+    expect(fs.existsSync(result.assetPath)).toBe(true);
+    expect(path.dirname(result.assetPath)).toBe(path.join(projectDir, "task-assets", "assets"));
   });
 });
 


### PR DESCRIPTION
## Summary

Closes #75

- workspace モードの Markdown メモで、クリップボード画像の貼り付けを受け取れるようにしました
- 貼り付けた画像を task 配下の `assets/` に保存し、本文へ相対パスの Markdown 画像記法を挿入するようにしました
- Electron preload / workspace IPC を追加して、renderer から画像保存を呼べるようにしました
- `workspace` の unit test と `Memo` の component test を追加して、保存先と貼り付け動線をカバーしました

## Why

Issue #59 の task 配下ファイル構成を前提にしつつ、Markdown メモで画像を貼り付けられない問題を解消するためです。Obsidian ライクなメモ体験に近づけるうえで、まずは `assets/` 保存規約と clipboard paste の導線を先に整えています。

## Validation

手元で以下を実行して通過を確認しました。

- `svelte-check --tsconfig ./tsconfig.json`
- `eslint electron/index.js electron/preload.js electron/workspace.js src/components/Memo.svelte src/components/MemoTab.svelte src/components/TaskDetail.svelte src/types/app.ts tests/component/Memo.test.js tests/unit/workspace.test.js`
- `prettier --check electron/index.js electron/preload.js electron/workspace.js src/components/Memo.svelte src/components/MemoTab.svelte src/components/TaskDetail.svelte src/types/app.ts tests/component/Memo.test.js tests/unit/workspace.test.js`
- `vitest run tests/unit/workspace.test.js tests/component/Memo.test.js`

結果:
- 2 test files passed
- 50 tests passed