### PR TITLE
fix: 省略タスク名のツールチップが機能しないバグを修正 (#82)

### DIFF
--- a/src/common/common.ts
+++ b/src/common/common.ts
@@ -45,7 +45,7 @@ export function tooltip(
     if (params.content) {
       tooltip.textContent = params.content;
     } else {
-      tooltip.textContent = node.textContent ?? node.value ?? "";
+      tooltip.textContent = node.textContent || node.value || "";
     }
     tooltip.style = `
       display: flex;

--- a/src/components/TaskName.svelte
+++ b/src/components/TaskName.svelte
@@ -138,6 +138,11 @@
     wrapped: true,
   };
 
+  const spanTooltipParams = {
+    color: "var(--theme-color-Main-main)",
+    backgroundColor: "var(--theme-color-Sub-main)",
+  };
+
   function splitHighlight(str, query) {
     if (!query) return [{ t: str ?? "", h: false }];
     const lower = (str ?? "").toLowerCase();
@@ -275,7 +280,7 @@
 
 <div style="--color:{color}; --backgroundColor:{backgroundColor};">
   {#if highlightParts}
-    <span class="highlight-display" title={text ?? ""}>
+    <span class="highlight-display" use:tooltip={spanTooltipParams}>
       {#each highlightParts as part}
         {#if part.h}<mark>{part.t}</mark>{:else}{part.t}{/if}
       {/each}
@@ -433,6 +438,9 @@
   input[readonly] {
     background-color: var(--backgroundColor);
     color: var(--color);
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
   }
   button {
     height: calc(100% - 0.5rem);


### PR DESCRIPTION
- common.ts の ?? を || に修正 (input.textContent が "" を返すため value にフォールスルーしていなかった)
- input[readonly] に text-overflow: ellipsis を追加して省略表示を明示
- 検索ハイライトモードの span を title 属性からカスタム use:tooltip に置き換え

https://claude.ai/code/session_01LKbAUA8g54rr5k31R9Tokv