### PR TITLE
fix: ワークスペースプロジェクトの変更をMDファイルに保存する

### DIFF
--- a/electron/index.js
+++ b/electron/index.js
@@ -587,6 +587,32 @@ app.on("ready", () => {
     }
   });
 
+  ipcMain.handle("ws:write-project", async (event, { projectDir, tasks }) => {
+    try {
+      const { taskDirs } = workspace.readProject(projectDir);
+      const newTaskIds = new Set(tasks.map((t) => t.id));
+
+      // Delete task dirs no longer in the new task list
+      for (const id of [...taskDirs.keys()]) {
+        if (!newTaskIds.has(id)) {
+          workspace.deleteTaskDir(projectDir, taskDirs, id);
+        }
+      }
+
+      for (const task of tasks) {
+        workspace.writeTask(projectDir, task, taskDirs);
+      }
+
+      // Invalidate cache so next read reflects the new state
+      wsCache.delete(projectDir);
+
+      return { success: true };
+    } catch (err) {
+      log.error("ws:write-project error:", err.message);
+      return { success: false, error: err.message };
+    }
+  });
+
   ipcMain.handle("ws:select-directory", async () => {
     const result = await dialog.showOpenDialog({
       properties: ["openDirectory"],

--- a/electron/preload.js
+++ b/electron/preload.js
@@ -83,6 +83,8 @@ const electronAPI = {
   wsWriteTask: (projectDir, task) => ipcRenderer.invoke("ws:write-task", { projectDir, task }),
   wsSaveMemoImage: (projectDir, taskId, bytes, mimeType) =>
     ipcRenderer.invoke("ws:save-memo-image", { projectDir, taskId, bytes, mimeType }),
+  wsWriteProject: (projectDir, tasks) =>
+    ipcRenderer.invoke("ws:write-project", { projectDir, tasks }),
   wsDeleteTask: (projectDir, taskId) =>
     ipcRenderer.invoke("ws:delete-task", { projectDir, taskId }),
   wsCreateProject: (workspacePath, name, id) =>

--- a/src/common/workspace_tree.ts
+++ b/src/common/workspace_tree.ts
@@ -1,4 +1,4 @@
-import type { WorkspaceTask } from "../types/workspace";
+import type { WorkspaceTask, WorkspaceTaskStatus } from "../types/workspace";
 import type { ProjectData, TreeData } from "./tree_control";
 
 const DEFAULT_HEADERS = [
@@ -55,4 +55,41 @@ export function workspaceToProjectData(
   }
 
   return { headers: DEFAULT_HEADERS, data: buildNode(rootId) };
+}
+
+/**
+ * Convert a ProjectData tree back to a flat WorkspaceTask array.
+ * Preserves createdAt from existingTasks when available.
+ */
+export function projectDataToWorkspaceTasks(
+  projectData: ProjectData,
+  existingTasks: Record<string, WorkspaceTask>
+): WorkspaceTask[] {
+  const result: WorkspaceTask[] = [];
+  const today = new Date().toISOString().slice(0, 10);
+
+  function traverse(node: TreeData, parentIds: string[]) {
+    const existing = existingTasks[node.id];
+    result.push({
+      id: node.id,
+      name: node.data.name,
+      status: (node.data.status as WorkspaceTaskStatus) || "Open",
+      dueDate: node.data["due date"] || undefined,
+      parents: parentIds,
+      memos: (node.data.memo || []).map((m) => ({
+        id: m.id || "",
+        title: m.title || "",
+        content: typeof m.content === "string" ? m.content : "",
+      })),
+      createdAt: existing?.createdAt || today,
+    });
+    for (const child of node.children || []) {
+      traverse(child, [node.id]);
+    }
+  }
+
+  if (projectData.data) {
+    traverse(projectData.data, []);
+  }
+  return result;
 }

--- a/src/stores/tree.ts
+++ b/src/stores/tree.ts
@@ -2,6 +2,7 @@ import { throttle } from "lodash";
 import _ from "lodash";
 import { get, writable, type Writable } from "svelte/store";
 import { getNode, type ProjectData, type TreeData } from "../common/tree_control";
+import { projectDataToWorkspaceTasks } from "../common/workspace_tree";
 import { filter } from "./search";
 import { project_ids } from "./project";
 import {
@@ -13,6 +14,7 @@ import {
   clearPendingTaskDetailSelection,
   saveStatus,
 } from "./ui";
+import { workspace_store, workspace_tasks_cache } from "./workspace";
 
 export interface TreeDataStore extends Writable<ProjectData | undefined> {
   init: () => void;
@@ -75,13 +77,17 @@ function createTreeData(initialValue: ProjectData | undefined): TreeDataStore {
       return;
     }
 
+    const isWorkspace = get(selected_type) === "WorkspaceProject";
+
     if (skipPersistOnce) {
       skipPersistOnce = false;
       previousData = _.cloneDeep(current);
       filter.set(get(filter));
-      window.electronAPI.getProjectIDs().then((result) => {
-        project_ids.set(result);
-      });
+      if (!isWorkspace) {
+        window.electronAPI.getProjectIDs().then((result) => {
+          project_ids.set(result);
+        });
+      }
       saveStatus.set("idle");
       return;
     }
@@ -114,15 +120,29 @@ function createTreeData(initialValue: ProjectData | undefined): TreeDataStore {
 
     previousData = _.cloneDeep(current);
     filter.set(get(filter));
-    try {
-      await window.electronAPI.setTreeData(current);
-      saveStatus.set("saved");
-    } catch {
-      saveStatus.set("error");
+
+    if (isWorkspace) {
+      const { activeProjectDir } = get(workspace_store);
+      if (!activeProjectDir) return;
+      const cachedTasks = get(workspace_tasks_cache);
+      const tasks = projectDataToWorkspaceTasks(current, cachedTasks);
+      try {
+        await window.electronAPI.wsWriteProject?.(activeProjectDir, tasks);
+        saveStatus.set("saved");
+      } catch {
+        saveStatus.set("error");
+      }
+    } else {
+      try {
+        await window.electronAPI.setTreeData(current);
+        saveStatus.set("saved");
+      } catch {
+        saveStatus.set("error");
+      }
+      window.electronAPI.getProjectIDs().then((result) => {
+        project_ids.set(result);
+      });
     }
-    window.electronAPI.getProjectIDs().then((result) => {
-      project_ids.set(result);
-    });
   }, 1000);
 
   return {

--- a/src/stores/ui.ts
+++ b/src/stores/ui.ts
@@ -3,7 +3,7 @@ import { getNode, type TreeData } from "../common/tree_control";
 import { workspaceToProjectData } from "../common/workspace_tree";
 import type { PendingTaskDetailSelection, SelectedType } from "../types/app";
 import { clearHistory, tree_data } from "./tree";
-import { workspace_store } from "./workspace";
+import { workspace_store, workspace_tasks_cache } from "./workspace";
 
 const currentHash = typeof window !== "undefined" ? window.location.hash : "";
 const currentSearch =
@@ -86,6 +86,7 @@ function createSelectedID(initialValue: string | undefined): SelectedIdStore {
           if (!activeProjectDir) return;
           window.electronAPI.wsReadProject?.(activeProjectDir).then((result) => {
             if (!result) return;
+            workspace_tasks_cache.set(result.tasks);
             const converted = workspaceToProjectData(result.tasks, current);
             tree_data.set(converted);
             table_selected_id.set(undefined);

--- a/src/stores/workspace.ts
+++ b/src/stores/workspace.ts
@@ -1,5 +1,8 @@
 import { writable, get, type Writable } from "svelte/store";
-import type { WorkspaceInfo, WorkspaceProjectListItem } from "../types/workspace";
+import type { WorkspaceInfo, WorkspaceProjectListItem, WorkspaceTask } from "../types/workspace";
+
+/** Last loaded workspace tasks, keyed by task id. Used during save to preserve metadata. */
+export const workspace_tasks_cache = writable<Record<string, WorkspaceTask>>({});
 
 export interface WorkspaceState {
   workspaces: WorkspaceInfo[];

--- a/src/types/app.ts
+++ b/src/types/app.ts
@@ -70,6 +70,10 @@ export interface ElectronAPI {
     bytes: Uint8Array,
     mimeType?: string
   ) => Promise<{ success: boolean; path?: string; error?: string }>;
+  wsWriteProject: (
+    projectDir: string,
+    tasks: WorkspaceTask[]
+  ) => Promise<{ success: boolean; error?: string }>;
   wsDeleteTask: (
     projectDir: string,
     taskId: string


### PR DESCRIPTION
WorkspaceProjectの編集が db.json に書き込まれ続け、MDファイルには
保存されていなかった問題を修正。

- ws:write-project IPC ハンドラを追加（全タスクを一括でMD書き込み）
- projectDataToWorkspaceTasks 変換関数を追加（ProjectData→WorkspaceTask[]）
- workspace_tasks_cache ストアでロード時のタスクを保持（createdAt 保全）
- persistTreeData を WorkspaceProject 判定で分岐:
  - WorkspaceProject: wsWriteProject 経由でMD保存、setTreeData は呼ばない
  - Projects（レガシー）: 従来通り setTreeData で db.json に保存

https://claude.ai/code/session_01DsUidMpLoXWe6jZv5xkVKW