### PR TITLE
[codex] Make memo editing explicit

### DIFF
--- a/src/components/Memo.svelte
+++ b/src/components/Memo.svelte
@@ -20,8 +20,10 @@
   let container: HTMLElement;
   let view: EditorView | null = null;
   let saveTimer: ReturnType<typeof setTimeout>;
+  let savedTimer: ReturnType<typeof setTimeout>;
   let isEditing = false;
   let hasChanges = false;
+  let saveState: "clean" | "dirty" | "saved" = "clean";
   let currentContent = toMarkdown(content);
   let renderedHtml = "";
   let renderSequence = 0;
@@ -109,6 +111,13 @@
     currentContent = nextContent;
     saveMemo(currentContent);
     hasChanges = false;
+    saveState = "saved";
+    clearTimeout(savedTimer);
+    savedTimer = setTimeout(() => {
+      if (!hasChanges) {
+        saveState = "clean";
+      }
+    }, 1600);
   }
 
   function canSavePastedImages(): boolean {
@@ -486,6 +495,7 @@
       EditorView.updateListener.of((update) => {
         if (update.docChanged) {
           hasChanges = true;
+          saveState = "dirty";
           const nextContent = update.view.state.doc.toString();
           currentContent = nextContent;
           void updateRenderedHtml(nextContent);
@@ -499,9 +509,10 @@
   }
 
   async function startEdit() {
-    if (readOnly) return;
+    if (readOnly || isEditing) return;
     isEditing = true;
     await tick();
+    if (!container || view) return;
     view = new EditorView({
       state: EditorState.create({ doc: currentContent, extensions: buildExtensions() }),
       parent: container,
@@ -523,6 +534,7 @@
   }
 
   onDestroy(() => {
+    clearTimeout(savedTimer);
     if (view) {
       clearTimeout(saveTimer);
       if (hasChanges) flushSave(view.state.doc.toString());
@@ -530,7 +542,7 @@
     }
   });
 
-  function handlePreviewClick(e: MouseEvent) {
+  function handlePreviewClick(e: MouseEvent | KeyboardEvent) {
     const link = (e.target as Element).closest("a") as HTMLAnchorElement | null;
     if (link?.dataset.memoLink) {
       e.preventDefault();
@@ -542,12 +554,20 @@
       window.electronAPI?.openExternalLink(link.href);
       return;
     }
-    startEdit();
+  }
+
+  function handlePreviewKeydown(e: KeyboardEvent) {
+    if (e.key === "Enter" || e.key === " ") {
+      handlePreviewClick(e);
+    }
   }
 
   $: normalizedContent = toMarkdown(content);
   $: if (!isEditing && normalizedContent !== currentContent) {
     currentContent = normalizedContent;
+  }
+  $: if (readOnly && isEditing) {
+    stopEdit();
   }
   $: if (!isEditing) {
     void updateRenderedHtml(currentContent || "");
@@ -626,8 +646,15 @@
           >
         </div>
         <div class="edit-bar-end">
-          <span class="shortcut-hint">Ctrl+S / Ctrl+Enter</span>
-          <button class="done-btn" on:click={stopEdit}>Done</button>
+          <span class="save-status" aria-live="polite">
+            {saveState === "dirty" ? "Unsaved" : saveState === "saved" ? "Saved" : ""}
+          </span>
+          <div class="mode-switch" role="group" aria-label="Memo mode">
+            <button class="read-mode-btn" type="button" aria-pressed="false" on:click={stopEdit}
+              >Read</button
+            >
+            <button class="edit-mode-btn active" type="button" aria-pressed="true">Edit</button>
+          </div>
         </div>
       </div>
       <div class="edit-body">
@@ -644,16 +671,25 @@
     </div>
   {:else}
     <!-- svelte-ignore a11y-no-static-element-interactions -->
-    <div
-      class="preview-mode"
-      on:click={handlePreviewClick}
-      on:keydown={(e) => e.key === "Enter" && startEdit()}
-    >
+    <div class="preview-mode" on:click={handlePreviewClick} on:keydown={handlePreviewKeydown}>
+      {#if !readOnly}
+        <div class="preview-bar">
+          <div class="mode-switch" role="group" aria-label="Memo mode">
+            <button class="read-mode-btn active" type="button" aria-pressed="true">Read</button>
+            <button
+              class="edit-mode-btn"
+              type="button"
+              aria-pressed="false"
+              on:click|stopPropagation={startEdit}>Edit</button
+            >
+          </div>
+        </div>
+      {/if}
       {#if currentContent.trim()}
         <!-- eslint-disable-next-line svelte/no-at-html-tags -->
         <div class="preview">{@html renderedHtml}</div>
       {:else if !readOnly}
-        <div class="placeholder">Click to start writing...</div>
+        <div class="placeholder">No content</div>
       {/if}
     </div>
   {/if}
@@ -736,28 +772,48 @@
   .edit-bar-end {
     display: flex;
     align-items: center;
-    gap: 0.75rem;
+    gap: 0.5rem;
     flex-shrink: 0;
   }
 
-  .shortcut-hint {
+  .save-status {
+    min-width: 4rem;
+    text-align: right;
     color: var(--theme-color-Sub-main);
     font-size: 0.75rem;
     white-space: nowrap;
   }
 
-  .done-btn {
-    padding: 0.2rem 0.75rem;
-    font-size: 0.8rem;
-    background-color: var(--theme-color-Primary-main);
-    color: var(--theme-color-Main-dark);
-    border: none;
+  .mode-switch {
+    display: inline-flex;
+    align-items: center;
+    padding: 0.15rem;
+    border: 1px solid var(--theme-color-Sub-dark);
     border-radius: 4px;
+    background-color: var(--theme-color-Main-main);
+    gap: 0.15rem;
+  }
+
+  .mode-switch button {
+    border: none;
+    border-radius: 3px;
+    background-color: transparent;
+    color: var(--theme-color-Sub-main);
+    padding: 0.2rem 0.55rem;
+    min-width: 3.25rem;
+    font-size: 0.78rem;
     cursor: pointer;
   }
 
-  .done-btn:hover {
+  .mode-switch button:hover {
+    color: var(--theme-color-Sub-light);
+    background-color: color-mix(in srgb, var(--theme-color-Sub-dark) 30%, transparent);
+  }
+
+  .mode-switch button.active {
     background-color: var(--theme-color-Primary-dark);
+    color: var(--theme-color-Main-dark);
+    cursor: default;
   }
 
   .editor {
@@ -784,7 +840,17 @@
     flex: 1;
     height: 100%;
     overflow: auto;
-    cursor: text;
+  }
+
+  .preview-bar {
+    position: sticky;
+    top: 0;
+    z-index: 1;
+    display: flex;
+    justify-content: flex-end;
+    padding: 0.45rem 0.6rem;
+    border-bottom: 1px solid var(--theme-color-Shadow-main);
+    background-color: color-mix(in srgb, var(--theme-color-Main-light) 94%, black);
   }
 
   .preview {

--- a/src/components/MemoTab.svelte
+++ b/src/components/MemoTab.svelte
@@ -1,22 +1,11 @@
 <script>
   import { tick } from "svelte";
   import { table_selected_id } from "../stores.ts";
-  import { ripple, tooltip } from "../common/common.js";
+  import { ripple } from "../common/common.js";
   import IconButton from "./IconButton.svelte";
   import Button from "./Button.svelte";
   import Memo from "./Memo.svelte";
   import Dialog from "./Dialog.svelte";
-
-  let show_confirm = false;
-  const toggle_confirm = () => {
-    show_confirm = !show_confirm;
-  };
-  let name_confirm = "";
-  const callback_confirm = () => {
-    if (deleteMemo(selectedMemoIndex)) {
-      selectedMemoIndex = selectedMemoIndex == 0 ? 0 : selectedMemoIndex - 1;
-    }
-  };
 
   export let memo = [];
   export let saveMemo;
@@ -27,24 +16,18 @@
   export let workspaceProjectDir = null;
   export let taskId = null;
 
+  let show_confirm = false;
+  let name_confirm = "";
   let selectedMemoIndex = 0;
   let previousTaskId;
+  let renamingIndex = null;
+  let draftTitle = "";
+  let renameInput;
 
-  $: if ($table_selected_id !== previousTaskId) {
-    previousTaskId = $table_selected_id;
-    selectedMemoIndex = 0;
-    edit = false;
-  }
+  const toggle_confirm = () => {
+    show_confirm = !show_confirm;
+  };
 
-  $: if (selectedMemoIndex >= memo.length && memo.length > 0) {
-    selectedMemoIndex = memo.length - 1;
-  }
-
-  $: editedContent = memo.length > selectedMemoIndex ? memo[selectedMemoIndex].content : "";
-
-  let newMemoTitle = "memo";
-  let inputs = Array(100).fill(null);
-  let edit = false;
   const hasSelectedMemo = () => Boolean(memo[selectedMemoIndex]);
 
   function normalizeMemoTitle(title) {
@@ -53,38 +36,103 @@
       .toLocaleLowerCase();
   }
 
+  function cancelRename() {
+    renamingIndex = null;
+    draftTitle = "";
+  }
+
+  function commitRename() {
+    if (renamingIndex === null) {
+      return;
+    }
+
+    const index = renamingIndex;
+    const nextTitle = draftTitle.trim();
+    renamingIndex = null;
+
+    if (nextTitle && nextTitle !== memo[index]?.title) {
+      renameMemo(nextTitle, index);
+    }
+  }
+
+  const callback_confirm = () => {
+    if (deleteMemo(selectedMemoIndex)) {
+      selectedMemoIndex = selectedMemoIndex == 0 ? 0 : selectedMemoIndex - 1;
+      cancelRename();
+    }
+  };
+
+  function buildNextMemoTitle() {
+    const existingTitles = new Set(memo.map((entry) => normalizeMemoTitle(entry.title)));
+    const baseTitle = "Note";
+
+    if (!existingTitles.has(normalizeMemoTitle(baseTitle))) {
+      return baseTitle;
+    }
+
+    let suffix = memo.length + 1;
+    let title = `${baseTitle} ${suffix}`;
+    while (existingTitles.has(normalizeMemoTitle(title))) {
+      suffix += 1;
+      title = `${baseTitle} ${suffix}`;
+    }
+    return title;
+  }
+
+  function selectMemo(index) {
+    if (renamingIndex !== null && renamingIndex !== index) {
+      commitRename();
+    }
+    selectedMemoIndex = index;
+  }
+
+  const beginRename = async (index = selectedMemoIndex) => {
+    if (disabled || !memo[index]) {
+      return;
+    }
+
+    selectedMemoIndex = index;
+    draftTitle = memo[index].title || "";
+    renamingIndex = index;
+    await tick();
+    renameInput?.focus();
+    renameInput?.select();
+  };
+
   const selectMemoByTitle = (title) => {
     const nextIndex = memo.findIndex(
       (entry) => normalizeMemoTitle(entry.title) === normalizeMemoTitle(title)
     );
 
     if (nextIndex >= 0) {
+      commitRename();
       selectedMemoIndex = nextIndex;
-      edit = false;
       return true;
     }
 
     return false;
   };
 
-  const toggle = async () => {
-    if (memo.length > 0) {
-      edit = !edit;
-      if (edit) {
-        await tick();
-        if (inputs[selectedMemoIndex]) {
-          inputs[selectedMemoIndex].focus();
-        }
-      }
+  const createFirstMemo = async () => {
+    if (addMemo(buildNextMemoTitle())) {
+      await tick();
+      selectedMemoIndex = memo.length - 1;
+      await beginRename(selectedMemoIndex);
     }
   };
 
-  const createFirstMemo = async () => {
-    if (addMemo(newMemoTitle)) {
-      await tick();
-      selectedMemoIndex = memo.length - 1;
-    }
-  };
+  $: if ($table_selected_id !== previousTaskId) {
+    previousTaskId = $table_selected_id;
+    selectedMemoIndex = 0;
+    cancelRename();
+  }
+
+  $: if (selectedMemoIndex >= memo.length && memo.length > 0) {
+    selectedMemoIndex = memo.length - 1;
+  }
+
+  $: editedContent = memo.length > selectedMemoIndex ? memo[selectedMemoIndex].content : "";
+  $: selectedMemo = memo[selectedMemoIndex];
 </script>
 
 <div class="container">
@@ -100,36 +148,33 @@
             class:selected={i == selectedMemoIndex}
             aria-label={`Select memo ${memo.title}`}
             on:click={() => {
-              selectedMemoIndex = i;
+              selectMemo(i);
+            }}
+            on:dblclick={() => {
+              beginRename(i);
             }}
           >
-            <input
-              type="text"
-              value={memo.title}
-              bind:this={inputs[i]}
-              readonly={!edit || i != selectedMemoIndex}
-              on:blur={() => {
-                edit = false;
-              }}
-              on:input={(e) => {
-                renameMemo(e.target.value, selectedMemoIndex);
-              }}
-              on:click={(e) => {
-                if (edit && i == selectedMemoIndex) {
-                  e.stopPropagation();
-                }
-              }}
-              on:keydown={(e) => {
-                if (e.key == "Enter") {
-                  edit = false;
-                }
-              }}
-              use:tooltip={{
-                color: "var(--theme-color-Main-main)",
-                backgroundColor: "var(--theme-color-Sub-main)",
-                wrapped: true,
-              }}
-            />
+            {#if renamingIndex === i}
+              <input
+                class="tab-rename"
+                type="text"
+                bind:this={renameInput}
+                bind:value={draftTitle}
+                aria-label={`Rename memo ${memo.title}`}
+                on:click|stopPropagation
+                on:blur={commitRename}
+                on:keydown={(e) => {
+                  if (e.key == "Enter") {
+                    commitRename();
+                  }
+                  if (e.key == "Escape") {
+                    cancelRename();
+                  }
+                }}
+              />
+            {:else}
+              <span class="tab-title" title={memo.title}>{memo.title || "Untitled"}</span>
+            {/if}
           </button>
         {/each}
       {/if}
@@ -154,7 +199,27 @@
         >
       </IconButton>
       <IconButton
-        tooltipContent="Delete the selected memo."
+        tooltipContent="Rename the selected note."
+        ariaLabel="Rename the selected memo"
+        disabled={disabled || memo.length === 0}
+        activeColor={"var(--theme-color-Info-dark)"}
+        normalColor={"var(--theme-color-Info-main)"}
+        on:click={() => {
+          beginRename();
+        }}
+      >
+        <svg viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg"
+          ><path
+            d="M4 20H20M5 16.5L6 12.5L15.5 3L19 6.5L9.5 16L5 16.5Z"
+            stroke="var(--theme-color-Main-main)"
+            stroke-width="1.8"
+            stroke-linecap="round"
+            stroke-linejoin="round"
+          ></path></svg
+        >
+      </IconButton>
+      <IconButton
+        tooltipContent="Delete the selected note."
         ariaLabel="Delete the selected memo"
         disabled={disabled || memo.length === 0}
         activeColor={"var(--theme-color-Error-dark)"}
@@ -177,19 +242,11 @@
           /></svg
         >
       </IconButton>
-      <Button
-        disabled={disabled || memo.length === 0}
-        variant={"text"}
-        activeColor={"var(--theme-color-Info-dark)"}
-        normalColor={"var(--theme-color-Info-main)"}
-        on:click={toggle}
-        content="rename"
-      />
     </div>
   </div>
 
   <div class="memotab-content">
-    {#if memo[selectedMemoIndex]}
+    {#if selectedMemo}
       {#key `${$table_selected_id ?? "none"}:${selectedMemoIndex}`}
         <Memo
           saveMemo={(editedContent) => saveMemo(editedContent, selectedMemoIndex)}
@@ -202,12 +259,7 @@
       {/key}
     {:else}
       <div class="empty-state" data-testid="memo-empty-state">
-        <p class="eyebrow">Notes</p>
-        <h2>Create the first note for this task</h2>
-        <p class="empty-copy">
-          Capture context, next steps, or research here. Notes stay with the task so they are easy
-          to revisit later.
-        </p>
+        <h2>Create a note</h2>
         <Button
           content="Create first note"
           ariaLabel="Create first note"
@@ -223,8 +275,8 @@
 <Dialog
   show={show_confirm}
   toggle={toggle_confirm}
-  header="Confirm."
-  content={`Do you really delete "${name_confirm}"?`}
+  header="Delete note?"
+  content={`Delete "${name_confirm}"?`}
   callback={callback_confirm}
 />
 
@@ -252,17 +304,22 @@
   .memotab-container {
     display: flex;
     flex-direction: row;
-    height: 3rem;
+    height: 3.25rem;
     width: 100%;
+    border-bottom: 1px solid var(--theme-color-Shadow-main);
+    background-color: var(--theme-color-Main-main);
   }
 
   .memotab {
     display: flex;
     flex-direction: row;
-    height: 2rem;
-    padding: 0.5rem;
+    align-items: center;
+    height: 100%;
+    padding: 0.35rem 0.5rem;
+    gap: 0.35rem;
     overflow-x: auto;
     flex: 1;
+    box-sizing: border-box;
   }
 
   .memotab-control {
@@ -271,41 +328,45 @@
     align-items: center;
     flex-shrink: 0;
     margin-left: auto;
+    padding-right: 0.25rem;
+    border-left: 1px solid var(--theme-color-Shadow-main);
   }
 
-  input {
+  .tab-rename {
     border: none;
-    padding: 0;
+    padding: 0.15rem 0.25rem;
     margin: 0;
     width: 100%;
-    text-align: center;
-  }
-
-  input:focus {
-    outline: auto;
+    min-width: 0;
+    text-align: left;
+    color: var(--theme-color-Sub-light);
+    background-color: var(--theme-color-Main-dark);
+    border-radius: 4px;
     cursor: text !important;
   }
 
-  input[readonly] {
-    color: var(--theme-color-Sub-main);
-    background-color: transparent;
-  }
-
-  input:hover {
-    cursor: pointer;
+  .tab-rename:focus {
+    outline: 2px solid var(--theme-color-Accent-main);
   }
 
   .memotab-item {
     display: flex;
     box-sizing: border-box;
-    height: 100%;
-    min-width: 5rem;
-    max-width: 10rem;
-    padding: 0.5rem;
-    flex: 1;
-    justify-content: center;
+    height: 2.25rem;
+    width: clamp(7rem, 16vw, 13rem);
+    min-width: 7rem;
+    padding: 0.35rem 0.65rem;
+    flex: 0 0 auto;
+    justify-content: flex-start;
     align-items: center;
     color: var(--theme-color-Sub-main);
+    border-radius: 0.45rem;
+    border: 1px solid transparent;
+    background-color: transparent;
+    transition:
+      background-color 120ms ease,
+      border-color 120ms ease,
+      color 120ms ease;
   }
 
   span.memotab-item {
@@ -318,23 +379,38 @@
     cursor: default !important;
   }
 
+  .tab-title {
+    min-width: 0;
+    width: 100%;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+    text-align: left;
+    font-size: 0.9rem;
+  }
+
   .empty-tab-label {
     opacity: 0.8;
   }
 
   .memotab-item:hover {
     cursor: pointer;
+    background-color: var(--theme-color-Shadow-sub);
+    color: var(--theme-color-Sub-light);
   }
 
   .selected {
-    border-bottom: 0.2rem solid var(--theme-color-Accent-main);
+    border-color: color-mix(in srgb, var(--theme-color-Accent-main) 55%, transparent);
+    background-color: var(--theme-color-Main-light);
+    color: var(--theme-color-Sub-light);
+    box-shadow: inset 0 -0.2rem 0 var(--theme-color-Accent-main);
   }
 
   .memotab-content {
     display: flex;
     box-sizing: border-box;
-    height: calc(100% - 5.5rem);
     flex: 1;
+    min-height: 0;
     overflow: hidden;
   }
 
@@ -343,33 +419,16 @@
     flex: 1;
     flex-direction: column;
     justify-content: center;
-    align-items: flex-start;
-    gap: 0.75rem;
+    align-items: center;
+    gap: 0.85rem;
     padding: 2rem;
-    border: 0.1rem dashed var(--theme-color-Shadow-main);
-    border-radius: 1rem;
-    margin: 1rem;
-    background:
-      linear-gradient(135deg, var(--theme-color-Shadow-sub), transparent 70%),
-      var(--theme-color-Main-main);
+    background-color: var(--theme-color-Main-light);
     color: var(--theme-color-Sub-main);
-  }
-
-  .eyebrow {
-    margin: 0;
-    text-transform: uppercase;
-    letter-spacing: 0.08em;
-    font-size: 0.8rem;
   }
 
   .empty-state h2 {
     margin: 0;
-    color: var(--theme-color-Primary-main);
-  }
-
-  .empty-copy {
-    margin: 0;
-    max-width: 34rem;
-    line-height: 1.5;
+    color: var(--theme-color-Sub-light);
+    font-size: 1.1rem;
   }
 </style>

--- a/tests/component/Memo.test.js
+++ b/tests/component/Memo.test.js
@@ -99,28 +99,28 @@ describe("Memo - edit mode", () => {
     delete window.electronAPI;
   });
 
-  test("clicking preview enters edit mode and shows CM6 editor", async () => {
+  test("clicking edit mode switch shows CM6 editor", async () => {
     render(Memo, { props: { saveMemo, content: "hello" } });
-    await fireEvent.click(document.querySelector(".preview-mode"));
+    await fireEvent.click(document.querySelector(".edit-mode-btn"));
     await waitFor(() => {
       expect(document.querySelector(".cm-editor")).toBeInTheDocument();
     });
   });
 
-  test("edit mode shows complete button", async () => {
+  test("edit mode shows read mode switch", async () => {
     render(Memo, { props: { saveMemo, content: "hello" } });
-    await fireEvent.click(document.querySelector(".preview-mode"));
+    await fireEvent.click(document.querySelector(".edit-mode-btn"));
     await waitFor(() => {
-      expect(document.querySelector(".done-btn")).toBeInTheDocument();
+      expect(document.querySelector(".read-mode-btn")).toBeInTheDocument();
     });
   });
 
-  test("clicking complete returns to view mode", async () => {
+  test("clicking read mode switch returns to view mode", async () => {
     render(Memo, { props: { saveMemo, content: "hello" } });
-    await fireEvent.click(document.querySelector(".preview-mode"));
-    await waitFor(() => expect(document.querySelector(".done-btn")).toBeInTheDocument());
+    await fireEvent.click(document.querySelector(".edit-mode-btn"));
+    await waitFor(() => expect(document.querySelector(".read-mode-btn")).toBeInTheDocument());
 
-    await fireEvent.click(document.querySelector(".done-btn"));
+    await fireEvent.click(document.querySelector(".read-mode-btn"));
     await tick();
 
     expect(document.querySelector(".cm-editor")).not.toBeInTheDocument();
@@ -142,12 +142,12 @@ describe("Memo - edit mode", () => {
     vi.useRealTimers();
   });
 
-  test("clicking complete without changes does not call saveMemo", async () => {
+  test("switching back to read mode without changes does not call saveMemo", async () => {
     render(Memo, { props: { saveMemo, content: "hello" } });
-    await fireEvent.click(document.querySelector(".preview-mode"));
-    await waitFor(() => expect(document.querySelector(".done-btn")).toBeInTheDocument());
+    await fireEvent.click(document.querySelector(".edit-mode-btn"));
+    await waitFor(() => expect(document.querySelector(".read-mode-btn")).toBeInTheDocument());
 
-    await fireEvent.click(document.querySelector(".done-btn"));
+    await fireEvent.click(document.querySelector(".read-mode-btn"));
     await tick();
 
     expect(saveMemo).not.toHaveBeenCalled();
@@ -170,7 +170,7 @@ describe("Memo - edit mode", () => {
       },
     });
 
-    await fireEvent.click(document.querySelector(".preview-mode"));
+    await fireEvent.click(document.querySelector(".edit-mode-btn"));
     await waitFor(() => {
       expect(document.querySelector(".cm-editor")).toBeInTheDocument();
     });
@@ -220,7 +220,7 @@ describe("Memo - edit mode", () => {
       },
     });
 
-    await fireEvent.click(document.querySelector(".preview-mode"));
+    await fireEvent.click(document.querySelector(".edit-mode-btn"));
     await waitFor(() => {
       expect(document.querySelector(".cm-editor")).toBeInTheDocument();
     });
@@ -310,11 +310,10 @@ describe("Memo - link handling in preview", () => {
     expect(window.electronAPI.openExternalLink).toHaveBeenCalledWith("https://example.com/");
   });
 
-  test("clicking non-link area enters edit mode", async () => {
+  test("clicking non-link preview area stays in read mode", async () => {
     render(Memo, { props: { saveMemo, content: "plain text" } });
     await fireEvent.click(document.querySelector(".preview-mode"));
-    await waitFor(() => {
-      expect(document.querySelector(".cm-editor")).toBeInTheDocument();
-    });
+    await tick();
+    expect(document.querySelector(".cm-editor")).not.toBeInTheDocument();
   });
 });

--- a/tests/component/TaskDetail.test.js
+++ b/tests/component/TaskDetail.test.js
@@ -82,9 +82,9 @@ describe("TaskDetail", () => {
     await fireEvent.click(buttons[0]);
     await tick();
 
-    expect(screen.getByDisplayValue("memo")).toBeInTheDocument();
+    expect(screen.getByDisplayValue("Note")).toBeInTheDocument();
     expect(get(tree_data).data.children[0].data.memo).toEqual([
-      expect.objectContaining({ title: "memo", content: "" }),
+      expect.objectContaining({ title: "Note", content: "" }),
     ]);
   });
 
@@ -97,10 +97,8 @@ describe("TaskDetail", () => {
     const { container } = render(TaskDetail);
 
     const buttons = container.querySelectorAll(".memotab-control button");
-    await fireEvent.click(buttons[1]);
-    expect(
-      screen.getByText((content) => content.includes("Do you really delete"))
-    ).toBeInTheDocument();
+    await fireEvent.click(buttons[2]);
+    expect(screen.getByText('Delete "draft"?')).toBeInTheDocument();
 
     await fireEvent.click(screen.getByRole("button", { name: "ok" }));
     await tick();
@@ -116,9 +114,9 @@ describe("TaskDetail", () => {
     await fireEvent.click(screen.getByRole("button", { name: "Create first note" }));
     await tick();
 
-    expect(screen.getByDisplayValue("memo")).toBeInTheDocument();
+    expect(screen.getByDisplayValue("Note")).toBeInTheDocument();
     expect(get(tree_data).data.children[0].data.memo).toEqual([
-      expect.objectContaining({ title: "memo", content: "" }),
+      expect.objectContaining({ title: "Note", content: "" }),
     ]);
   });
 
@@ -133,13 +131,13 @@ describe("TaskDetail", () => {
 
     render(TaskDetail);
 
-    await fireEvent.click(screen.getByDisplayValue("notes").closest("button"));
-    expect(screen.getByDisplayValue("notes").closest("button")).toHaveClass("selected");
+    await fireEvent.click(screen.getByRole("button", { name: "Select memo notes" }));
+    expect(screen.getByRole("button", { name: "Select memo notes" })).toHaveClass("selected");
 
     table_selected_id.set("task-2");
     await tick();
 
-    expect(screen.getByDisplayValue("review").closest("button")).toHaveClass("selected");
+    expect(screen.getByRole("button", { name: "Select memo review" })).toHaveClass("selected");
   });
 
   test("shows empty content after switching from existing memo to new empty memo and back", async () => {
@@ -157,19 +155,19 @@ describe("TaskDetail", () => {
     await fireEvent.click(addButton);
     await tick();
 
-    // Now on the new empty memo (index 1) - verify "memo" tab is selected
-    expect(screen.getByDisplayValue("memo").closest("button")).toHaveClass("selected");
+    // Now on the new empty memo (index 1) - verify "Note" tab is selected
+    expect(screen.getByDisplayValue("Note").closest("button")).toHaveClass("selected");
 
     // Switch to existing memo (index 0)
-    await fireEvent.click(screen.getByDisplayValue("existing").closest("button"));
+    await fireEvent.click(screen.getByRole("button", { name: "Select memo existing" }));
     await tick();
-    expect(screen.getByDisplayValue("existing").closest("button")).toHaveClass("selected");
+    expect(screen.getByRole("button", { name: "Select memo existing" })).toHaveClass("selected");
 
     // Switch back to the empty memo (index 1)
-    await fireEvent.click(screen.getByDisplayValue("memo").closest("button"));
+    await fireEvent.click(screen.getByRole("button", { name: "Select memo Note" }));
     await tick();
 
-    expect(screen.getByDisplayValue("memo").closest("button")).toHaveClass("selected");
+    expect(screen.getByRole("button", { name: "Select memo Note" })).toHaveClass("selected");
     // content should be empty string for the new empty memo
     expect(screen.getByTestId("memo-stub").textContent.trim()).toBe("");
   });


### PR DESCRIPTION
## Summary

This PR improves the memo experience by making editing an explicit mode switch instead of entering edit mode when the preview body is clicked.

## Changes

- Adds a visible Read / Edit mode switch to memo view and edit states.
- Keeps read-only memos in view mode and hides editing controls there.
- Shows a lightweight save status while editing.
- Separates memo tab selection from renaming, adds a rename icon action, and starts new notes as `Note`.
- Updates component tests for the new explicit edit flow and tab behavior.

## Validation

- `vitest run tests/component/Memo.test.js tests/component/TaskDetail.test.js --pool=threads` passed before branch creation.
- `svelte-check --tsconfig ./tsconfig.json` passed.
- `vite build` passed after rebasing the work onto current `origin/main`.

## Conflict Check

The branch was created from the latest `origin/main` (`bf0f7d5`), and the upstream changes did not touch the four memo files changed here.