### PR TITLE
fix: improve UX with deadline row highlighting and search match highlighting

### DIFF
--- a/src/components/PageSearchBox.svelte
+++ b/src/components/PageSearchBox.svelte
@@ -1,6 +1,7 @@
 <script>
   import { onMount, onDestroy, createEventDispatcher, tick } from "svelte";
   import IconButton from "./IconButton.svelte";
+  import { pageSearchQuery } from "../stores/search";
 
   export let show = false;
 
@@ -35,8 +36,11 @@
   $: if (show === false) {
     searchText = ""; // search box内をクリア
     lastSearchText = ""; // ステータスをクリア
+    pageSearchQuery.set("");
     window.electronAPI.stopFindInPage(); // matchCount, activeMatchOrdinalはMainから0が通知される
   }
+
+  $: pageSearchQuery.set(show && searchText.trim() ? searchText.trim() : "");
 
   // search
   async function executeSearch() {
@@ -109,6 +113,7 @@
     searchText = "";
     matchCount = 0;
     activeMatchOrdinal = 0;
+    pageSearchQuery.set("");
     focusInput();
   }
 

--- a/src/components/TaskName.svelte
+++ b/src/components/TaskName.svelte
@@ -157,9 +157,8 @@
     return parts;
   }
 
-  $: highlightParts = !isEditing && $pageSearchQuery
-    ? splitHighlight(text, $pageSearchQuery)
-    : null;
+  $: highlightParts =
+    !isEditing && $pageSearchQuery ? splitHighlight(text, $pageSearchQuery) : null;
 
   const dispatchCommitIfChanged = () => {
     const currentText = text ?? "";

--- a/src/components/TaskName.svelte
+++ b/src/components/TaskName.svelte
@@ -3,6 +3,7 @@
   import { debounce } from "lodash";
   import { ripple, tooltip } from "../common/common.js";
   import TaskMenu from "./TaskMenu.svelte";
+  import { pageSearchQuery } from "../stores/search";
 
   export let text;
   export let color = "var(--theme-color-Sub-main)";
@@ -137,6 +138,29 @@
     wrapped: true,
   };
 
+  function splitHighlight(str, query) {
+    if (!query) return [{ t: str ?? "", h: false }];
+    const lower = (str ?? "").toLowerCase();
+    const lowerQ = query.toLowerCase();
+    const parts = [];
+    let pos = 0;
+    while (pos <= lower.length) {
+      const idx = lower.indexOf(lowerQ, pos);
+      if (idx === -1) {
+        parts.push({ t: (str ?? "").slice(pos), h: false });
+        break;
+      }
+      if (idx > pos) parts.push({ t: (str ?? "").slice(pos, idx), h: false });
+      parts.push({ t: (str ?? "").slice(idx, idx + lowerQ.length), h: true });
+      pos = idx + lowerQ.length;
+    }
+    return parts;
+  }
+
+  $: highlightParts = !isEditing && $pageSearchQuery
+    ? splitHighlight(text, $pageSearchQuery)
+    : null;
+
   const dispatchCommitIfChanged = () => {
     const currentText = text ?? "";
     if (draftText === currentText || draftText === lastSubmittedText) {
@@ -251,6 +275,13 @@
 </script>
 
 <div style="--color:{color}; --backgroundColor:{backgroundColor};">
+  {#if highlightParts}
+    <span class="highlight-display" title={text ?? ""}>
+      {#each highlightParts as part}
+        {#if part.h}<mark>{part.t}</mark>{:else}{part.t}{/if}
+      {/each}
+    </span>
+  {/if}
   <input
     type="text"
     bind:this={input}
@@ -258,6 +289,7 @@
     readonly={!isEditing}
     aria-readonly={!isEditing}
     draggable="true"
+    class:hidden-by-highlight={highlightParts}
     on:blur={() => {
       if (!isEditing) {
         return;
@@ -365,6 +397,29 @@
     align-items: center;
     flex: 1;
     position: relative;
+  }
+  .highlight-display {
+    position: relative;
+    border: none;
+    padding: 0;
+    margin: 0;
+    width: 100%;
+    overflow: hidden;
+    white-space: nowrap;
+    text-overflow: ellipsis;
+    color: var(--color);
+    background-color: var(--backgroundColor);
+    font: inherit;
+    cursor: default;
+  }
+  .highlight-display mark {
+    background-color: color-mix(in srgb, #f5c518 60%, transparent);
+    color: inherit;
+    border-radius: 2px;
+    padding: 0 1px;
+  }
+  input.hidden-by-highlight {
+    display: none;
   }
   input {
     border: none;

--- a/src/components/TreeTableRow.svelte
+++ b/src/components/TreeTableRow.svelte
@@ -34,6 +34,19 @@
   let isDragging = false;
   let isMenuOpen = false;
 
+  const DAYS_5_MS = 5 * 24 * 60 * 60 * 1000;
+  const DAY_MS = 24 * 60 * 60 * 1000;
+
+  function getDueDateUrgency(dueDate, status) {
+    if (!dueDate || status === "Completed" || status === "Canceled") return null;
+    const diff = new Date(dueDate) - new Date() + DAY_MS - 1;
+    if (diff < 0) return "overdue";
+    if (diff < DAYS_5_MS) return "due-soon";
+    return null;
+  }
+
+  $: dueDateUrgency = getDueDateUrgency(data["due date"], data["status"]);
+
   function select(e) {
     e.stopPropagation();
     dispatch("select", { id });
@@ -139,6 +152,8 @@
   class:MenuOpen={isMenuOpen}
   class:DragOverTop={dragOverType === "DragOverTop"}
   class:DragOverBottom={dragOverType === "DragOverBottom"}
+  class:OverdueRow={dueDateUrgency === "overdue"}
+  class:DueSoonRow={dueDateUrgency === "due-soon"}
   use:ripple
   tabindex="0"
   draggable="true"
@@ -317,6 +332,12 @@
   }
   .TableRow :global(*) {
     --backgroundColor: var(--theme-color-Main-light);
+  }
+  .TableRow.OverdueRow :global(*) {
+    --backgroundColor: color-mix(in srgb, var(--theme-color-Error-main) 12%, var(--theme-color-Main-light));
+  }
+  .TableRow.DueSoonRow :global(*) {
+    --backgroundColor: color-mix(in srgb, var(--theme-color-Warning-main) 12%, var(--theme-color-Main-light));
   }
   .TableRow:focus-visible {
     outline: auto;

--- a/src/components/TreeTableRow.svelte
+++ b/src/components/TreeTableRow.svelte
@@ -334,10 +334,18 @@
     --backgroundColor: var(--theme-color-Main-light);
   }
   .TableRow.OverdueRow :global(*) {
-    --backgroundColor: color-mix(in srgb, var(--theme-color-Error-main) 12%, var(--theme-color-Main-light));
+    --backgroundColor: color-mix(
+      in srgb,
+      var(--theme-color-Error-main) 12%,
+      var(--theme-color-Main-light)
+    );
   }
   .TableRow.DueSoonRow :global(*) {
-    --backgroundColor: color-mix(in srgb, var(--theme-color-Warning-main) 12%, var(--theme-color-Main-light));
+    --backgroundColor: color-mix(
+      in srgb,
+      var(--theme-color-Warning-main) 12%,
+      var(--theme-color-Main-light)
+    );
   }
   .TableRow:focus-visible {
     outline: auto;

--- a/src/stores/search.ts
+++ b/src/stores/search.ts
@@ -61,3 +61,4 @@ function createFilter(initialValue: FilterState): FilterStore {
 // eslint-disable-next-line prefer-const
 export let filter: FilterStore = createFilter({});
 export const filtered_data = writable<TreeData | null | undefined>(undefined);
+export const pageSearchQuery = writable<string>("");


### PR DESCRIPTION
- #86: Highlight overdue (red) and due-soon within 5 days (yellow) task rows
  in TreeTableRow.svelte using color-mix for both light and dark themes.
  Completed/Canceled tasks are excluded from highlighting.

- #87: Add pageSearchQuery store to propagate active search text from
  PageSearchBox to TaskName.svelte, where matching text is rendered with
  <mark> highlight spans instead of the readonly input.

https://claude.ai/code/session_01GnmLPyj5JU8VKVU3JJyvta