### PR TITLE
[codex] fix memo action button colors

### DIFF
--- a/src/components/Button.svelte
+++ b/src/components/Button.svelte
@@ -12,36 +12,44 @@
   export let ariaLabel = undefined;
   // tooltip
   let use_tooltip = tooltipContent === undefined ? false : true;
-  // colors
-  // default "filled"
-  let afcolor = disabled ? "gray" : "var(--theme-color-Main-light)";
-  let abgcolor = disabled ? "gray" : activeColor;
-  let abdcolor = disabled ? "gray" : "none";
-  let fcolor = disabled ? "gray" : "var(--theme-color-Main-light)";
-  let bgcolor = disabled ? "gray" : normalColor;
-  let bdcolor = disabled ? "gray" : "none";
-  // shadow
+  let afcolor = "gray";
+  let abgcolor = "gray";
+  let abdcolor = "gray";
+  let fcolor = "gray";
+  let bgcolor = "gray";
+  let bdcolor = "gray";
   let shadow = "0 .2rem .5rem rgba(0,0,0,0.25), 0 .1em .25rem rgba(0,0,0,0);";
-  if (!disabled) {
-    switch (variant) {
-      case "outlined":
-        afcolor = activeColor;
-        abgcolor = "var(--theme-color-Shadow-sub)";
-        abdcolor = activeColor;
-        fcolor = normalColor;
-        bgcolor = "transparent";
-        bdcolor = normalColor;
-        shadow = "none";
-        break;
-      case "text":
-        afcolor = activeColor;
-        abgcolor = "var(--theme-color-Shadow-sub)";
-        abdcolor = "none";
-        fcolor = normalColor;
-        bgcolor = "transparent";
-        bdcolor = "none";
-        shadow = "none";
-        break;
+
+  $: {
+    afcolor = disabled ? "gray" : "var(--theme-color-Main-light)";
+    abgcolor = disabled ? "gray" : activeColor;
+    abdcolor = disabled ? "gray" : "none";
+    fcolor = disabled ? "gray" : "var(--theme-color-Main-light)";
+    bgcolor = disabled ? "gray" : normalColor;
+    bdcolor = disabled ? "gray" : "none";
+    shadow = "0 .2rem .5rem rgba(0,0,0,0.25), 0 .1em .25rem rgba(0,0,0,0);";
+
+    if (!disabled) {
+      switch (variant) {
+        case "outlined":
+          afcolor = activeColor;
+          abgcolor = "var(--theme-color-Shadow-sub)";
+          abdcolor = activeColor;
+          fcolor = normalColor;
+          bgcolor = "transparent";
+          bdcolor = normalColor;
+          shadow = "none";
+          break;
+        case "text":
+          afcolor = activeColor;
+          abgcolor = "var(--theme-color-Shadow-sub)";
+          abdcolor = "none";
+          fcolor = normalColor;
+          bgcolor = "transparent";
+          bdcolor = "none";
+          shadow = "none";
+          break;
+      }
     }
   }
 </script>

--- a/src/components/IconButton.svelte
+++ b/src/components/IconButton.svelte
@@ -11,36 +11,44 @@
   export let ariaLabel = undefined;
   // tooltip
   let use_tooltip = tooltipContent === undefined ? false : true;
-  // colors
-  // default "filled"
-  let afcolor = disabled ? "gray" : "var(--theme-color-Main-light)";
-  let abgcolor = disabled ? "gray" : activeColor;
-  let abdcolor = disabled ? "gray" : "none";
-  let fcolor = disabled ? "gray" : "var(--theme-color-Main-light)";
-  let bgcolor = disabled ? "gray" : normalColor;
-  let bdcolor = disabled ? "gray" : "none";
-  // shadow
+  let afcolor = "gray";
+  let abgcolor = "gray";
+  let abdcolor = "gray";
+  let fcolor = "gray";
+  let bgcolor = "gray";
+  let bdcolor = "gray";
   let shadow = "0 .2rem .5rem rgba(0,0,0,0.25), 0 .1em .25rem rgba(0,0,0,0);";
-  if (!disabled) {
-    switch (variant) {
-      case "outlined":
-        afcolor = activeColor;
-        abgcolor = "var(--theme-color-Shadow-sub)";
-        abdcolor = activeColor;
-        fcolor = normalColor;
-        bgcolor = "transparent";
-        bdcolor = normalColor;
-        shadow = "none";
-        break;
-      case "text":
-        afcolor = activeColor;
-        abgcolor = "var(--theme-color-Shadow-sub)";
-        abdcolor = "none";
-        fcolor = normalColor;
-        bgcolor = "transparent";
-        bdcolor = "none";
-        shadow = "none";
-        break;
+
+  $: {
+    afcolor = disabled ? "gray" : "var(--theme-color-Main-light)";
+    abgcolor = disabled ? "gray" : activeColor;
+    abdcolor = disabled ? "gray" : "none";
+    fcolor = disabled ? "gray" : "var(--theme-color-Main-light)";
+    bgcolor = disabled ? "gray" : normalColor;
+    bdcolor = disabled ? "gray" : "none";
+    shadow = "0 .2rem .5rem rgba(0,0,0,0.25), 0 .1em .25rem rgba(0,0,0,0);";
+
+    if (!disabled) {
+      switch (variant) {
+        case "outlined":
+          afcolor = activeColor;
+          abgcolor = "var(--theme-color-Shadow-sub)";
+          abdcolor = activeColor;
+          fcolor = normalColor;
+          bgcolor = "transparent";
+          bdcolor = normalColor;
+          shadow = "none";
+          break;
+        case "text":
+          afcolor = activeColor;
+          abgcolor = "var(--theme-color-Shadow-sub)";
+          abdcolor = "none";
+          fcolor = normalColor;
+          bgcolor = "transparent";
+          bdcolor = "none";
+          shadow = "none";
+          break;
+      }
     }
   }
 </script>

--- a/tests/component/ButtonState.test.js
+++ b/tests/component/ButtonState.test.js
@@ -1,0 +1,61 @@
+import { render } from "@testing-library/svelte";
+import { tick } from "svelte";
+
+import Button from "../../src/components/Button.svelte";
+import IconButton from "../../src/components/IconButton.svelte";
+
+describe("button color reactivity", () => {
+  test("Button updates theme colors when disabled changes", async () => {
+    const { rerender, container } = render(Button, {
+      props: {
+        content: "rename",
+        disabled: true,
+        variant: "text",
+        normalColor: "var(--theme-color-Info-main)",
+        activeColor: "var(--theme-color-Info-dark)",
+      },
+    });
+
+    expect(container.querySelector("button").getAttribute("style")).toContain("--fontColor: gray");
+
+    await rerender({
+      content: "rename",
+      disabled: false,
+      variant: "text",
+      normalColor: "var(--theme-color-Info-main)",
+      activeColor: "var(--theme-color-Info-dark)",
+    });
+    await tick();
+
+    const style = container.querySelector("button").getAttribute("style");
+    expect(style).toContain("--fontColor: var(--theme-color-Info-main)");
+    expect(style).toContain("--backgroundColor: transparent");
+  });
+
+  test("IconButton updates theme colors when disabled changes", async () => {
+    const { rerender, container } = render(IconButton, {
+      props: {
+        disabled: true,
+        normalColor: "var(--theme-color-Error-main)",
+        activeColor: "var(--theme-color-Error-dark)",
+        ariaLabel: "Delete memo",
+      },
+    });
+
+    expect(container.querySelector("button").getAttribute("style")).toContain(
+      "--backgroundColor: gray"
+    );
+
+    await rerender({
+      disabled: false,
+      normalColor: "var(--theme-color-Error-main)",
+      activeColor: "var(--theme-color-Error-dark)",
+      ariaLabel: "Delete memo",
+    });
+    await tick();
+
+    const style = container.querySelector("button").getAttribute("style");
+    expect(style).toContain("--backgroundColor: var(--theme-color-Error-main)");
+    expect(style).toContain("--fontColor: var(--theme-color-Main-light)");
+  });
+});


### PR DESCRIPTION
## Summary
- make `Button` and `IconButton` recompute their theme colors reactively when `disabled` or `variant` changes
- restore the correct themed appearance for the memo `delete` and `rename` actions after they become enabled
- add a regression test covering the disabled-to-enabled color transition

## Root cause
`Button.svelte` and `IconButton.svelte` were deriving their style variables only during component initialization, so controls that started disabled could stay visually gray even after they became enabled.

## Validation
- `tests/component/ButtonState.test.js`
- `tests/component/TaskDetail.test.js`
- `vitest run tests/component/ButtonState.test.js tests/component/TaskDetail.test.js`

## Related
- Fixes #101