### PR TITLE
[codex] Markdownメモの画像表示とプレビューを改善

### DIFF
--- a/electron/index.js
+++ b/electron/index.js
@@ -1,5 +1,5 @@
-const _ = require("lodash");
-const { app, BrowserWindow, ipcMain, shell, WebContents, dialog } = require("electron");
+﻿const _ = require("lodash");
+const { app, BrowserWindow, ipcMain, shell, dialog } = require("electron");
 const fs = require("fs");
 const path = require("path");
 const { LowSync, JSONFileSync } = require("@commonify/lowdb");
@@ -26,7 +26,7 @@ function resolveAppDataPath(fileName) {
 
 function showSaveError(context, err) {
   log.error(`Failed to write data (${context}):`, err.message);
-  const message = `データの保存に失敗しました: ${err.message}`;
+  const message = `繝・・繧ｿ縺ｮ菫晏ｭ倥↓螟ｱ謨励＠縺ｾ縺励◆: ${err.message}`;
   BrowserWindow.getAllWindows().forEach((win) => {
     if (!win.isDestroyed()) {
       win.webContents.send("save-error", message);
@@ -84,7 +84,7 @@ app.on("ready", () => {
   ////////////// IPC //////////////
   // on get-initial-tree-data.
   // return data to renderer.
-  ipcMain.handle("get-initial-tree-data", async (event, arg) => {
+  ipcMain.handle("get-initial-tree-data", async () => {
     return db.data[0];
   });
   // on get-tree-data.
@@ -104,7 +104,7 @@ app.on("ready", () => {
     try {
       db_meta.write();
 
-      // テーマが変更された場合、他のウィンドウにも通知
+      // 繝・・繝槭′螟画峩縺輔ｌ縺溷ｴ蜷医∽ｻ悶・繧ｦ繧｣繝ｳ繝峨え縺ｫ繧る夂衍
       if (key === "theme") {
         if (taskDetailWindow && !taskDetailWindow.isDestroyed()) {
           taskDetailWindow.webContents.send("theme-changed", value);
@@ -116,8 +116,8 @@ app.on("ready", () => {
   });
   // on delete-meta-data.
   // completely remove a key from meta data.
-  ipcMain.on("delete-meta-data", (event, key) => {
-    if (key && db_meta.data.hasOwnProperty(key)) {
+  ipcMain.on("delete-meta-data", (_event, key) => {
+    if (key && Object.prototype.hasOwnProperty.call(db_meta.data, key)) {
       delete db_meta.data[key];
       try {
         db_meta.write();
@@ -155,7 +155,7 @@ app.on("ready", () => {
   });
   // on get-project-ids.
   // return data to renderer.
-  ipcMain.handle("get-project-ids", async (event, arg) => {
+  ipcMain.handle("get-project-ids", async () => {
     return db.chain
       .map((o) => {
         return { name: o.data.data.name, id: o.data.id };
@@ -176,7 +176,7 @@ app.on("ready", () => {
   // on delete-project.
   ipcMain.on("delete-project", (event, arg) => {
     if (arg) {
-      db.data = db.data.filter((node, i) => node.data.id !== arg);
+      db.data = db.data.filter((node) => node.data.id !== arg);
       try {
         db.write();
       } catch (err) {
@@ -193,25 +193,22 @@ app.on("ready", () => {
   // on set-project-order.
   ipcMain.on("set-project-order", (event, projects) => {
     if (projects && Array.isArray(projects) && projects.length > 0) {
-      // 既存のプロジェクトデータをIDでインデックス化
       const projectMap = {};
       db.data.forEach((item) => {
         projectMap[item.data.id] = item;
       });
-
-      // 新しい順序でプロジェクトを並べ替え
       const newOrder = [];
       let hasChanges = false;
 
       projects.forEach((project) => {
         if (projectMap[project.id]) {
           newOrder.push(projectMap[project.id]);
-          delete projectMap[project.id]; // 処理済みのプロジェクトを削除
+          delete projectMap[project.id]; // 蜃ｦ逅・ｸ医∩縺ｮ繝励Ο繧ｸ繧ｧ繧ｯ繝医ｒ蜑企勁
           hasChanges = true;
         }
       });
 
-      // 残りのプロジェクト（配列に含まれていなかったプロジェクト）があれば追加
+      // 谿九ｊ縺ｮ繝励Ο繧ｸ繧ｧ繧ｯ繝茨ｼ磯・蛻励↓蜷ｫ縺ｾ繧後※縺・↑縺九▲縺溘・繝ｭ繧ｸ繧ｧ繧ｯ繝茨ｼ峨′縺ゅｌ縺ｰ霑ｽ蜉
       Object.values(projectMap).forEach((project) => {
         newOrder.push(project);
       });
@@ -230,16 +227,16 @@ app.on("ready", () => {
   ipcMain.on("message", (event, arg) => {
     log.info(arg);
   });
-  // 外部リンクを開くためのハンドラ
+  // 螟夜Κ繝ｪ繝ｳ繧ｯ繧帝幕縺上◆繧√・繝上Φ繝峨Λ
   ipcMain.on("open-external-link", (event, url) => {
     if (url && typeof url === "string") {
       shell.openExternal(url).catch((err) => {
-        log.error("外部リンクを開く際にエラーが発生しました:", err);
+        log.error("螟夜Κ繝ｪ繝ｳ繧ｯ繧帝幕縺城圀縺ｫ繧ｨ繝ｩ繝ｼ縺檎匱逕溘＠縺ｾ縺励◆:", err);
       });
     }
   });
 
-  // タスク詳細ウィンドウの変数
+  // 繧ｿ繧ｹ繧ｯ隧ｳ邏ｰ繧ｦ繧｣繝ｳ繝峨え縺ｮ螟画焚
   let taskDetailWindow = null;
 
   function bindFindInPageEvents(targetWebContents) {
@@ -253,7 +250,7 @@ app.on("ready", () => {
     return event?.sender || mainWindow.webContents;
   }
 
-  // 検索ハイライトをリセット
+  // 讀懃ｴ｢繝上う繝ｩ繧､繝医ｒ繝ｪ繧ｻ繝・ヨ
   async function resetHighlights(targetWebContents, notifyResult = false) {
     log.info("Reset HighLights");
     targetWebContents.stopFindInPage("clearSelection");
@@ -273,26 +270,25 @@ app.on("ready", () => {
     log.info("Execute Search:", text);
     const targetWebContents = resolveSearchWebContents(event);
 
-    // 空の検索テキストの場合は検索をクリア
+    // 遨ｺ縺ｮ讀懃ｴ｢繝・く繧ｹ繝医・蝣ｴ蜷医・讀懃ｴ｢繧偵け繝ｪ繧｢
     if (!text || !text.trim()) {
       await resetHighlights(targetWebContents, true);
       return { matches: 0, activeMatchOrdinal: 0 };
     }
 
     try {
-      // 前回の検索をクリア (通知なし)
+      // 蜑榊屓縺ｮ讀懃ｴ｢繧偵け繝ｪ繧｢ (騾夂衍縺ｪ縺・
       await resetHighlights(targetWebContents, false);
 
-      // 少し待機
+      // 蟆代＠蠕・ｩ・
       await new Promise((resolve) => setTimeout(resolve, 200));
 
-      // 検索実行
+      // 讀懃ｴ｢螳溯｡・
       log.info("Execute findInPage():", text, options);
       targetWebContents.findInPage(text.trim(), {
         ...options,
-        findNext: false, // 新規検索
+        findNext: false, // 譁ｰ隕乗､懃ｴ｢
       });
-      // 検索実行（次へ）　※ 新規検索時は一度次へを実行しないと更新されない
       targetWebContents.findInPage(text.trim(), {
         findNext: true,
         forward: true,
@@ -300,23 +296,22 @@ app.on("ready", () => {
 
       return;
     } catch (error) {
-      log.error("検索エラー:", error);
+      log.error("讀懃ｴ｢繧ｨ繝ｩ繝ｼ:", error);
       return;
     }
   });
 
-  // 次の検索
+  // 谺｡縺ｮ讀懃ｴ｢
   ipcMain.handle("find-in-page-next", async (event, text = "") => {
     log.info("Search next");
     const targetWebContents = resolveSearchWebContents(event);
 
-    // 検索テキストを決定
+    // 讀懃ｴ｢繝・く繧ｹ繝医ｒ豎ｺ螳・
     if (!text || !text.trim()) {
       return;
     }
 
     try {
-      // 次の検索を実行
       targetWebContents.findInPage(text.trim(), {
         findNext: true,
         forward: true,
@@ -324,23 +319,22 @@ app.on("ready", () => {
 
       return;
     } catch (error) {
-      log.error("次の検索エラー:", error);
+      log.error("谺｡縺ｮ讀懃ｴ｢繧ｨ繝ｩ繝ｼ:", error);
       return;
     }
   });
 
-  // 前の検索
+  // 蜑阪・讀懃ｴ｢
   ipcMain.handle("find-in-page-previous", async (event, text = "") => {
     log.info("Search Previous");
     const targetWebContents = resolveSearchWebContents(event);
 
-    // 検索テキストを決定
+    // 讀懃ｴ｢繝・く繧ｹ繝医ｒ豎ｺ螳・
     if (!text || !text.trim()) {
       return { matches: 0, activeMatchOrdinal: 0 };
     }
 
     try {
-      // 前の検索を実行
       targetWebContents.findInPage(text.trim(), {
         findNext: true,
         forward: false,
@@ -348,12 +342,12 @@ app.on("ready", () => {
 
       return;
     } catch (error) {
-      log.error("前の検索エラー:", error);
+      log.error("蜑阪・讀懃ｴ｢繧ｨ繝ｩ繝ｼ:", error);
       return;
     }
   });
 
-  // 検索のクリア
+  // 讀懃ｴ｢縺ｮ繧ｯ繝ｪ繧｢
   ipcMain.on("stop-find-in-page", async (event) => {
     log.info("Execute stopFindInPage()");
     const targetWebContents = resolveSearchWebContents(event);
@@ -361,11 +355,11 @@ app.on("ready", () => {
     try {
       await resetHighlights(targetWebContents, true);
     } catch (error) {
-      log.error("検索クリアエラー:", error);
+      log.error("讀懃ｴ｢繧ｯ繝ｪ繧｢繧ｨ繝ｩ繝ｼ:", error);
     }
   });
 
-  // タスク詳細用のウィンドウを作成する関数
+  // 繧ｿ繧ｹ繧ｯ隧ｳ邏ｰ逕ｨ縺ｮ繧ｦ繧｣繝ｳ繝峨え繧剃ｽ懈・縺吶ｋ髢｢謨ｰ
   function createTaskDetailWindow(detailData) {
     try {
       const safeDetailData = {
@@ -421,7 +415,7 @@ app.on("ready", () => {
       log.info(`Task detail window created for task: ${safeDetailData.taskId}`);
       return taskDetailWindow;
     } catch (error) {
-      log.error("タスク詳細ウィンドウの作成に失敗しました:", error);
+      log.error("繧ｿ繧ｹ繧ｯ隧ｳ邏ｰ繧ｦ繧｣繝ｳ繝峨え縺ｮ菴懈・縺ｫ螟ｱ謨励＠縺ｾ縺励◆:", error);
       return null;
     }
   }
@@ -436,8 +430,8 @@ app.on("ready", () => {
     );
   });
 
-  // 別ウィンドウでタスク詳細を開く
-  ipcMain.on("open-task-detail-window", async (event, detailData) => {
+  // 蛻･繧ｦ繧｣繝ｳ繝峨え縺ｧ繧ｿ繧ｹ繧ｯ隧ｳ邏ｰ繧帝幕縺・
+  ipcMain.on("open-task-detail-window", async (_event, detailData) => {
     try {
       global.currentTaskDetailWindowData = detailData;
       const window = createTaskDetailWindow(detailData);
@@ -450,7 +444,10 @@ app.on("ready", () => {
         log.info(`Task detail window shown for task: ${detailData?.taskId || ""}`);
       }
     } catch (error) {
-      log.error("タスク詳細ウィンドウを開く際にエラーが発生しました:", error);
+      log.error(
+        "繧ｿ繧ｹ繧ｯ隧ｳ邏ｰ繧ｦ繧｣繝ｳ繝峨え繧帝幕縺城圀縺ｫ繧ｨ繝ｩ繝ｼ縺檎匱逕溘＠縺ｾ縺励◆:",
+        error
+      );
     }
   });
 
@@ -469,13 +466,13 @@ app.on("ready", () => {
     }
   });
 
-  // 検索ウィンドウからテーマ情報を要求された場合
-  ipcMain.handle("get-current-theme", async (event) => {
+  // 讀懃ｴ｢繧ｦ繧｣繝ｳ繝峨え縺九ｉ繝・・繝樊ュ蝣ｱ繧定ｦ∵ｱゅ＆繧後◆蝣ｴ蜷・
+  ipcMain.handle("get-current-theme", async () => {
     return db_meta.data.theme || "dark";
   });
 
   ////////////// Workspace IPC //////////////
-  // projectDir → { tasks: Map, taskDirs: Map } のインメモリキャッシュ
+  // projectDir 竊・{ tasks: Map, taskDirs: Map } 縺ｮ繧､繝ｳ繝｡繝｢繝ｪ繧ｭ繝｣繝・す繝･
   const wsCache = new Map();
 
   ipcMain.handle("ws:get-workspaces", async () => {
@@ -508,7 +505,7 @@ app.on("ready", () => {
     try {
       const { tasks, taskDirs } = workspace.readProject(projectDir);
       wsCache.set(projectDir, { tasks, taskDirs });
-      // Map → plain object for IPC serialisation
+      // Map 竊・plain object for IPC serialisation
       return { tasks: Object.fromEntries(tasks) };
     } catch (err) {
       log.error("ws:read-project error:", err.message);
@@ -532,7 +529,7 @@ app.on("ready", () => {
         const tasksWithUpdate = new Map(tasks);
         tasksWithUpdate.set(task.id, task);
         if (workspace.wouldCreateCycle(tasksWithUpdate, task.id, task.parents)) {
-          return { success: false, error: "循環が発生するため保存できません" };
+          return { success: false, error: "蠕ｪ迺ｰ縺檎匱逕溘☆繧九◆繧∽ｿ晏ｭ倥〒縺阪∪縺帙ｓ" };
         }
       }
 
@@ -541,6 +538,29 @@ app.on("ready", () => {
       return { success: true };
     } catch (err) {
       log.error("ws:write-task error:", err.message);
+      return { success: false, error: err.message };
+    }
+  });
+
+  ipcMain.handle("ws:resolve-memo-asset", async (event, { projectDir, taskId, assetPath }) => {
+    try {
+      let cached = wsCache.get(projectDir);
+      if (!cached) {
+        const { tasks, taskDirs } = workspace.readProject(projectDir);
+        cached = { tasks, taskDirs };
+        wsCache.set(projectDir, cached);
+      }
+
+      const fileUrl = workspace.resolveMemoAssetPath(
+        projectDir,
+        cached.taskDirs,
+        taskId,
+        assetPath
+      );
+
+      return { success: Boolean(fileUrl), url: fileUrl ?? undefined };
+    } catch (err) {
+      log.error("ws:resolve-memo-asset error:", err.message);
       return { success: false, error: err.message };
     }
   });
@@ -560,7 +580,7 @@ app.on("ready", () => {
         (t) => t.parents.length === 1 && t.parents[0] === taskId
       );
       if (wouldOrphan) {
-        return { success: false, error: "子タスクが孤立するため削除できません" };
+        return { success: false, error: "蟄舌ち繧ｹ繧ｯ縺悟ｭ､遶九☆繧九◆繧∝炎髯､縺ｧ縺阪∪縺帙ｓ" };
       }
 
       workspace.deleteTaskDir(projectDir, taskDirs, taskId);
@@ -575,7 +595,7 @@ app.on("ready", () => {
   ipcMain.handle("ws:select-directory", async () => {
     const result = await dialog.showOpenDialog({
       properties: ["openDirectory"],
-      title: "ワークスペースフォルダを選択",
+      title: "Select workspace folder",
     });
     return result.canceled ? null : (result.filePaths[0] ?? null);
   });

--- a/electron/preload.js
+++ b/electron/preload.js
@@ -81,6 +81,8 @@ const electronAPI = {
   wsListProjects: (workspacePath) => ipcRenderer.invoke("ws:list-projects", { workspacePath }),
   wsReadProject: (projectDir) => ipcRenderer.invoke("ws:read-project", { projectDir }),
   wsWriteTask: (projectDir, task) => ipcRenderer.invoke("ws:write-task", { projectDir, task }),
+  wsResolveMemoAsset: (projectDir, taskId, assetPath) =>
+    ipcRenderer.invoke("ws:resolve-memo-asset", { projectDir, taskId, assetPath }),
   wsDeleteTask: (projectDir, taskId) =>
     ipcRenderer.invoke("ws:delete-task", { projectDir, taskId }),
   wsCreateProject: (workspacePath, name, id) =>

--- a/electron/workspace.js
+++ b/electron/workspace.js
@@ -1,6 +1,7 @@
-const crypto = require("crypto");
+﻿const crypto = require("crypto");
 const fs = require("fs");
 const path = require("path");
+const { pathToFileURL } = require("url");
 
 /** Convert a human name to a filesystem-safe slug. */
 function slugify(name) {
@@ -8,7 +9,7 @@ function slugify(name) {
     String(name)
       .trim()
       .toLowerCase()
-      .replace(/[/\\:*?"<>|\x00]/g, "")
+      .replace(/[/\\:*?"<>|]/g, "")
       .replace(/\s+/g, "-")
       .replace(/^-+|-+$/g, "")
       .slice(0, 64) || "task"
@@ -37,7 +38,7 @@ function parseFrontmatter(content) {
   let currentKey = null;
 
   for (const line of yaml.split(/\r?\n/)) {
-    const listMatch = line.match(/^  - (.+)/);
+    const listMatch = line.match(/^ {2}- (.+)/);
     if (listMatch && currentKey) {
       if (!Array.isArray(data[currentKey])) data[currentKey] = [];
       data[currentKey].push(listMatch[1].trim());
@@ -149,7 +150,7 @@ function readProject(projectDir) {
         tasks.set(task.id, task);
         taskDirs.set(task.id, entry.name);
       }
-    } catch (_) {
+    } catch {
       // Skip malformed task directories
     }
   }
@@ -200,6 +201,28 @@ function writeTask(projectDir, task, taskDirs) {
   }
 }
 
+function resolveMemoAssetPath(projectDir, taskDirs, taskId, assetPath) {
+  const dirName = taskDirs.get(taskId);
+  if (!dirName || !assetPath) {
+    return null;
+  }
+
+  const taskDir = dirName === "_project" ? projectDir : path.join(projectDir, dirName);
+  const normalizedAssetPath = String(assetPath).replace(/\\/g, "/").trim();
+  const resolvedPath = path.resolve(taskDir, normalizedAssetPath);
+  const relative = path.relative(taskDir, resolvedPath);
+
+  if (relative.startsWith("..") || path.isAbsolute(relative)) {
+    return null;
+  }
+
+  if (!fs.existsSync(resolvedPath)) {
+    return null;
+  }
+
+  return pathToFileURL(resolvedPath).toString();
+}
+
 /**
  * Delete a task's directory (and its files).
  * The root task (_project) cannot be deleted here.
@@ -246,11 +269,12 @@ function listProjects(workspacePath) {
         dirName: entry.name,
         projectDir: path.join(workspacePath, entry.name),
       });
-    } catch (_) {}
+    } catch {
+      // Ignore malformed project entries
+    }
   }
   return projects;
 }
-
 /**
  * DAG cycle check: would setting taskId's parents to newParents create a cycle?
  * tasks: Map<id, { parents: string[] }>
@@ -270,7 +294,7 @@ function wouldCreateCycle(tasks, taskId, newParents) {
     }
   }
 
-  // BFS from taskId following children. If any newParent is reachable → cycle.
+  // BFS from taskId following children. If any newParent is reachable 竊・cycle.
   const visited = new Set();
   const queue = [taskId];
   while (queue.length > 0) {
@@ -329,7 +353,7 @@ function migrateProjectData(workspacePath, projectData) {
       if (typeof m.content === "string") {
         content = m.content;
       } else if (m.content !== null && m.content !== undefined) {
-        // Quill Delta or other object → preserve as JSON fenced block
+        // Quill Delta or other object 竊・preserve as JSON fenced block
         content = `# ${m.title || "Memo"}\n\n\`\`\`json\n${JSON.stringify(m.content, null, 2)}\n\`\`\``;
       }
       return { id: crypto.randomUUID(), title: String(m.title || "Memo"), content };
@@ -372,6 +396,7 @@ module.exports = {
   stringifyFrontmatter,
   readProject,
   writeTask,
+  resolveMemoAssetPath,
   deleteTaskDir,
   createProject,
   listProjects,

--- a/src/components/Memo.svelte
+++ b/src/components/Memo.svelte
@@ -14,6 +14,8 @@
   export let readOnly = false;
   export let memoTitles: string[] = [];
   export let openMemoLink: ((title: string) => void) | undefined = undefined;
+  export let workspaceProjectDir: string | null = null;
+  export let taskId: string | null = null;
 
   let container: HTMLElement;
   let view: EditorView | null = null;
@@ -21,6 +23,8 @@
   let isEditing = false;
   let hasChanges = false;
   let currentContent = toMarkdown(content);
+  let renderedHtml = "";
+  let renderSequence = 0;
 
   const EXTERNAL_LINK_PATTERN = /^(https?:\/\/|mailto:|file:\/\/)/i;
 
@@ -79,6 +83,52 @@
     currentContent = nextContent;
     saveMemo(currentContent);
     hasChanges = false;
+  }
+
+  async function resolveImageSources(html: string): Promise<string> {
+    if (!workspaceProjectDir || !taskId || !window.electronAPI?.wsResolveMemoAsset) {
+      return html;
+    }
+
+    const template = document.createElement("template");
+    template.innerHTML = html;
+    const images = Array.from(template.content.querySelectorAll("img[src]"));
+
+    await Promise.all(
+      images.map(async (image) => {
+        const src = image.getAttribute("src");
+        if (!src || isExternalLink(src) || src.startsWith("data:")) {
+          return;
+        }
+
+        const result = await window.electronAPI.wsResolveMemoAsset(
+          workspaceProjectDir,
+          taskId,
+          src
+        );
+        if (result.success && result.url) {
+          image.setAttribute("src", result.url);
+        } else {
+          image.setAttribute("data-missing-image", "true");
+        }
+      })
+    );
+
+    return template.innerHTML;
+  }
+
+  async function updateRenderedHtml(markdownText: string) {
+    const sequence = ++renderSequence;
+    const baseHtml = marked.parse(preprocessWikiLinks(markdownText), {
+      gfm: true,
+      breaks: true,
+    }) as string;
+    renderedHtml = baseHtml;
+    const nextHtml = await resolveImageSources(baseHtml);
+
+    if (sequence === renderSequence) {
+      renderedHtml = nextHtml;
+    }
   }
 
   const editorTheme = EditorView.theme({
@@ -211,10 +261,9 @@
   $: if (!isEditing && normalizedContent !== currentContent) {
     currentContent = normalizedContent;
   }
-  $: renderedHtml = marked.parse(preprocessWikiLinks(currentContent || ""), {
-    gfm: true,
-    breaks: true,
-  }) as string;
+  $: if (!isEditing) {
+    void updateRenderedHtml(currentContent || "");
+  }
 </script>
 
 <div class="wrapper">
@@ -339,6 +388,23 @@
 
   .preview :global(p) {
     margin: 0.5em 0;
+  }
+
+  .preview :global(img) {
+    display: block;
+    max-width: min(100%, 48rem);
+    height: auto;
+    margin: 0.75rem 0;
+    border-radius: 0.75rem;
+    border: 1px solid color-mix(in srgb, var(--theme-color-Sub-main) 25%, transparent);
+    background: color-mix(in srgb, var(--theme-color-Main-dark) 80%, transparent);
+    box-shadow: 0 0.75rem 1.5rem rgba(0, 0, 0, 0.18);
+  }
+
+  .preview :global(img[data-missing-image="true"]) {
+    min-height: 6rem;
+    object-fit: contain;
+    opacity: 0.65;
   }
 
   .preview :global(a) {

--- a/src/components/MemoTab.svelte
+++ b/src/components/MemoTab.svelte
@@ -24,6 +24,8 @@
   export let deleteMemo;
   export let renameMemo;
   export let disabled = false;
+  export let workspaceProjectDir = null;
+  export let taskId = null;
 
   let selectedMemoIndex = 0;
   let previousTaskId;
@@ -192,6 +194,8 @@
           content={editedContent}
           memoTitles={memo.map((entry) => entry.title)}
           openMemoLink={selectMemoByTitle}
+          {workspaceProjectDir}
+          {taskId}
         />
       {/key}
     {:else}

--- a/src/components/TaskDetail.svelte
+++ b/src/components/TaskDetail.svelte
@@ -1,7 +1,13 @@
 <script>
   import { getNode, updateNodeDataById } from "../common/tree_control.ts";
   import { uuidV4 } from "../common/uuid";
-  import { tree_data, table_selected_id, cancelPendingOperations } from "../stores.ts";
+  import {
+    tree_data,
+    table_selected_id,
+    cancelPendingOperations,
+    selected_type,
+    workspace_store,
+  } from "../stores.ts";
   import { debounce } from "lodash";
   import { onDestroy } from "svelte";
   import MemoTab from "./MemoTab.svelte";
@@ -11,6 +17,8 @@
     $table_selected_id && $tree_data ? getNode($table_selected_id, $tree_data.data) : undefined;
   $: name = node ? node.data["name"] : "Select Task";
   $: memo = node ? node.data["memo"] : [];
+  $: workspaceProjectDir =
+    $selected_type === "WorkspaceProject" ? $workspace_store.activeProjectDir : null;
   const changeData = (node, key, value) => {
     if (!node) {
       return;
@@ -68,7 +76,15 @@
 <div class="container">
   <div class="memotab-container">
     {#if is_selected}
-      <MemoTab {memo} {saveMemo} {addMemo} {deleteMemo} {renameMemo} />
+      <MemoTab
+        {memo}
+        {saveMemo}
+        {addMemo}
+        {deleteMemo}
+        {renameMemo}
+        {workspaceProjectDir}
+        taskId={$table_selected_id ?? null}
+      />
     {:else}
       <h1 style="color:var(--theme-color-Sub-main); display:flex; justify-content:center">
         No data.

--- a/src/types/app.ts
+++ b/src/types/app.ts
@@ -64,6 +64,11 @@ export interface ElectronAPI {
     projectDir: string,
     task: WorkspaceTask
   ) => Promise<{ success: boolean; error?: string }>;
+  wsResolveMemoAsset: (
+    projectDir: string,
+    taskId: string,
+    assetPath: string
+  ) => Promise<{ success: boolean; url?: string; error?: string }>;
   wsDeleteTask: (
     projectDir: string,
     taskId: string

--- a/tests/component/Memo.test.js
+++ b/tests/component/Memo.test.js
@@ -9,6 +9,11 @@ describe("Memo - view mode (default)", () => {
 
   beforeEach(() => {
     saveMemo = vi.fn();
+    window.electronAPI = { wsResolveMemoAsset: vi.fn(), openExternalLink: vi.fn() };
+  });
+
+  afterEach(() => {
+    delete window.electronAPI;
   });
 
   test("renders in view mode by default (no CM6 editor)", () => {
@@ -42,6 +47,30 @@ describe("Memo - view mode (default)", () => {
     expect(links).toHaveLength(2);
     expect(links[0]).toHaveClass("is-resolved");
     expect(links[1]).toHaveClass("is-unresolved");
+  });
+
+  test("resolves workspace image paths to previewable file URLs", async () => {
+    window.electronAPI.wsResolveMemoAsset.mockResolvedValue({
+      success: true,
+      url: "file:///C:/workspace/project/task-1/assets/diagram.png",
+    });
+
+    render(Memo, {
+      props: {
+        saveMemo,
+        content: "![Diagram](./assets/diagram.png)",
+        workspaceProjectDir: "C:\\workspace\\project",
+        taskId: "task-1",
+      },
+    });
+
+    await waitFor(() => {
+      const image = document.querySelector(".preview img");
+      expect(image).toBeInTheDocument();
+      expect(image.getAttribute("src")).toBe(
+        "file:///C:/workspace/project/task-1/assets/diagram.png"
+      );
+    });
   });
 
   test("converts legacy Quill Delta object to JSON string for display", () => {
@@ -123,7 +152,7 @@ describe("Memo - link handling in preview", () => {
 
   beforeEach(() => {
     saveMemo = vi.fn();
-    window.electronAPI = { openExternalLink: vi.fn() };
+    window.electronAPI = { openExternalLink: vi.fn(), wsResolveMemoAsset: vi.fn() };
   });
 
   afterEach(() => {

--- a/tests/unit/workspace.test.js
+++ b/tests/unit/workspace.test.js
@@ -11,6 +11,7 @@ import {
   createProject,
   readProject,
   writeTask,
+  resolveMemoAssetPath,
   deleteTaskDir,
   listProjects,
   migrateProjectData,
@@ -306,6 +307,34 @@ describe("file system operations", () => {
     deleteTaskDir(projectDir, taskDirs, "task-del");
     expect(fs.existsSync(path.join(projectDir, dirName))).toBe(false);
     expect(taskDirs.has("task-del")).toBe(false);
+  });
+
+  it("resolveMemoAssetPath returns a file URL for existing task assets", () => {
+    const { projectDir } = createProject(tmpDir, "Proj", "root-id");
+    const taskDirs = new Map([["root-id", "_project"]]);
+    const task = {
+      id: "task-preview",
+      name: "Preview",
+      status: "Open",
+      parents: ["root-id"],
+      memos: [],
+      createdAt: "2026-04-24",
+    };
+    writeTask(projectDir, task, taskDirs);
+
+    const assetDir = path.join(projectDir, "task-preview", "assets");
+    fs.mkdirSync(assetDir, { recursive: true });
+    const assetPath = path.join(assetDir, "diagram.png");
+    fs.writeFileSync(assetPath, "png-data");
+
+    const fileUrl = resolveMemoAssetPath(
+      projectDir,
+      taskDirs,
+      "task-preview",
+      "./assets/diagram.png"
+    );
+
+    expect(fileUrl).toBe(`file:///${assetPath.replace(/\\/g, "/")}`);
   });
 });
 


### PR DESCRIPTION
## Summary

Closes #76

- workspace モードの Markdown プレビューで、`./assets/...` の相対画像パスを実ファイル URL に解決するようにしました
- 画像プレビューの表示スタイルを追加し、大きい画像でもレイアウトが崩れにくいようにしました
- `Memo` に workspace 文脈を渡し、renderer から asset 解決 IPC を呼べるようにしました
- `workspace` の unit test と `Memo` の component test を追加して、相対画像パスの解決をカバーしました

## Why

Issue #75 で保存規約を整えたあとも、`![](./assets/...)` の画像が preview 上で自然に見えないと、ノート体験としてまだ弱いままでした。まずは workspace 内のローカル画像を確実に表示し、読む体験を改善するための変更です。

## Validation

手元で以下を実行して通過を確認しました。

- `svelte-check --tsconfig ./tsconfig.json`
- `eslint electron/index.js electron/preload.js electron/workspace.js src/components/Memo.svelte src/components/MemoTab.svelte src/components/TaskDetail.svelte src/types/app.ts tests/component/Memo.test.js tests/unit/workspace.test.js`
- `prettier --check electron/index.js electron/preload.js electron/workspace.js src/components/Memo.svelte src/components/MemoTab.svelte src/components/TaskDetail.svelte src/types/app.ts tests/component/Memo.test.js tests/unit/workspace.test.js`
- `vitest run tests/unit/workspace.test.js tests/component/Memo.test.js`

結果:
- 2 test files passed
- 50 tests passed