### PR TITLE
fix: モーダルを外クリック・Escapeキーで閉じられないバグを修正

### DIFF
--- a/src/components/Modal.svelte
+++ b/src/components/Modal.svelte
@@ -36,15 +36,13 @@
   }
 
   function handleKeydown(e) {
-    if (e.key === "Escape") {
+    if (show && e.key === "Escape") {
       toggle();
     }
   }
 </script>
 
-{#if show}
-  <svelte:window on:keydown={handleKeydown} />
-{/if}
+<svelte:window on:keydown={handleKeydown} />
 {#if show}
   <div class="Mask"></div>
 {/if}

--- a/src/components/Modal.svelte
+++ b/src/components/Modal.svelte
@@ -34,8 +34,17 @@
       mask.remove();
     }
   }
+
+  function handleKeydown(e) {
+    if (e.key === "Escape") {
+      toggle();
+    }
+  }
 </script>
 
+{#if show}
+  <svelte:window on:keydown={handleKeydown} />
+{/if}
 {#if show}
   <div class="Mask"></div>
 {/if}
@@ -49,7 +58,7 @@
   aria-label={label}
   aria-labelledby={labelledBy}
   use:clickOutside
-  on:outclick={toggle()}
+  on:outclick={toggle}
 >
   <Card style="width: 100%; height:100%;">
     <slot>


### PR DESCRIPTION
## 概要

`Modal.svelte` の `on:outclick` ハンドラーの記述ミスにより、モーダルを外クリックで閉じられないバグを修正しました。あわせて Escape キーでの閉じ操作を追加しています。

## バグの原因

```svelte
<!-- 修正前 -->
on:outclick={toggle()}
```

Svelte のテンプレートでは `on:event={expression}` の `expression` はハンドラーとして評価されます。`toggle()` と書くと、**イベント発生時ではなくコンポーネントのマウント時に `toggle()` を即時実行**し、その戻り値（`undefined`）がハンドラーとして登録されます。

結果:
- モーダルを外クリックしても何も起きない（ハンドラーが `undefined`）
- Dialog / WorkspaceSetup / MigrationWizard を含む全 Modal 利用箇所に影響

## 変更内容

```svelte
<!-- 修正後 -->
on:outclick={toggle}
```

加えて `<svelte:window>` で Escape キーを捕捉し、モーダル表示中のみ `toggle()` を呼ぶ処理を追加しました:

```svelte
{#if show}
  <svelte:window on:keydown={handleKeydown} />
{/if}
```

## テスト観点

- [ ] モーダル表示中に外クリックでモーダルが閉じる
- [ ] モーダル表示中に Escape キーでモーダルが閉じる
- [ ] モーダルが表示されていないとき Escape を押しても何も起きない
- [ ] Dialog (確認ダイアログ) / WorkspaceSetup / MigrationWizard でも同様に動作する

## 関連

- issue #86, #87 はコードベースを確認したところすでに実装済みのためクローズ済み
- 空のタスク名が保存されるバグは別 issue として起票済み

https://claude.ai/code/session_01NA9YrMCVtuCQmq3Q2cr3fU

---
_Generated by [Claude Code](https://claude.ai/code/session_01NA9YrMCVtuCQmq3Q2cr3fU)_