### PR TITLE
[codex] fix reported task bugs

### DIFF
--- a/electron/index.js
+++ b/electron/index.js
@@ -133,7 +133,7 @@ app.on("ready", () => {
     if (arg) {
       db.data = db.chain
         .map((o) => {
-          if (o.data.id == arg.data.id) {
+          if (o.data.id === arg.data.id) {
             return arg;
           } else {
             return o;

--- a/src/components/Memo.svelte
+++ b/src/components/Memo.svelte
@@ -28,21 +28,35 @@
 
   const EXTERNAL_LINK_PATTERN = /^(https?:\/\/|mailto:|file:\/\/)/i;
 
+  function isQuillDelta(value: unknown): value is { ops: Array<{ insert?: unknown }> } {
+    return (
+      typeof value === "object" && value !== null && Array.isArray((value as { ops?: unknown }).ops)
+    );
+  }
+
+  function quillDeltaToMarkdown(delta: { ops: Array<{ insert?: unknown }> }): string {
+    return delta.ops
+      .map((op) => {
+        if (typeof op.insert === "string") {
+          return op.insert;
+        }
+        if (
+          typeof op.insert === "object" &&
+          op.insert !== null &&
+          typeof (op.insert as { image?: unknown }).image === "string"
+        ) {
+          return `![](${(op.insert as { image: string }).image})`;
+        }
+        return "";
+      })
+      .join("")
+      .replace(/\s+$/, "");
+  }
+
   function toMarkdown(val: unknown): string {
     if (!val) return "";
     if (typeof val === "string") return val;
-    // Convert legacy Quill Delta format to plain text
-    if (
-      typeof val === "object" &&
-      val !== null &&
-      "ops" in val &&
-      Array.isArray((val as { ops: unknown }).ops)
-    ) {
-      return (val as { ops: { insert?: unknown }[] }).ops
-        .map((op) => (typeof op.insert === "string" ? op.insert : ""))
-        .join("")
-        .replace(/\s+$/, "");
-    }
+    if (isQuillDelta(val)) return quillDeltaToMarkdown(val);
     return JSON.stringify(val, null, 2);
   }
 
@@ -98,12 +112,23 @@
   }
 
   function canSavePastedImages(): boolean {
-    return Boolean(workspaceProjectDir && taskId && window.electronAPI?.wsSaveMemoImage);
+    return Boolean(
+      (workspaceProjectDir && taskId && window.electronAPI?.wsSaveMemoImage) || !workspaceProjectDir
+    );
+  }
+
+  function readFileAsDataUrl(file: File): Promise<string | null> {
+    return new Promise((resolve) => {
+      const reader = new FileReader();
+      reader.onload = () => resolve(typeof reader.result === "string" ? reader.result : null);
+      reader.onerror = () => resolve(null);
+      reader.readAsDataURL(file);
+    });
   }
 
   async function persistPastedImage(file: File): Promise<string | null> {
     if (!workspaceProjectDir || !taskId || !window.electronAPI?.wsSaveMemoImage) {
-      return null;
+      return readFileAsDataUrl(file);
     }
 
     const bytes = new Uint8Array(await file.arrayBuffer());

--- a/src/stores/column_settings.ts
+++ b/src/stores/column_settings.ts
@@ -30,6 +30,7 @@ function isColumnSettingsArray(value: unknown): value is ColumnSetting[] {
         typeof item === "object" &&
         item !== null &&
         typeof (item as Record<string, unknown>).id === "string" &&
+        typeof (item as Record<string, unknown>).label === "string" &&
         typeof (item as Record<string, unknown>).visible === "boolean"
     )
   );

--- a/src/stores/tree.ts
+++ b/src/stores/tree.ts
@@ -69,7 +69,8 @@ function createTreeData(initialValue: ProjectData | undefined): TreeDataStore {
 
     const oldIds = oldData.data ? collectNodeIds(oldData.data) : [];
     const newIds = newData.data ? collectNodeIds(newData.data) : [];
-    return oldIds.filter((id) => !newIds.includes(id));
+    const newIdSet = new Set(newIds);
+    return oldIds.filter((id) => !newIdSet.has(id));
   };
 
   const persistTreeData = throttle(async (current: ProjectData | undefined) => {

--- a/tests/component/Memo.test.js
+++ b/tests/component/Memo.test.js
@@ -73,11 +73,12 @@ describe("Memo - view mode (default)", () => {
     });
   });
 
-  test("converts legacy Quill Delta object to plain text for display", () => {
-    const delta = { ops: [{ insert: "hello" }] };
+  test("converts legacy Quill Delta object to readable markdown text", () => {
+    const delta = { ops: [{ insert: "hello" }, { insert: "\nworld" }] };
     render(Memo, { props: { saveMemo, content: delta } });
-    expect(document.querySelector(".preview")).toBeInTheDocument();
-    expect(document.querySelector(".preview").textContent).toContain("hello");
+    expect(document.querySelector(".preview")).toHaveTextContent("hello");
+    expect(document.querySelector(".preview")).toHaveTextContent("world");
+    expect(document.querySelector(".preview")).not.toHaveTextContent('"ops"');
   });
 
   test("readOnly: no placeholder shown when empty", () => {
@@ -203,6 +204,48 @@ describe("Memo - edit mode", () => {
         "![pasted-image](./assets/pasted-image.png)"
       );
     });
+
+    Range.prototype.getClientRects = originalGetClientRects;
+  });
+
+  test("pasting an image in db.json mode inserts a data URL image", async () => {
+    const originalGetClientRects = Range.prototype.getClientRects;
+    Range.prototype.getClientRects = () => [];
+
+    render(Memo, {
+      props: {
+        saveMemo,
+        content: "",
+        taskId: "task-1",
+      },
+    });
+
+    await fireEvent.click(document.querySelector(".preview-mode"));
+    await waitFor(() => {
+      expect(document.querySelector(".cm-editor")).toBeInTheDocument();
+    });
+
+    const file = new File(["image-bytes"], "pasted-image.png", { type: "image/png" });
+    const pasteEvent = new Event("paste", { bubbles: true, cancelable: true });
+    Object.defineProperty(pasteEvent, "clipboardData", {
+      value: {
+        items: [
+          {
+            type: "image/png",
+            getAsFile: () => file,
+          },
+        ],
+      },
+    });
+
+    document.querySelector(".cm-content").dispatchEvent(pasteEvent);
+
+    await waitFor(() => {
+      expect(document.querySelector(".cm-content").textContent).toContain(
+        "![pasted-image](data:image/png;base64,"
+      );
+    });
+    expect(window.electronAPI.wsSaveMemoImage).not.toHaveBeenCalled();
 
     Range.prototype.getClientRects = originalGetClientRects;
   });

--- a/tests/unit/column_settings.test.js
+++ b/tests/unit/column_settings.test.js
@@ -137,6 +137,19 @@ describe("column_settings store", () => {
     expect(settings).toEqual(DEFAULT_COLUMN_SETTINGS);
   });
 
+  test("init keeps defaults when saved settings are missing labels", async () => {
+    mockGetMetaData.mockResolvedValue([
+      { id: "name", visible: true },
+      { id: "status", visible: false },
+    ]);
+
+    await column_settings.init();
+    await new Promise((r) => setTimeout(r, 0));
+
+    const settings = get(column_settings);
+    expect(settings).toEqual(DEFAULT_COLUMN_SETTINGS);
+  });
+
   test("init keeps defaults when metaData fails", async () => {
     mockGetMetaData.mockRejectedValue(new Error("network error"));
 


### PR DESCRIPTION
## Summary

Fixes several reported task-manage bugs from the issue tracker.

## Changes

- Allow memo image paste in db.json mode by embedding pasted images as data URLs.
- Convert legacy Quill Delta memo content into readable markdown text instead of rendering raw JSON.
- Validate `label` in column settings metadata before accepting saved settings.
- Use `Set` lookups for removed tree node detection to avoid O(n²) behavior.
- Use strict equality in the Electron `set-tree-data` IPC handler.
- Add regression coverage for memo paste, legacy Quill content, and invalid column settings.

## Validation

- `svelte-check --tsconfig ./tsconfig.json`
- `vitest run --pool=threads`
- `vite build`
- `git diff --check`

## Issues

Closes #96
Closes #97
Closes #98

Also verified #95 was already fixed in the current code and closed it as completed. #101 and #103 were already closed before this PR.