### PR TITLE
fix: カラム設定ボタンの高さをrem指定に統一

### DIFF
--- a/src/components/TreeTableHeader.svelte
+++ b/src/components/TreeTableHeader.svelte
@@ -203,7 +203,7 @@
     position: absolute;
     top: 0;
     right: 0;
-    height: 100%;
+    height: 4rem;
     width: 2rem;
     flex-shrink: 0;
     display: flex;


### PR DESCRIPTION
height: 100% から height: 4rem に変更し、TableRow・TableHeader と同一の値に揃える

https://claude.ai/code/session_01EU4HBK4pRcphozK7ZNb9yR