### PR TITLE
[codex] Markdownメモの画像表示とプレビューを改善

### DIFF
--- a/electron/index.js
+++ b/electron/index.js
@@ -560,6 +560,29 @@ app.on("ready", () => {
     }
   );
 
+  ipcMain.handle("ws:resolve-memo-asset", async (event, { projectDir, taskId, assetPath }) => {
+    try {
+      let cached = wsCache.get(projectDir);
+      if (!cached) {
+        const { tasks, taskDirs } = workspace.readProject(projectDir);
+        cached = { tasks, taskDirs };
+        wsCache.set(projectDir, cached);
+      }
+
+      const fileUrl = workspace.resolveMemoAssetPath(
+        projectDir,
+        cached.taskDirs,
+        taskId,
+        assetPath
+      );
+
+      return { success: Boolean(fileUrl), url: fileUrl ?? undefined };
+    } catch (err) {
+      log.error("ws:resolve-memo-asset error:", err.message);
+      return { success: false, error: err.message };
+    }
+  });
+
   ipcMain.handle("ws:delete-task", async (event, { projectDir, taskId }) => {
     try {
       let cached = wsCache.get(projectDir);

--- a/electron/preload.js
+++ b/electron/preload.js
@@ -83,6 +83,8 @@ const electronAPI = {
   wsWriteTask: (projectDir, task) => ipcRenderer.invoke("ws:write-task", { projectDir, task }),
   wsSaveMemoImage: (projectDir, taskId, bytes, mimeType) =>
     ipcRenderer.invoke("ws:save-memo-image", { projectDir, taskId, bytes, mimeType }),
+  wsResolveMemoAsset: (projectDir, taskId, assetPath) =>
+    ipcRenderer.invoke("ws:resolve-memo-asset", { projectDir, taskId, assetPath }),
   wsWriteProject: (projectDir, tasks) =>
     ipcRenderer.invoke("ws:write-project", { projectDir, tasks }),
   wsDeleteTask: (projectDir, taskId) =>

--- a/electron/workspace.js
+++ b/electron/workspace.js
@@ -1,6 +1,7 @@
 const crypto = require("crypto");
 const fs = require("fs");
 const path = require("path");
+const { pathToFileURL } = require("url");
 
 /** Convert a human name to a filesystem-safe slug. */
 function slugify(name) {
@@ -245,6 +246,28 @@ function saveMemoImage(projectDir, taskDirs, taskId, bytes, mimeType) {
   };
 }
 
+function resolveMemoAssetPath(projectDir, taskDirs, taskId, assetPath) {
+  const dirName = taskDirs.get(taskId);
+  if (!dirName || !assetPath) {
+    return null;
+  }
+
+  const taskDir = dirName === "_project" ? projectDir : path.join(projectDir, dirName);
+  const normalizedAssetPath = String(assetPath).replace(/\\/g, "/").trim();
+  const resolvedPath = path.resolve(taskDir, normalizedAssetPath);
+  const relativePath = path.relative(taskDir, resolvedPath);
+
+  if (relativePath.startsWith("..") || path.isAbsolute(relativePath)) {
+    return null;
+  }
+
+  if (!fs.existsSync(resolvedPath)) {
+    return null;
+  }
+
+  return pathToFileURL(resolvedPath).toString();
+}
+
 /**
  * Delete a task's directory (and its files).
  * The root task (_project) cannot be deleted here.
@@ -420,6 +443,7 @@ module.exports = {
   readProject,
   writeTask,
   saveMemoImage,
+  resolveMemoAssetPath,
   deleteTaskDir,
   createProject,
   listProjects,

--- a/src/components/Memo.svelte
+++ b/src/components/Memo.svelte
@@ -23,6 +23,8 @@
   let isEditing = false;
   let hasChanges = false;
   let currentContent = toMarkdown(content);
+  let renderedHtml = "";
+  let renderSequence = 0;
 
   const EXTERNAL_LINK_PATTERN = /^(https?:\/\/|mailto:|file:\/\/)/i;
 
@@ -121,6 +123,53 @@
       },
       scrollIntoView: true,
     });
+  }
+
+  async function resolveImageSources(html: string): Promise<string> {
+    if (!workspaceProjectDir || !taskId || !window.electronAPI?.wsResolveMemoAsset) {
+      return html;
+    }
+
+    const template = document.createElement("template");
+    template.innerHTML = html;
+    const images = Array.from(template.content.querySelectorAll("img[src]"));
+
+    await Promise.all(
+      images.map(async (image) => {
+        const src = image.getAttribute("src");
+        if (!src || isExternalLink(src) || src.startsWith("data:")) {
+          return;
+        }
+
+        const result = await window.electronAPI.wsResolveMemoAsset(
+          workspaceProjectDir,
+          taskId,
+          src
+        );
+
+        if (result.success && result.url) {
+          image.setAttribute("src", result.url);
+        } else {
+          image.setAttribute("data-missing-image", "true");
+        }
+      })
+    );
+
+    return template.innerHTML;
+  }
+
+  async function updateRenderedHtml(markdownText: string) {
+    const sequence = ++renderSequence;
+    const baseHtml = marked.parse(preprocessWikiLinks(markdownText), {
+      gfm: true,
+      breaks: true,
+    }) as string;
+    renderedHtml = baseHtml;
+
+    const nextHtml = await resolveImageSources(baseHtml);
+    if (sequence === renderSequence) {
+      renderedHtml = nextHtml;
+    }
   }
 
   const editorTheme = EditorView.theme({
@@ -286,10 +335,9 @@
   $: if (!isEditing && normalizedContent !== currentContent) {
     currentContent = normalizedContent;
   }
-  $: renderedHtml = marked.parse(preprocessWikiLinks(currentContent || ""), {
-    gfm: true,
-    breaks: true,
-  }) as string;
+  $: if (!isEditing) {
+    void updateRenderedHtml(currentContent || "");
+  }
 </script>
 
 <div class="wrapper">
@@ -414,6 +462,23 @@
 
   .preview :global(p) {
     margin: 0.5em 0;
+  }
+
+  .preview :global(img) {
+    display: block;
+    max-width: min(100%, 48rem);
+    height: auto;
+    margin: 0.75rem 0;
+    border-radius: 0.75rem;
+    border: 1px solid color-mix(in srgb, var(--theme-color-Sub-main) 25%, transparent);
+    background: color-mix(in srgb, var(--theme-color-Main-dark) 80%, transparent);
+    box-shadow: 0 0.75rem 1.5rem rgba(0, 0, 0, 0.18);
+  }
+
+  .preview :global(img[data-missing-image="true"]) {
+    min-height: 6rem;
+    object-fit: contain;
+    opacity: 0.65;
   }
 
   .preview :global(a) {

--- a/src/types/app.ts
+++ b/src/types/app.ts
@@ -70,6 +70,11 @@ export interface ElectronAPI {
     bytes: Uint8Array,
     mimeType?: string
   ) => Promise<{ success: boolean; path?: string; error?: string }>;
+  wsResolveMemoAsset: (
+    projectDir: string,
+    taskId: string,
+    assetPath: string
+  ) => Promise<{ success: boolean; url?: string; error?: string }>;
   wsWriteProject: (
     projectDir: string,
     tasks: WorkspaceTask[]

--- a/tests/component/Memo.test.js
+++ b/tests/component/Memo.test.js
@@ -9,6 +9,11 @@ describe("Memo - view mode (default)", () => {
 
   beforeEach(() => {
     saveMemo = vi.fn();
+    window.electronAPI = { wsResolveMemoAsset: vi.fn(), openExternalLink: vi.fn() };
+  });
+
+  afterEach(() => {
+    delete window.electronAPI;
   });
 
   test("renders in view mode by default (no CM6 editor)", () => {
@@ -42,6 +47,30 @@ describe("Memo - view mode (default)", () => {
     expect(links).toHaveLength(2);
     expect(links[0]).toHaveClass("is-resolved");
     expect(links[1]).toHaveClass("is-unresolved");
+  });
+
+  test("resolves workspace image paths to previewable file URLs", async () => {
+    window.electronAPI.wsResolveMemoAsset.mockResolvedValue({
+      success: true,
+      url: "file:///C:/workspace/project/task-1/assets/diagram.png",
+    });
+
+    render(Memo, {
+      props: {
+        saveMemo,
+        content: "![Diagram](./assets/diagram.png)",
+        workspaceProjectDir: "C:\\workspace\\project",
+        taskId: "task-1",
+      },
+    });
+
+    await waitFor(() => {
+      const image = document.querySelector(".preview img");
+      expect(image).toBeInTheDocument();
+      expect(image.getAttribute("src")).toBe(
+        "file:///C:/workspace/project/task-1/assets/diagram.png"
+      );
+    });
   });
 
   test("converts legacy Quill Delta object to JSON string for display", () => {
@@ -183,7 +212,7 @@ describe("Memo - link handling in preview", () => {
 
   beforeEach(() => {
     saveMemo = vi.fn();
-    window.electronAPI = { openExternalLink: vi.fn() };
+    window.electronAPI = { openExternalLink: vi.fn(), wsResolveMemoAsset: vi.fn() };
   });
 
   afterEach(() => {

--- a/tests/unit/workspace.test.js
+++ b/tests/unit/workspace.test.js
@@ -2,6 +2,7 @@ import { describe, it, expect, beforeEach, afterEach } from "vitest";
 import fs from "fs";
 import path from "path";
 import os from "os";
+import { pathToFileURL } from "url";
 import {
   slugify,
   parseFrontmatter,
@@ -12,6 +13,7 @@ import {
   readProject,
   writeTask,
   saveMemoImage,
+  resolveMemoAssetPath,
   deleteTaskDir,
   listProjects,
   migrateProjectData,
@@ -333,6 +335,34 @@ describe("file system operations", () => {
     expect(result.relativePath).toMatch(/^\.\/assets\/pasted-.+\.png$/);
     expect(fs.existsSync(result.assetPath)).toBe(true);
     expect(path.dirname(result.assetPath)).toBe(path.join(projectDir, "task-assets", "assets"));
+  });
+
+  it("resolveMemoAssetPath returns a file URL for existing task assets", () => {
+    const { projectDir } = createProject(tmpDir, "Proj", "root-id");
+    const taskDirs = new Map([["root-id", "_project"]]);
+    const task = {
+      id: "task-preview",
+      name: "Preview",
+      status: "Open",
+      parents: ["root-id"],
+      memos: [],
+      createdAt: "2026-04-24",
+    };
+    writeTask(projectDir, task, taskDirs);
+
+    const assetDir = path.join(projectDir, "task-preview", "assets");
+    fs.mkdirSync(assetDir, { recursive: true });
+    const assetPath = path.join(assetDir, "diagram.png");
+    fs.writeFileSync(assetPath, "png-data");
+
+    const fileUrl = resolveMemoAssetPath(
+      projectDir,
+      taskDirs,
+      "task-preview",
+      "./assets/diagram.png"
+    );
+
+    expect(fileUrl).toBe(pathToFileURL(assetPath).toString());
   });
 });
 


### PR DESCRIPTION
## Summary

Closes #76
Supersedes #89

- workspace モードの Markdown プレビューで、`./assets/...` の相対画像パスを実ファイル URL に解決するようにしました
- 画像プレビューの表示スタイルを追加し、大きい画像でもレイアウトが崩れにくいようにしました
- `Memo` から asset 解決 IPC を呼べるようにし、workspace のローカル画像を preview で表示できるようにしました
- `workspace` の unit test と `Memo` の component test を追加し、相対画像パスの解決をカバーしました
- `#89` で混ざっていた文字コード汚染や不要差分を含めず、clean branch から切り直しました

## Why

Issue #75 で画像の保存規約を整えたあとも、`![](./assets/...)` が preview 上で自然に表示されないとノート体験としてまだ弱いままでした。workspace 内のローカル画像を確実に表示し、読む体験を改善するための変更です。

## Validation

手元で以下を実行して通過を確認しました。

- `svelte-check --tsconfig ./tsconfig.json`
- `eslint src tests electron`
- `prettier --check electron/index.js electron/preload.js electron/workspace.js src/components/Memo.svelte src/types/app.ts tests/component/Memo.test.js tests/unit/workspace.test.js`
- `vitest run --pool=threads --maxWorkers=1 tests/unit`
- `vitest run --pool=threads --maxWorkers=1 tests/component`

結果:
- unit: `4 files / 68 tests passed`
- component: `8 files / 49 tests passed`

補足:
- `#89` の CI failure は `workspace.test.js` の file URL 期待値が Linux で 1 文字ずれていたのが原因でした
- worker 起動の都合で、ローカルでは `--pool=threads --maxWorkers=1` を付けて確認しています