### PR TITLE
fix: MemoTabのタブ入力クリック時に親ボタンのイベントが発火されない問題を修正

### DIFF
--- a/src/components/MemoTab.svelte
+++ b/src/components/MemoTab.svelte
@@ -107,7 +107,7 @@
               type="text"
               value={memo.title}
               bind:this={inputs[i]}
-              disabled={!edit || i != selectedMemoIndex}
+              readonly={!edit || i != selectedMemoIndex}
               on:blur={() => {
                 edit = false;
               }}
@@ -115,7 +115,9 @@
                 renameMemo(e.target.value, selectedMemoIndex);
               }}
               on:click={(e) => {
-                e.stopPropagation();
+                if (edit && i == selectedMemoIndex) {
+                  e.stopPropagation();
+                }
               }}
               on:keydown={(e) => {
                 if (e.key == "Enter") {
@@ -284,7 +286,7 @@
     cursor: text !important;
   }
 
-  input:disabled {
+  input[readonly] {
     color: var(--theme-color-Sub-main);
     background-color: transparent;
   }


### PR DESCRIPTION
disabled を readonly に変更し、stopPropagation を編集中のみに限定することで
タブクリック時に selectedMemoIndex が正しく更新されるようにした

https://claude.ai/code/session_01Ncqj1BrysbxaQibXDienM2