### PR TITLE
[codex] improve workspace markdown notes

### DIFF
--- a/electron/workspace.js
+++ b/electron/workspace.js
@@ -94,12 +94,13 @@ function stringifyFrontmatter(data, body = "") {
   return lines.join("\n") + "\n";
 }
 
-/** Read memos from a task directory (all .md files except _index.md). */
-function readMemos(taskDir) {
+/** Read memos from a task directory. */
+function readMemos(taskDir, reservedFiles = ["_index.md"]) {
   const memos = [];
+  const reserved = new Set(reservedFiles);
   const files = fs
     .readdirSync(taskDir)
-    .filter((f) => f.endsWith(".md") && f !== "_index.md")
+    .filter((f) => f.endsWith(".md") && !reserved.has(f))
     .sort();
   for (const file of files) {
     const raw = fs.readFileSync(path.join(taskDir, file), "utf8");
@@ -122,7 +123,7 @@ function readRootTask(projectDir) {
     status: data.status || "Open",
     dueDate: data.due || undefined,
     parents: [],
-    memos: [],
+    memos: readMemos(projectDir, ["_project.md"]),
     createdAt: data.created || "",
   };
 }
@@ -179,6 +180,15 @@ function readProject(projectDir) {
   return { tasks, taskDirs };
 }
 
+function writeMemoFiles(taskDir, indexFileName, memos) {
+  const existing = fs.readdirSync(taskDir).filter((f) => f.endsWith(".md") && f !== indexFileName);
+  for (const f of existing) fs.unlinkSync(path.join(taskDir, f));
+  for (const memo of memos || []) {
+    const id = memo.id || crypto.randomUUID();
+    fs.writeFileSync(path.join(taskDir, `${id}.md`), stringifyFrontmatter({ id }, memo.content));
+  }
+}
+
 /** Write root task to _project.md. */
 function writeRootTask(projectDir, task) {
   fs.mkdirSync(projectDir, { recursive: true });
@@ -186,6 +196,7 @@ function writeRootTask(projectDir, task) {
   if (task.dueDate) data.due = task.dueDate;
   data.created = task.createdAt || new Date().toISOString().slice(0, 10);
   fs.writeFileSync(path.join(projectDir, "_project.md"), stringifyFrontmatter(data));
+  writeMemoFiles(projectDir, "_project.md", task.memos);
 }
 
 /**
@@ -213,13 +224,7 @@ function writeTask(projectDir, task, taskDirs) {
   data.created = task.createdAt || new Date().toISOString().slice(0, 10);
   fs.writeFileSync(path.join(taskDir, "_index.md"), stringifyFrontmatter(data));
 
-  // Replace all memo files
-  const existing = fs.readdirSync(taskDir).filter((f) => f.endsWith(".md") && f !== "_index.md");
-  for (const f of existing) fs.unlinkSync(path.join(taskDir, f));
-  for (const memo of task.memos || []) {
-    const id = memo.id || crypto.randomUUID();
-    fs.writeFileSync(path.join(taskDir, `${id}.md`), stringifyFrontmatter({ id }, memo.content));
-  }
+  writeMemoFiles(taskDir, "_index.md", task.memos);
 }
 
 function saveMemoImage(projectDir, taskDirs, taskId, bytes, mimeType) {

--- a/src/components/Button.svelte
+++ b/src/components/Button.svelte
@@ -12,36 +12,44 @@
   export let ariaLabel = undefined;
   // tooltip
   let use_tooltip = tooltipContent === undefined ? false : true;
-  // colors
-  // default "filled"
-  let afcolor = disabled ? "gray" : "var(--theme-color-Main-light)";
-  let abgcolor = disabled ? "gray" : activeColor;
-  let abdcolor = disabled ? "gray" : "none";
-  let fcolor = disabled ? "gray" : "var(--theme-color-Main-light)";
-  let bgcolor = disabled ? "gray" : normalColor;
-  let bdcolor = disabled ? "gray" : "none";
-  // shadow
+  let afcolor = "gray";
+  let abgcolor = "gray";
+  let abdcolor = "gray";
+  let fcolor = "gray";
+  let bgcolor = "gray";
+  let bdcolor = "gray";
   let shadow = "0 .2rem .5rem rgba(0,0,0,0.25), 0 .1em .25rem rgba(0,0,0,0);";
-  if (!disabled) {
-    switch (variant) {
-      case "outlined":
-        afcolor = activeColor;
-        abgcolor = "var(--theme-color-Shadow-sub)";
-        abdcolor = activeColor;
-        fcolor = normalColor;
-        bgcolor = "transparent";
-        bdcolor = normalColor;
-        shadow = "none";
-        break;
-      case "text":
-        afcolor = activeColor;
-        abgcolor = "var(--theme-color-Shadow-sub)";
-        abdcolor = "none";
-        fcolor = normalColor;
-        bgcolor = "transparent";
-        bdcolor = "none";
-        shadow = "none";
-        break;
+
+  $: {
+    afcolor = disabled ? "gray" : "var(--theme-color-Main-light)";
+    abgcolor = disabled ? "gray" : activeColor;
+    abdcolor = disabled ? "gray" : "none";
+    fcolor = disabled ? "gray" : "var(--theme-color-Main-light)";
+    bgcolor = disabled ? "gray" : normalColor;
+    bdcolor = disabled ? "gray" : "none";
+    shadow = "0 .2rem .5rem rgba(0,0,0,0.25), 0 .1em .25rem rgba(0,0,0,0);";
+
+    if (!disabled) {
+      switch (variant) {
+        case "outlined":
+          afcolor = activeColor;
+          abgcolor = "var(--theme-color-Shadow-sub)";
+          abdcolor = activeColor;
+          fcolor = normalColor;
+          bgcolor = "transparent";
+          bdcolor = normalColor;
+          shadow = "none";
+          break;
+        case "text":
+          afcolor = activeColor;
+          abgcolor = "var(--theme-color-Shadow-sub)";
+          abdcolor = "none";
+          fcolor = normalColor;
+          bgcolor = "transparent";
+          bdcolor = "none";
+          shadow = "none";
+          break;
+      }
     }
   }
 </script>

--- a/src/components/IconButton.svelte
+++ b/src/components/IconButton.svelte
@@ -11,36 +11,44 @@
   export let ariaLabel = undefined;
   // tooltip
   let use_tooltip = tooltipContent === undefined ? false : true;
-  // colors
-  // default "filled"
-  let afcolor = disabled ? "gray" : "var(--theme-color-Main-light)";
-  let abgcolor = disabled ? "gray" : activeColor;
-  let abdcolor = disabled ? "gray" : "none";
-  let fcolor = disabled ? "gray" : "var(--theme-color-Main-light)";
-  let bgcolor = disabled ? "gray" : normalColor;
-  let bdcolor = disabled ? "gray" : "none";
-  // shadow
+  let afcolor = "gray";
+  let abgcolor = "gray";
+  let abdcolor = "gray";
+  let fcolor = "gray";
+  let bgcolor = "gray";
+  let bdcolor = "gray";
   let shadow = "0 .2rem .5rem rgba(0,0,0,0.25), 0 .1em .25rem rgba(0,0,0,0);";
-  if (!disabled) {
-    switch (variant) {
-      case "outlined":
-        afcolor = activeColor;
-        abgcolor = "var(--theme-color-Shadow-sub)";
-        abdcolor = activeColor;
-        fcolor = normalColor;
-        bgcolor = "transparent";
-        bdcolor = normalColor;
-        shadow = "none";
-        break;
-      case "text":
-        afcolor = activeColor;
-        abgcolor = "var(--theme-color-Shadow-sub)";
-        abdcolor = "none";
-        fcolor = normalColor;
-        bgcolor = "transparent";
-        bdcolor = "none";
-        shadow = "none";
-        break;
+
+  $: {
+    afcolor = disabled ? "gray" : "var(--theme-color-Main-light)";
+    abgcolor = disabled ? "gray" : activeColor;
+    abdcolor = disabled ? "gray" : "none";
+    fcolor = disabled ? "gray" : "var(--theme-color-Main-light)";
+    bgcolor = disabled ? "gray" : normalColor;
+    bdcolor = disabled ? "gray" : "none";
+    shadow = "0 .2rem .5rem rgba(0,0,0,0.25), 0 .1em .25rem rgba(0,0,0,0);";
+
+    if (!disabled) {
+      switch (variant) {
+        case "outlined":
+          afcolor = activeColor;
+          abgcolor = "var(--theme-color-Shadow-sub)";
+          abdcolor = activeColor;
+          fcolor = normalColor;
+          bgcolor = "transparent";
+          bdcolor = normalColor;
+          shadow = "none";
+          break;
+        case "text":
+          afcolor = activeColor;
+          abgcolor = "var(--theme-color-Shadow-sub)";
+          abdcolor = "none";
+          fcolor = normalColor;
+          bgcolor = "transparent";
+          bdcolor = "none";
+          shadow = "none";
+          break;
+      }
     }
   }
 </script>

--- a/src/components/Memo.svelte
+++ b/src/components/Memo.svelte
@@ -198,6 +198,32 @@
     view.focus();
   }
 
+  function toggleLinePrefix(prefix: string) {
+    if (!view) return;
+    const { from } = view.state.selection.main;
+    const line = view.state.doc.lineAt(from);
+    if (line.text.startsWith(prefix)) {
+      view.dispatch({
+        changes: { from: line.from, to: line.from + prefix.length, insert: "" },
+        selection: { anchor: Math.max(line.from, from - prefix.length) },
+      });
+    } else {
+      view.dispatch({
+        changes: { from: line.from, insert: prefix },
+        selection: { anchor: from + prefix.length },
+      });
+    }
+    view.focus();
+  }
+
+  function formatBulletList() {
+    toggleLinePrefix("- ");
+  }
+
+  function formatQuote() {
+    toggleLinePrefix("> ");
+  }
+
   function formatLink() {
     if (!view) return;
     const { from, to } = view.state.selection.main;
@@ -410,9 +436,12 @@
       EditorView.updateListener.of((update) => {
         if (update.docChanged) {
           hasChanges = true;
+          const nextContent = update.view.state.doc.toString();
+          currentContent = nextContent;
+          void updateRenderedHtml(nextContent);
           clearTimeout(saveTimer);
           saveTimer = setTimeout(() => {
-            flushSave(update.view.state.doc.toString());
+            flushSave(nextContent);
           }, 500);
         }
       }),
@@ -482,67 +511,86 @@
         <div class="toolbar">
           <button
             class="tool-btn tool-bold"
-            title="太字 (Ctrl+B)"
+            title="Bold (Ctrl+B)"
             on:mousedown|preventDefault
             on:click={formatBold}>B</button
           >
           <button
             class="tool-btn tool-italic"
-            title="斜体 (Ctrl+I)"
+            title="Italic (Ctrl+I)"
             on:mousedown|preventDefault
             on:click={formatItalic}>I</button
+          >
+          <button
+            class="tool-btn tool-mono"
+            title="Inline code"
+            on:mousedown|preventDefault
+            on:click={formatInlineCode}>`</button
           >
           <span class="tool-sep"></span>
           <button
             class="tool-btn"
-            title="見出し1"
+            title="Heading 1"
             on:mousedown|preventDefault
             on:click={() => formatHeading(1)}>H1</button
           >
           <button
             class="tool-btn"
-            title="見出し2"
+            title="Heading 2"
             on:mousedown|preventDefault
             on:click={() => formatHeading(2)}>H2</button
           >
           <button
             class="tool-btn"
-            title="見出し3"
+            title="Heading 3"
             on:mousedown|preventDefault
             on:click={() => formatHeading(3)}>H3</button
           >
           <span class="tool-sep"></span>
           <button
             class="tool-btn"
-            title="リンク (Ctrl+K)"
+            title="Link (Ctrl+K)"
             on:mousedown|preventDefault
-            on:click={formatLink}>[url]</button
+            on:click={formatLink}>[]</button
           >
           <button
             class="tool-btn"
-            title="チェックリスト"
+            title="Bullet list"
             on:mousedown|preventDefault
-            on:click={formatCheckbox}>☐</button
+            on:click={formatBulletList}>-</button
+          >
+          <button
+            class="tool-btn"
+            title="Checklist"
+            on:mousedown|preventDefault
+            on:click={formatCheckbox}>[ ]</button
+          >
+          <button class="tool-btn" title="Quote" on:mousedown|preventDefault on:click={formatQuote}
+            >&gt;</button
           >
           <button
             class="tool-btn tool-mono"
-            title="インラインコード"
-            on:mousedown|preventDefault
-            on:click={formatInlineCode}>`</button
-          >
-          <button
-            class="tool-btn tool-mono"
-            title="コードブロック"
+            title="Code block"
             on:mousedown|preventDefault
             on:click={formatCodeBlock}>```</button
           >
         </div>
         <div class="edit-bar-end">
-          <span class="shortcut-hint">Ctrl+S · Ctrl+Enter</span>
+          <span class="shortcut-hint">Ctrl+S / Ctrl+Enter</span>
           <button class="done-btn" on:click={stopEdit}>Done</button>
         </div>
       </div>
-      <div class="editor" bind:this={container}></div>
+      <div class="edit-body">
+        <div class="editor" bind:this={container}></div>
+        <div class="live-preview" aria-label="Markdown preview">
+          {#if currentContent.trim()}
+            <!-- eslint-disable-next-line svelte/no-at-html-tags -->
+            <div class="preview">{@html renderedHtml}</div>
+          {:else}
+            <div class="placeholder">Preview</div>
+          {/if}
+        </div>
+      </div>
     </div>
   {:else}
     <!-- svelte-ignore a11y-no-static-element-interactions -->
@@ -665,6 +713,21 @@
   .editor {
     flex: 1;
     overflow: hidden;
+    min-width: 0;
+  }
+
+  .edit-body {
+    display: grid;
+    grid-template-columns: minmax(0, 1fr) minmax(16rem, 0.9fr);
+    min-height: 0;
+    flex: 1;
+  }
+
+  .live-preview {
+    min-width: 0;
+    overflow: auto;
+    border-left: 1px solid var(--theme-color-Sub-dark);
+    background-color: color-mix(in srgb, var(--theme-color-Main-light) 92%, black);
   }
 
   .preview-mode {
@@ -679,6 +742,16 @@
     color: var(--theme-color-Sub-light);
     font-size: 0.9rem;
     line-height: 1.7;
+  }
+
+  @media (max-width: 900px) {
+    .edit-body {
+      grid-template-columns: 1fr;
+    }
+
+    .live-preview {
+      display: none;
+    }
   }
 
   .placeholder {

--- a/src/components/MenuList.svelte
+++ b/src/components/MenuList.svelte
@@ -11,11 +11,23 @@
   import { ripple, tooltip } from "../common/common.js";
   import { project_ids, info_ids, selected_type, selected_id } from "../stores.ts";
   import { workspace_store } from "../stores/workspace";
+  import { getDefaultProject } from "../common/tree_control";
 
   function selectWorkspaceProject(proj) {
     workspace_store.setActiveProject(proj.projectDir);
     $selected_type = "WorkspaceProject";
     $selected_id = proj.rootId;
+  }
+
+  async function addWorkspaceProject(e) {
+    e.stopPropagation();
+    const project = getDefaultProject();
+    const result = await workspace_store.createProject(project.data.data.name, project.data.id);
+    if (result.success && result.projectDir) {
+      workspace_store.setActiveProject(result.projectDir);
+      $selected_type = "WorkspaceProject";
+      $selected_id = project.data.id;
+    }
   }
 
   let show_workspace_setup = false;
@@ -236,9 +248,28 @@
     </svg>
     <span class="TextOverFlow">Workspace</span>
     <div class="AddButtonContainer">
+      {#if $workspace_store.activeWorkspacePath}
+        <IconButton
+          tooltipContent="Add a workspace project."
+          ariaLabel="Add a workspace project"
+          normalColor="rgba(255,255,255,0.1)"
+          activeColor="rgba(255,255,255,0.2)"
+          on:click={addWorkspaceProject}
+        >
+          <svg viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg"
+            ><path
+              d="M12 5V19M5 12H19"
+              stroke="white"
+              stroke-width="2"
+              stroke-linecap="round"
+              stroke-linejoin="round"
+            ></path></svg
+          >
+        </IconButton>
+      {/if}
       <IconButton
-        tooltipContent="ワークスペースを管理"
-        ariaLabel="ワークスペースを管理"
+        tooltipContent="Manage workspaces"
+        ariaLabel="Manage workspaces"
         normalColor="rgba(255,255,255,0.1)"
         activeColor="rgba(255,255,255,0.2)"
         on:click={() => {
@@ -272,7 +303,7 @@
           show_workspace_setup = true;
         }}
       >
-        ＋ ワークスペースを設定
+        Set workspace
       </button>
     {/if}
   </div>

--- a/src/components/TaskDetail.svelte
+++ b/src/components/TaskDetail.svelte
@@ -28,7 +28,6 @@
       $tree_data = { ...$tree_data, data };
     }
   };
-  // データストア更新処理のdebounce - 全てのUI更新を統合的に処理
   const changeDataDebounce = debounce(changeData, 500);
 
   const unsubscribeCancelPending = cancelPendingOperations.subscribe(() => {

--- a/src/stores/workspace.ts
+++ b/src/stores/workspace.ts
@@ -19,6 +19,10 @@ export interface WorkspaceStore extends Writable<WorkspaceState> {
   setActive: (path: string) => Promise<void>;
   refreshProjects: () => Promise<void>;
   setActiveProject: (projectDir: string) => void;
+  createProject: (
+    name: string,
+    id: string
+  ) => Promise<{ success: boolean; projectDir?: string; error?: string }>;
 }
 
 function createWorkspaceStore(): WorkspaceStore {
@@ -107,6 +111,26 @@ function createWorkspaceStore(): WorkspaceStore {
 
     setActiveProject(projectDir: string) {
       update((s) => ({ ...s, activeProjectDir: projectDir }));
+    },
+
+    async createProject(name: string, id: string) {
+      const { activeWorkspacePath } = get({ subscribe } as WorkspaceStore);
+      if (!activeWorkspacePath) {
+        return { success: false, error: "No active workspace" };
+      }
+
+      const result = await window.electronAPI?.wsCreateProject?.(activeWorkspacePath, name, id);
+      if (!result?.success || !result.projectDir) {
+        return { success: false, error: result?.error ?? "Failed to create workspace project" };
+      }
+
+      const projects = await loadProjects(activeWorkspacePath);
+      update((s) => ({
+        ...s,
+        projects,
+        activeProjectDir: result.projectDir ?? s.activeProjectDir,
+      }));
+      return { success: true, projectDir: result.projectDir };
     },
   };
 }

--- a/tests/component/ButtonState.test.js
+++ b/tests/component/ButtonState.test.js
@@ -1,0 +1,61 @@
+import { render } from "@testing-library/svelte";
+import { tick } from "svelte";
+
+import Button from "../../src/components/Button.svelte";
+import IconButton from "../../src/components/IconButton.svelte";
+
+describe("button color reactivity", () => {
+  test("Button updates theme colors when disabled changes", async () => {
+    const { rerender, container } = render(Button, {
+      props: {
+        content: "rename",
+        disabled: true,
+        variant: "text",
+        normalColor: "var(--theme-color-Info-main)",
+        activeColor: "var(--theme-color-Info-dark)",
+      },
+    });
+
+    expect(container.querySelector("button").getAttribute("style")).toContain("--fontColor: gray");
+
+    await rerender({
+      content: "rename",
+      disabled: false,
+      variant: "text",
+      normalColor: "var(--theme-color-Info-main)",
+      activeColor: "var(--theme-color-Info-dark)",
+    });
+    await tick();
+
+    const style = container.querySelector("button").getAttribute("style");
+    expect(style).toContain("--fontColor: var(--theme-color-Info-main)");
+    expect(style).toContain("--backgroundColor: transparent");
+  });
+
+  test("IconButton updates theme colors when disabled changes", async () => {
+    const { rerender, container } = render(IconButton, {
+      props: {
+        disabled: true,
+        normalColor: "var(--theme-color-Error-main)",
+        activeColor: "var(--theme-color-Error-dark)",
+        ariaLabel: "Delete memo",
+      },
+    });
+
+    expect(container.querySelector("button").getAttribute("style")).toContain(
+      "--backgroundColor: gray"
+    );
+
+    await rerender({
+      disabled: false,
+      normalColor: "var(--theme-color-Error-main)",
+      activeColor: "var(--theme-color-Error-dark)",
+      ariaLabel: "Delete memo",
+    });
+    await tick();
+
+    const style = container.querySelector("button").getAttribute("style");
+    expect(style).toContain("--backgroundColor: var(--theme-color-Error-main)");
+    expect(style).toContain("--fontColor: var(--theme-color-Main-light)");
+  });
+});

--- a/tests/unit/workspace.test.js
+++ b/tests/unit/workspace.test.js
@@ -234,6 +234,30 @@ describe("file system operations", () => {
     expect(root.parents).toEqual([]);
   });
 
+  it("writeTask + readProject round-trips root memos", () => {
+    const { projectDir } = createProject(tmpDir, "Proj", "root-id");
+    const taskDirs = new Map([["root-id", "_project"]]);
+    const rootTask = {
+      id: "root-id",
+      name: "Proj",
+      status: "Open",
+      parents: [],
+      memos: [{ id: "root-memo", title: "Root Notes", content: "# Root Notes\n\nStored here" }],
+      createdAt: "2026-04-24",
+    };
+
+    writeTask(projectDir, rootTask, taskDirs);
+
+    expect(fs.existsSync(path.join(projectDir, "root-memo.md"))).toBe(true);
+
+    const { tasks } = readProject(projectDir);
+    const loaded = tasks.get("root-id");
+    expect(loaded.memos).toHaveLength(1);
+    expect(loaded.memos[0].id).toBe("root-memo");
+    expect(loaded.memos[0].title).toBe("Root Notes");
+    expect(loaded.memos[0].content).toContain("Stored here");
+  });
+
   it("writeTask + readProject round-trips a regular task", () => {
     const { projectDir } = createProject(tmpDir, "Proj", "root-id");
     const taskDirs = new Map([["root-id", "_project"]]);


### PR DESCRIPTION
## Summary

- Improve the memo Markdown editor with repaired toolbar actions and a live preview while editing.
- Add workspace project creation from the Workspace section so new projects are written into the selected workspace.
- Persist root task memos as Markdown files in workspace projects and cover the behavior with a unit test.

## Root Cause

Workspace mode could load and save regular task memo files, but root task memos were not read from or written to the project directory. The UI also made it easy to keep using legacy Projects even when a workspace was selected, and the Markdown toolbar had broken labels/markup.

## Validation

- `svelte-check --tsconfig ./tsconfig.json`
- `vitest run tests/unit/workspace.test.js tests/component/Memo.test.js tests/component/TaskDetail.test.js --pool=threads`
- `vite build` via the Vite JS entry