### PR TITLE
fix: db.jsonモードでの画像ペーストと旧QuillコンテンツのMarkdown変換

### DIFF
--- a/src/components/Memo.svelte
+++ b/src/components/Memo.svelte
@@ -41,7 +41,7 @@
       return (val as { ops: { insert?: unknown }[] }).ops
         .map((op) => (typeof op.insert === "string" ? op.insert : ""))
         .join("")
-        .trimEnd();
+        .replace(/\s+$/, "");
     }
     return JSON.stringify(val, null, 2);
   }

--- a/src/components/Memo.svelte
+++ b/src/components/Memo.svelte
@@ -126,7 +126,7 @@
     return new Promise((resolve, reject) => {
       const reader = new FileReader();
       reader.onload = () => resolve(reader.result as string);
-      reader.onerror = reject;
+      reader.onerror = () => reject(new Error("Failed to read image file"));
       reader.readAsDataURL(file);
     });
   }

--- a/src/components/Memo.svelte
+++ b/src/components/Memo.svelte
@@ -31,6 +31,18 @@
   function toMarkdown(val: unknown): string {
     if (!val) return "";
     if (typeof val === "string") return val;
+    // Convert legacy Quill Delta format to plain text
+    if (
+      typeof val === "object" &&
+      val !== null &&
+      "ops" in val &&
+      Array.isArray((val as { ops: unknown }).ops)
+    ) {
+      return (val as { ops: { insert?: unknown }[] }).ops
+        .map((op) => (typeof op.insert === "string" ? op.insert : ""))
+        .join("")
+        .trimEnd();
+    }
     return JSON.stringify(val, null, 2);
   }
 
@@ -108,6 +120,15 @@
   function buildImageMarkdown(relativePath: string, label = ""): string {
     const alt = label.replace(/\.[^.]+$/, "").trim();
     return alt ? `![${alt}](${relativePath})` : `![](${relativePath})`;
+  }
+
+  function imageToDataUrl(file: File): Promise<string> {
+    return new Promise((resolve, reject) => {
+      const reader = new FileReader();
+      reader.onload = () => resolve(reader.result as string);
+      reader.onerror = reject;
+      reader.readAsDataURL(file);
+    });
   }
 
   function insertTextAtSelection(editorView: EditorView, text: string) {
@@ -380,7 +401,7 @@
             item.type.startsWith("image/")
           );
 
-          if (!imageItem || !canSavePastedImages()) {
+          if (!imageItem) {
             return false;
           }
 
@@ -391,16 +412,20 @@
 
           event.preventDefault();
           void (async () => {
-            const savedPath = await persistPastedImage(file);
-            if (!savedPath) {
+            let imageSrc: string | null;
+            if (canSavePastedImages()) {
+              imageSrc = await persistPastedImage(file);
+            } else {
+              imageSrc = await imageToDataUrl(file);
+            }
+            if (!imageSrc) {
               return;
             }
 
             const prefix = editorView.state.doc.length === 0 ? "" : "\n";
-            const suffix = "\n";
             insertTextAtSelection(
               editorView,
-              `${prefix}${buildImageMarkdown(savedPath, file.name || "Pasted image")}${suffix}`
+              `${prefix}${buildImageMarkdown(imageSrc, file.name || "Pasted image")}\n`
             );
           })();
 

--- a/tests/component/Memo.test.js
+++ b/tests/component/Memo.test.js
@@ -73,10 +73,11 @@ describe("Memo - view mode (default)", () => {
     });
   });
 
-  test("converts legacy Quill Delta object to JSON string for display", () => {
+  test("converts legacy Quill Delta object to plain text for display", () => {
     const delta = { ops: [{ insert: "hello" }] };
     render(Memo, { props: { saveMemo, content: delta } });
     expect(document.querySelector(".preview")).toBeInTheDocument();
+    expect(document.querySelector(".preview").textContent).toContain("hello");
   });
 
   test("readOnly: no placeholder shown when empty", () => {


### PR DESCRIPTION
- db.jsonモード（workspaceProjectDirなし）で画像をペーストした際、
  base64データURLとしてMarkdownに埋め込むフォールバックを追加。
  resolveImageSources()はすでにdata:URLをスキップする実装のため、
  プレビュー描画もそのまま動作する。
- toMarkdown()で旧QuillのDelta形式（{ops: [...]}）を検出した場合、
  ops[].insertを結合してプレーンテキストとして返すよう修正。
  これにより旧Quillコンテンツが生JSONではなく読める状態で表示される。

Closes #103

https://claude.ai/code/session_011yya6bT1xocraNc2QndUSo