### PR TITLE
fix: 空白・空文字のタスク名が保存されるバグを修正 (#114)

### DIFF
--- a/src/components/TaskName.svelte
+++ b/src/components/TaskName.svelte
@@ -166,6 +166,9 @@
     !isEditing && $pageSearchQuery ? splitHighlight(text, $pageSearchQuery) : null;
 
   const dispatchCommitIfChanged = () => {
+    if (!draftText.trim()) {
+      return;
+    }
     const currentText = text ?? "";
     if (draftText === currentText || draftText === lastSubmittedText) {
       return;
@@ -191,6 +194,10 @@
 
   const flushCommit = () => {
     debouncedCommit.cancel();
+    if (!draftText.trim()) {
+      draftText = text ?? "";
+      return;
+    }
     dispatchCommitIfChanged();
   };
 

--- a/tests/component/TaskName.test.js
+++ b/tests/component/TaskName.test.js
@@ -1,6 +1,7 @@
 import { fireEvent, render, screen } from "@testing-library/svelte";
 
 import TaskNameClickHarness from "../mocks/TaskNameClickHarness.svelte";
+import TaskNameCommitHarness from "../mocks/TaskNameCommitHarness.svelte";
 
 describe("TaskName", () => {
   test("allows click on read-only input to bubble to row selection handler", async () => {
@@ -13,5 +14,60 @@ describe("TaskName", () => {
     await fireEvent.click(input);
 
     expect(screen.getByTestId("count")).toHaveTextContent("1");
+  });
+
+  describe("empty/whitespace validation", () => {
+    async function enterEditingMode() {
+      const editButton = screen.getByRole("button", { name: /edit task name/i });
+      await fireEvent.click(editButton);
+    }
+
+    test("does not commit empty string on blur", async () => {
+      render(TaskNameCommitHarness, { initialText: "Original" });
+      await enterEditingMode();
+
+      const input = screen.getByDisplayValue("Original");
+      await fireEvent.input(input, { target: { value: "" } });
+      await fireEvent.blur(input);
+
+      expect(screen.getByTestId("committed-count")).toHaveTextContent("0");
+      expect(screen.getByTestId("current-text")).toHaveTextContent("Original");
+    });
+
+    test("does not commit whitespace-only string on blur", async () => {
+      render(TaskNameCommitHarness, { initialText: "Original" });
+      await enterEditingMode();
+
+      const input = screen.getByDisplayValue("Original");
+      await fireEvent.input(input, { target: { value: "   " } });
+      await fireEvent.blur(input);
+
+      expect(screen.getByTestId("committed-count")).toHaveTextContent("0");
+      expect(screen.getByTestId("current-text")).toHaveTextContent("Original");
+    });
+
+    test("restores original text when empty string submitted with Enter", async () => {
+      render(TaskNameCommitHarness, { initialText: "Original" });
+      await enterEditingMode();
+
+      const input = screen.getByDisplayValue("Original");
+      await fireEvent.input(input, { target: { value: "" } });
+      await fireEvent.keyDown(input, { key: "Enter" });
+
+      expect(screen.getByTestId("committed-count")).toHaveTextContent("0");
+      expect(input).toHaveValue("Original");
+    });
+
+    test("commits valid non-empty text normally", async () => {
+      render(TaskNameCommitHarness, { initialText: "Original" });
+      await enterEditingMode();
+
+      const input = screen.getByDisplayValue("Original");
+      await fireEvent.input(input, { target: { value: "Updated" } });
+      await fireEvent.blur(input);
+
+      expect(screen.getByTestId("committed-count")).toHaveTextContent("1");
+      expect(screen.getByTestId("last-committed")).toHaveTextContent("Updated");
+    });
   });
 });

--- a/tests/mocks/TaskNameCommitHarness.svelte
+++ b/tests/mocks/TaskNameCommitHarness.svelte
@@ -1,0 +1,20 @@
+<script>
+  import TaskName from "../../src/components/TaskName.svelte";
+
+  export let initialText = "Task 1";
+  let currentText = initialText;
+  let committedCount = 0;
+  let lastCommitted = "";
+
+  function handleCommit(event) {
+    currentText = event.detail.value;
+    lastCommitted = event.detail.value;
+    committedCount += 1;
+  }
+</script>
+
+<TaskName text={currentText} on:commit={handleCommit} />
+
+<p data-testid="current-text">{currentText}</p>
+<p data-testid="committed-count">{committedCount}</p>
+<p data-testid="last-committed">{lastCommitted}</p>


### PR DESCRIPTION
## 概要

issue #114 の修正。タスク名を空文字またはスペースのみにしてEnter/フォーカスアウトすると保存されてしまうバグを修正。

## 変更内容

**`src/components/TaskName.svelte`**

- `dispatchCommitIfChanged()`: `draftText.trim()` が空の場合はcommitをスキップ（デバウンス中の誤送信も防止）
- `flushCommit()`: blur/Enter確定時に空文字・空白のみなら元のテキストに復元してリターン

```js
// 修正前
const dispatchCommitIfChanged = () => {
  const currentText = text ?? "";
  if (draftText === currentText || draftText === lastSubmittedText) {
    return; // 空文字チェックなし
  }
  lastSubmittedText = draftText;
  dispatch("commit", { value: draftText });
};

const flushCommit = () => {
  debouncedCommit.cancel();
  dispatchCommitIfChanged(); // 空文字でもそのまま通過
};
```

```js
// 修正後
const dispatchCommitIfChanged = () => {
  if (!draftText.trim()) {
    return; // 空文字・空白はcommitしない
  }
  // ...
};

const flushCommit = () => {
  debouncedCommit.cancel();
  if (!draftText.trim()) {
    draftText = text ?? ""; // 元のテキストに復元
    return;
  }
  dispatchCommitIfChanged();
};
```

## テスト

`TaskNameCommitHarness.svelte` を新規追加し、以下のケースを検証：

- 空文字でblurしてもcommitされない
- 空白のみでblurしてもcommitされない
- 空文字でEnterを押すと元のテキストに復元される
- 有効なテキストは正常にcommitされる

## 関連

Closes #114

https://claude.ai/code/session_01LTjBkV2Q4UBnAwYuE8xqXY

---
_Generated by [Claude Code](https://claude.ai/code/session_01LTjBkV2Q4UBnAwYuE8xqXY)_