### PR TITLE
fix: ツールチップの表示位置がX/Y座標の入れ替わりで正しくない (#95)

### DIFF
--- a/src/common/common.ts
+++ b/src/common/common.ts
@@ -58,8 +58,8 @@ export function tooltip(
       border-radius: 0.5rem;
 			padding: 0.5rem;
 			position: fixed;
-			top: calc(${e.pageX}px + 1rem);
-			left: calc(${e.pageY}px + 1rem);
+			top: calc(${e.pageY}px + 1rem);
+			left: calc(${e.pageX}px + 1rem);
       z-index: 9999999999999999999;
 		`;
     document.body.appendChild(tooltip);
@@ -72,7 +72,7 @@ export function tooltip(
   const handleMouseMove = (e: MouseEvent) => {
     if (tooltip) {
       tooltip.style.left = `calc(${e.pageX}px + 1rem)`;
-      tooltip.style.top = `calc(${e.pageY}px + 1rem)`;
+      tooltip.style.top  = `calc(${e.pageY}px + 1rem)`;
     }
   };
   const target = params.wrapped ? (node.parentElement ?? node) : node;

--- a/src/common/common.ts
+++ b/src/common/common.ts
@@ -72,7 +72,7 @@ export function tooltip(
   const handleMouseMove = (e: MouseEvent) => {
     if (tooltip) {
       tooltip.style.left = `calc(${e.pageX}px + 1rem)`;
-      tooltip.style.top  = `calc(${e.pageY}px + 1rem)`;
+      tooltip.style.top = `calc(${e.pageY}px + 1rem)`;
     }
   };
   const target = params.wrapped ? (node.parentElement ?? node) : node;


### PR DESCRIPTION
handleMouseEnter の初期スタイルで pageX が top に、pageY が left に
誤って割り当てられていたのを修正。

https://claude.ai/code/session_01JSq9gppaXmRGH7F55y4UtW