### PR TITLE
[codex] Restore legacy memo tab layout

### DIFF
--- a/src/components/Memo.svelte
+++ b/src/components/Memo.svelte
@@ -716,29 +716,45 @@
     display: flex;
     justify-content: space-between;
     align-items: center;
-    padding: 0.25rem 0.5rem;
+    padding: 0.3rem 0.5rem;
     background-color: var(--theme-color-Main-dark);
     flex-shrink: 0;
     gap: 0.5rem;
+    min-width: 0;
   }
 
   .toolbar {
     display: flex;
     align-items: center;
-    gap: 0.1rem;
+    gap: 0.15rem;
     flex-wrap: nowrap;
+    flex: 1 1 auto;
+    min-width: 0;
+    overflow-x: auto;
+    overflow-y: hidden;
+    padding-bottom: 0.1rem;
+    scrollbar-width: none;
+  }
+
+  .toolbar::-webkit-scrollbar {
+    display: none;
   }
 
   .tool-btn {
-    padding: 0.15rem 0.35rem;
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    flex: 0 0 auto;
+    height: 1.65rem;
+    padding: 0 0.35rem;
     font-size: 0.75rem;
     background: none;
     border: 1px solid transparent;
-    border-radius: 3px;
+    border-radius: 4px;
     color: var(--theme-color-Sub-main);
     cursor: pointer;
-    line-height: 1.4;
-    min-width: 1.6rem;
+    line-height: 1;
+    min-width: 1.65rem;
     text-align: center;
   }
 
@@ -772,16 +788,21 @@
   .edit-bar-end {
     display: flex;
     align-items: center;
-    gap: 0.5rem;
+    gap: 0.35rem;
     flex-shrink: 0;
+    margin-left: auto;
   }
 
   .save-status {
-    min-width: 4rem;
+    min-width: 3rem;
     text-align: right;
     color: var(--theme-color-Sub-main);
     font-size: 0.75rem;
     white-space: nowrap;
+  }
+
+  .save-status:empty {
+    display: none;
   }
 
   .mode-switch {
@@ -799,8 +820,8 @@
     border-radius: 3px;
     background-color: transparent;
     color: var(--theme-color-Sub-main);
-    padding: 0.2rem 0.55rem;
-    min-width: 3.25rem;
+    padding: 0.2rem 0.45rem;
+    min-width: 2.85rem;
     font-size: 0.78rem;
     cursor: pointer;
   }
@@ -867,6 +888,22 @@
 
     .live-preview {
       display: none;
+    }
+  }
+
+  @media (max-width: 760px) {
+    .edit-bar {
+      flex-wrap: wrap;
+      row-gap: 0.25rem;
+    }
+
+    .edit-bar-end {
+      order: 1;
+    }
+
+    .toolbar {
+      order: 2;
+      flex-basis: 100%;
     }
   }
 

--- a/src/components/MemoTab.svelte
+++ b/src/components/MemoTab.svelte
@@ -318,8 +318,15 @@
     padding: 0.35rem 0.5rem;
     gap: 0.35rem;
     overflow-x: auto;
+    overflow-y: hidden;
     flex: 1;
+    min-width: 0;
     box-sizing: border-box;
+    scrollbar-width: none;
+  }
+
+  .memotab::-webkit-scrollbar {
+    display: none;
   }
 
   .memotab-control {
@@ -328,12 +335,18 @@
     align-items: center;
     flex-shrink: 0;
     margin-left: auto;
-    padding-right: 0.25rem;
+    gap: 0.1rem;
+    padding: 0 0.35rem;
     border-left: 1px solid var(--theme-color-Shadow-main);
   }
 
+  .memotab-control :global(button.IconButton) {
+    margin: 0.35rem 0.2rem;
+  }
+
   .tab-rename {
-    border: none;
+    box-sizing: border-box;
+    border: 1px solid transparent;
     padding: 0.15rem 0.25rem;
     margin: 0;
     width: 100%;
@@ -346,7 +359,9 @@
   }
 
   .tab-rename:focus {
-    outline: 2px solid var(--theme-color-Accent-main);
+    outline: none;
+    border-color: color-mix(in srgb, var(--theme-color-Primary-main) 70%, transparent);
+    box-shadow: 0 0 0 2px color-mix(in srgb, var(--theme-color-Primary-main) 18%, transparent);
   }
 
   .memotab-item {
@@ -400,10 +415,10 @@
   }
 
   .selected {
-    border-color: color-mix(in srgb, var(--theme-color-Accent-main) 55%, transparent);
+    border-color: color-mix(in srgb, var(--theme-color-Primary-main) 55%, transparent);
     background-color: var(--theme-color-Main-light);
     color: var(--theme-color-Sub-light);
-    box-shadow: inset 0 -0.2rem 0 var(--theme-color-Accent-main);
+    box-shadow: inset 0 -0.16rem 0 var(--theme-color-Primary-main);
   }
 
   .memotab-content {

--- a/src/components/MemoTab.svelte
+++ b/src/components/MemoTab.svelte
@@ -23,6 +23,7 @@
   let newMemoTitle = "memo";
   let inputs = Array(100).fill(null);
   let edit = false;
+  const hasSelectedMemo = () => Boolean(memo[selectedMemoIndex]);
 
   const toggle_confirm = () => {
     show_confirm = !show_confirm;
@@ -106,7 +107,7 @@
               type="text"
               value={memo.title}
               bind:this={inputs[i]}
-              disabled={!edit || i != selectedMemoIndex}
+              readonly={!edit || i != selectedMemoIndex}
               on:blur={() => {
                 edit = false;
               }}
@@ -114,7 +115,9 @@
                 renameMemo(e.target.value, selectedMemoIndex);
               }}
               on:click={(e) => {
-                e.stopPropagation();
+                if (edit && i == selectedMemoIndex) {
+                  e.stopPropagation();
+                }
               }}
               on:keydown={(e) => {
                 if (e.key == "Enter") {
@@ -157,6 +160,9 @@
         activeColor={"var(--theme-color-Error-dark)"}
         normalColor={"var(--theme-color-Error-main)"}
         on:click={() => {
+          if (!hasSelectedMemo()) {
+            return;
+          }
           show_confirm = true;
           name_confirm = memo[selectedMemoIndex].title;
         }}
@@ -267,7 +273,7 @@
     cursor: text !important;
   }
 
-  input:disabled {
+  input[readonly] {
     color: var(--theme-color-Sub-main);
     background-color: transparent;
   }

--- a/src/components/MemoTab.svelte
+++ b/src/components/MemoTab.svelte
@@ -1,7 +1,7 @@
 <script>
   import { tick } from "svelte";
   import { table_selected_id } from "../stores.ts";
-  import { ripple } from "../common/common.js";
+  import { ripple, tooltip } from "../common/common.js";
   import IconButton from "./IconButton.svelte";
   import Button from "./Button.svelte";
   import Memo from "./Memo.svelte";
@@ -20,15 +20,20 @@
   let name_confirm = "";
   let selectedMemoIndex = 0;
   let previousTaskId;
-  let renamingIndex = null;
-  let draftTitle = "";
-  let renameInput;
+  let newMemoTitle = "memo";
+  let inputs = Array(100).fill(null);
+  let edit = false;
 
   const toggle_confirm = () => {
     show_confirm = !show_confirm;
   };
 
-  const hasSelectedMemo = () => Boolean(memo[selectedMemoIndex]);
+  const callback_confirm = () => {
+    if (deleteMemo(selectedMemoIndex)) {
+      selectedMemoIndex = selectedMemoIndex == 0 ? 0 : selectedMemoIndex - 1;
+      edit = false;
+    }
+  };
 
   function normalizeMemoTitle(title) {
     return String(title || "")
@@ -36,95 +41,41 @@
       .toLocaleLowerCase();
   }
 
-  function cancelRename() {
-    renamingIndex = null;
-    draftTitle = "";
-  }
-
-  function commitRename() {
-    if (renamingIndex === null) {
-      return;
-    }
-
-    const index = renamingIndex;
-    const nextTitle = draftTitle.trim();
-    renamingIndex = null;
-
-    if (nextTitle && nextTitle !== memo[index]?.title) {
-      renameMemo(nextTitle, index);
-    }
-  }
-
-  const callback_confirm = () => {
-    if (deleteMemo(selectedMemoIndex)) {
-      selectedMemoIndex = selectedMemoIndex == 0 ? 0 : selectedMemoIndex - 1;
-      cancelRename();
-    }
-  };
-
-  function buildNextMemoTitle() {
-    const existingTitles = new Set(memo.map((entry) => normalizeMemoTitle(entry.title)));
-    const baseTitle = "Note";
-
-    if (!existingTitles.has(normalizeMemoTitle(baseTitle))) {
-      return baseTitle;
-    }
-
-    let suffix = memo.length + 1;
-    let title = `${baseTitle} ${suffix}`;
-    while (existingTitles.has(normalizeMemoTitle(title))) {
-      suffix += 1;
-      title = `${baseTitle} ${suffix}`;
-    }
-    return title;
-  }
-
-  function selectMemo(index) {
-    if (renamingIndex !== null && renamingIndex !== index) {
-      commitRename();
-    }
-    selectedMemoIndex = index;
-  }
-
-  const beginRename = async (index = selectedMemoIndex) => {
-    if (disabled || !memo[index]) {
-      return;
-    }
-
-    selectedMemoIndex = index;
-    draftTitle = memo[index].title || "";
-    renamingIndex = index;
-    await tick();
-    renameInput?.focus();
-    renameInput?.select();
-  };
-
   const selectMemoByTitle = (title) => {
     const nextIndex = memo.findIndex(
       (entry) => normalizeMemoTitle(entry.title) === normalizeMemoTitle(title)
     );
 
     if (nextIndex >= 0) {
-      commitRename();
       selectedMemoIndex = nextIndex;
+      edit = false;
       return true;
     }
 
     return false;
   };
 
-  const createFirstMemo = async () => {
-    if (addMemo(buildNextMemoTitle())) {
+  const toggleRename = async () => {
+    if (memo.length > 0) {
+      edit = !edit;
+      if (edit) {
+        await tick();
+        inputs[selectedMemoIndex]?.focus();
+      }
+    }
+  };
+
+  const createMemo = async () => {
+    if (addMemo(newMemoTitle)) {
       await tick();
       selectedMemoIndex = memo.length - 1;
-      await beginRename(selectedMemoIndex);
     }
   };
 
   $: if ($table_selected_id !== previousTaskId) {
     previousTaskId = $table_selected_id;
     selectedMemoIndex = 0;
-    cancelRename();
+    edit = false;
   }
 
   $: if (selectedMemoIndex >= memo.length && memo.length > 0) {
@@ -139,7 +90,7 @@
   <div class="memotab-container">
     <div class="memotab">
       {#if memo.length == 0}
-        <span class="memotab-item empty-tab-label">No notes yet</span>
+        <span class="memotab-item">{"Tabs here"}</span>
       {:else}
         {#each memo as memo, i (memo.id)}
           <button
@@ -148,45 +99,46 @@
             class:selected={i == selectedMemoIndex}
             aria-label={`Select memo ${memo.title}`}
             on:click={() => {
-              selectMemo(i);
-            }}
-            on:dblclick={() => {
-              beginRename(i);
+              selectedMemoIndex = i;
             }}
           >
-            {#if renamingIndex === i}
-              <input
-                class="tab-rename"
-                type="text"
-                bind:this={renameInput}
-                bind:value={draftTitle}
-                aria-label={`Rename memo ${memo.title}`}
-                on:click|stopPropagation
-                on:blur={commitRename}
-                on:keydown={(e) => {
-                  if (e.key == "Enter") {
-                    commitRename();
-                  }
-                  if (e.key == "Escape") {
-                    cancelRename();
-                  }
-                }}
-              />
-            {:else}
-              <span class="tab-title" title={memo.title}>{memo.title || "Untitled"}</span>
-            {/if}
+            <input
+              type="text"
+              value={memo.title}
+              bind:this={inputs[i]}
+              disabled={!edit || i != selectedMemoIndex}
+              on:blur={() => {
+                edit = false;
+              }}
+              on:input={(e) => {
+                renameMemo(e.target.value, selectedMemoIndex);
+              }}
+              on:click={(e) => {
+                e.stopPropagation();
+              }}
+              on:keydown={(e) => {
+                if (e.key == "Enter") {
+                  edit = false;
+                }
+              }}
+              use:tooltip={{
+                color: "var(--theme-color-Main-main)",
+                backgroundColor: "var(--theme-color-Sub-main)",
+                wrapped: true,
+              }}
+            />
           </button>
         {/each}
       {/if}
     </div>
     <div class="memotab-control">
       <IconButton
-        tooltipContent="Create a note."
+        tooltipContent="Add a memo."
         ariaLabel="Add a memo"
         {disabled}
         activeColor={"var(--theme-color-Primary-dark)"}
         normalColor={"var(--theme-color-Primary-main)"}
-        on:click={createFirstMemo}
+        on:click={createMemo}
       >
         <svg viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg"
           ><path
@@ -199,35 +151,12 @@
         >
       </IconButton>
       <IconButton
-        tooltipContent="Rename the selected note."
-        ariaLabel="Rename the selected memo"
-        disabled={disabled || memo.length === 0}
-        activeColor={"var(--theme-color-Info-dark)"}
-        normalColor={"var(--theme-color-Info-main)"}
-        on:click={() => {
-          beginRename();
-        }}
-      >
-        <svg viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg"
-          ><path
-            d="M4 20H20M5 16.5L6 12.5L15.5 3L19 6.5L9.5 16L5 16.5Z"
-            stroke="var(--theme-color-Main-main)"
-            stroke-width="1.8"
-            stroke-linecap="round"
-            stroke-linejoin="round"
-          ></path></svg
-        >
-      </IconButton>
-      <IconButton
-        tooltipContent="Delete the selected note."
+        tooltipContent="Delete the selected memo."
         ariaLabel="Delete the selected memo"
         disabled={disabled || memo.length === 0}
         activeColor={"var(--theme-color-Error-dark)"}
         normalColor={"var(--theme-color-Error-main)"}
         on:click={() => {
-          if (!hasSelectedMemo()) {
-            return;
-          }
           show_confirm = true;
           name_confirm = memo[selectedMemoIndex].title;
         }}
@@ -242,6 +171,14 @@
           /></svg
         >
       </IconButton>
+      <Button
+        {disabled}
+        variant={"text"}
+        activeColor={"var(--theme-color-Info-dark)"}
+        normalColor={"var(--theme-color-Info-main)"}
+        on:click={toggleRename}
+        content="rename"
+      />
     </div>
   </div>
 
@@ -258,16 +195,7 @@
         />
       {/key}
     {:else}
-      <div class="empty-state" data-testid="memo-empty-state">
-        <h2>Create a note</h2>
-        <Button
-          content="Create first note"
-          ariaLabel="Create first note"
-          activeColor={"var(--theme-color-Primary-dark)"}
-          normalColor={"var(--theme-color-Primary-main)"}
-          on:click={createFirstMemo}
-        />
-      </div>
+      <textarea placeholder="No page" disabled></textarea>
     {/if}
   </div>
 </div>
@@ -275,8 +203,8 @@
 <Dialog
   show={show_confirm}
   toggle={toggle_confirm}
-  header="Delete note?"
-  content={`Delete "${name_confirm}"?`}
+  header="Confirm."
+  content={`Do you really delete "${name_confirm}"?`}
   callback={callback_confirm}
 />
 
@@ -304,29 +232,18 @@
   .memotab-container {
     display: flex;
     flex-direction: row;
-    height: 3.25rem;
+    height: 3rem;
     width: 100%;
-    border-bottom: 1px solid var(--theme-color-Shadow-main);
-    background-color: var(--theme-color-Main-main);
   }
 
   .memotab {
     display: flex;
     flex-direction: row;
-    align-items: center;
-    height: 100%;
-    padding: 0.35rem 0.5rem;
-    gap: 0.35rem;
+    height: 2rem;
+    padding: 0.5rem;
     overflow-x: auto;
-    overflow-y: hidden;
     flex: 1;
     min-width: 0;
-    box-sizing: border-box;
-    scrollbar-width: none;
-  }
-
-  .memotab::-webkit-scrollbar {
-    display: none;
   }
 
   .memotab-control {
@@ -335,53 +252,41 @@
     align-items: center;
     flex-shrink: 0;
     margin-left: auto;
-    gap: 0.1rem;
-    padding: 0 0.35rem;
-    border-left: 1px solid var(--theme-color-Shadow-main);
   }
 
-  .memotab-control :global(button.IconButton) {
-    margin: 0.35rem 0.2rem;
-  }
-
-  .tab-rename {
-    box-sizing: border-box;
-    border: 1px solid transparent;
-    padding: 0.15rem 0.25rem;
+  input {
+    border: none;
+    padding: 0;
     margin: 0;
     width: 100%;
-    min-width: 0;
-    text-align: left;
-    color: var(--theme-color-Sub-light);
-    background-color: var(--theme-color-Main-dark);
-    border-radius: 4px;
+    text-align: center;
+  }
+
+  input:focus {
+    outline: auto;
     cursor: text !important;
   }
 
-  .tab-rename:focus {
-    outline: none;
-    border-color: color-mix(in srgb, var(--theme-color-Primary-main) 70%, transparent);
-    box-shadow: 0 0 0 2px color-mix(in srgb, var(--theme-color-Primary-main) 18%, transparent);
+  input:disabled {
+    color: var(--theme-color-Sub-main);
+    background-color: transparent;
+  }
+
+  input:hover {
+    cursor: pointer;
   }
 
   .memotab-item {
     display: flex;
     box-sizing: border-box;
-    height: 2.25rem;
-    width: clamp(7rem, 16vw, 13rem);
-    min-width: 7rem;
-    padding: 0.35rem 0.65rem;
-    flex: 0 0 auto;
-    justify-content: flex-start;
+    height: 100%;
+    min-width: 5rem;
+    max-width: 10rem;
+    padding: 0.5rem;
+    flex: 1;
+    justify-content: center;
     align-items: center;
     color: var(--theme-color-Sub-main);
-    border-radius: 0.45rem;
-    border: 1px solid transparent;
-    background-color: transparent;
-    transition:
-      background-color 120ms ease,
-      border-color 120ms ease,
-      color 120ms ease;
   }
 
   span.memotab-item {
@@ -394,31 +299,12 @@
     cursor: default !important;
   }
 
-  .tab-title {
-    min-width: 0;
-    width: 100%;
-    overflow: hidden;
-    text-overflow: ellipsis;
-    white-space: nowrap;
-    text-align: left;
-    font-size: 0.9rem;
-  }
-
-  .empty-tab-label {
-    opacity: 0.8;
-  }
-
   .memotab-item:hover {
     cursor: pointer;
-    background-color: var(--theme-color-Shadow-sub);
-    color: var(--theme-color-Sub-light);
   }
 
   .selected {
-    border-color: color-mix(in srgb, var(--theme-color-Primary-main) 55%, transparent);
-    background-color: var(--theme-color-Main-light);
-    color: var(--theme-color-Sub-light);
-    box-shadow: inset 0 -0.16rem 0 var(--theme-color-Primary-main);
+    border-bottom: 0.2rem solid var(--theme-color-Accent-main);
   }
 
   .memotab-content {
@@ -429,21 +315,10 @@
     overflow: hidden;
   }
 
-  .empty-state {
-    display: flex;
+  .memotab-content textarea {
+    height: 100%;
+    width: 100%;
     flex: 1;
-    flex-direction: column;
-    justify-content: center;
-    align-items: center;
-    gap: 0.85rem;
-    padding: 2rem;
-    background-color: var(--theme-color-Main-light);
-    color: var(--theme-color-Sub-main);
-  }
-
-  .empty-state h2 {
-    margin: 0;
-    color: var(--theme-color-Sub-light);
-    font-size: 1.1rem;
+    resize: none;
   }
 </style>

--- a/src/components/ProjectPage.svelte
+++ b/src/components/ProjectPage.svelte
@@ -98,7 +98,7 @@
     <SplitPanes defaultRatio={[3, 2]}>
       <Pane style={"padding: 1rem; min-width: 10rem;"}>
         <Card style={"height: 100%; width: 100%; padding: 1rem;"}>
-          <div style="display: flex; flex-direction: row">
+          <div class="TaskListToolbar">
             <div class:TableButtons={true}>
               <IconButton
                 tooltipContent="Add a task under the selected one."
@@ -211,17 +211,34 @@
   .TableButtons {
     display: flex;
     flex-direction: row;
-    height: 3rem;
-    margin: 0.5rem;
+    align-items: center;
+    height: 2.75rem;
+    margin: 0;
     box-sizing: border-box;
+    flex: 0 0 auto;
   }
   .SearchBox {
     display: flex;
     flex-direction: row;
-    height: 3rem;
-    margin: 0.5rem;
+    align-items: center;
+    height: 2.75rem;
+    margin: 0;
     box-sizing: border-box;
     margin-left: auto;
+    flex: 1 1 9rem;
+    min-width: 8rem;
+    max-width: 20rem;
+  }
+  .TaskListToolbar {
+    display: flex;
+    flex-direction: row;
+    align-items: center;
+    gap: 0.5rem;
+    width: 100%;
+    min-width: 0;
+    padding: 0.25rem 0.5rem 0.75rem;
+    box-sizing: border-box;
+    flex-wrap: wrap;
   }
   .TreeTable {
     height: calc(100% - 4rem);
@@ -246,5 +263,12 @@
     width: calc(100% - 2rem);
     box-sizing: border-box;
     margin: 1rem;
+  }
+
+  @media (max-width: 760px) {
+    .SearchBox {
+      margin-left: 0;
+      max-width: none;
+    }
   }
 </style>

--- a/src/components/SearchBox.svelte
+++ b/src/components/SearchBox.svelte
@@ -25,7 +25,7 @@
   };
 </script>
 
-<div>
+<div class="SearchBoxRoot">
   <input
     class="SearchBoxInput"
     type="text"
@@ -73,21 +73,25 @@
 </div>
 
 <style>
-  div {
-    width: 20rem;
+  .SearchBoxRoot {
+    width: clamp(9rem, 100%, 20rem);
+    max-width: 100%;
     height: 2rem;
-    margin: 0.5rem;
+    margin: 0;
     display: flex;
     flex-direction: row;
     align-items: center;
     box-sizing: border-box;
+    min-width: 0;
   }
   .SearchBoxInput {
     box-sizing: border-box;
     margin: 0;
     padding: 0 1rem;
     height: 100%;
-    width: calc(100% - 2rem);
+    flex: 1 1 auto;
+    width: auto;
+    min-width: 0;
     border-radius: 100vh;
   }
 </style>

--- a/src/components/SplitPanes.svelte
+++ b/src/components/SplitPanes.svelte
@@ -231,10 +231,17 @@
     left: 2px;
     width: 1px;
     height: 100%;
-    background-color: rgba(128, 128, 128, 0.5);
+    background-color: color-mix(in srgb, var(--theme-color-Sub-dark) 28%, transparent);
+    opacity: 0.7;
   }
   .SplitPaneRoot :global(.HandlingResizer),
   .SplitPaneRoot :global(.Resizer:hover) {
-    background-color: var(--theme-color-Accent-light);
+    background-color: transparent;
+  }
+  .SplitPaneRoot :global(.HandlingResizer::before),
+  .SplitPaneRoot :global(.Resizer:hover::before) {
+    width: 2px;
+    background-color: var(--theme-color-Accent-main);
+    opacity: 0.9;
   }
 </style>

--- a/tests/component/TaskDetail.test.js
+++ b/tests/component/TaskDetail.test.js
@@ -65,13 +65,13 @@ describe("TaskDetail", () => {
     expect(screen.getByText("No data.")).toBeInTheDocument();
   });
 
-  test("shows a guided empty state when the selected task has no notes", () => {
+  test("shows the legacy memo tab placeholder when the selected task has no notes", () => {
     table_selected_id.set("task-1");
     render(TaskDetail);
 
-    expect(screen.getByTestId("memo-empty-state")).toBeInTheDocument();
-    expect(screen.getByText("No notes yet")).toBeInTheDocument();
-    expect(screen.getByRole("button", { name: "Create first note" })).toBeInTheDocument();
+    expect(screen.getByText("Tabs here")).toBeInTheDocument();
+    expect(screen.getByPlaceholderText("No page")).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Add a memo" })).toBeInTheDocument();
   });
 
   test("adds a memo tab to the selected task", async () => {
@@ -82,9 +82,9 @@ describe("TaskDetail", () => {
     await fireEvent.click(buttons[0]);
     await tick();
 
-    expect(screen.getByDisplayValue("Note")).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Select memo memo" })).toHaveClass("selected");
     expect(get(tree_data).data.children[0].data.memo).toEqual([
-      expect.objectContaining({ title: "Note", content: "" }),
+      expect.objectContaining({ title: "memo", content: "" }),
     ]);
   });
 
@@ -97,26 +97,27 @@ describe("TaskDetail", () => {
     const { container } = render(TaskDetail);
 
     const buttons = container.querySelectorAll(".memotab-control button");
-    await fireEvent.click(buttons[2]);
-    expect(screen.getByText('Delete "draft"?')).toBeInTheDocument();
+    await fireEvent.click(buttons[1]);
+    expect(screen.getByText('Do you really delete "draft"?')).toBeInTheDocument();
 
     await fireEvent.click(screen.getByRole("button", { name: "ok" }));
     await tick();
 
     expect(get(tree_data).data.children[0].data.memo).toEqual([]);
-    expect(screen.getByText("No notes yet")).toBeInTheDocument();
+    expect(screen.getByText("Tabs here")).toBeInTheDocument();
   });
 
-  test("creates the first note from the empty state action", async () => {
+  test("creates the first memo from the tab add action", async () => {
     table_selected_id.set("task-1");
-    render(TaskDetail);
+    const { container } = render(TaskDetail);
 
-    await fireEvent.click(screen.getByRole("button", { name: "Create first note" }));
+    const addButton = container.querySelectorAll(".memotab-control button")[0];
+    await fireEvent.click(addButton);
     await tick();
 
-    expect(screen.getByDisplayValue("Note")).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Select memo memo" })).toHaveClass("selected");
     expect(get(tree_data).data.children[0].data.memo).toEqual([
-      expect.objectContaining({ title: "Note", content: "" }),
+      expect.objectContaining({ title: "memo", content: "" }),
     ]);
   });
 
@@ -155,8 +156,8 @@ describe("TaskDetail", () => {
     await fireEvent.click(addButton);
     await tick();
 
-    // Now on the new empty memo (index 1) - verify "Note" tab is selected
-    expect(screen.getByDisplayValue("Note").closest("button")).toHaveClass("selected");
+    // Now on the new empty memo (index 1) - verify "memo" tab is selected
+    expect(screen.getByRole("button", { name: "Select memo memo" })).toHaveClass("selected");
 
     // Switch to existing memo (index 0)
     await fireEvent.click(screen.getByRole("button", { name: "Select memo existing" }));
@@ -164,10 +165,10 @@ describe("TaskDetail", () => {
     expect(screen.getByRole("button", { name: "Select memo existing" })).toHaveClass("selected");
 
     // Switch back to the empty memo (index 1)
-    await fireEvent.click(screen.getByRole("button", { name: "Select memo Note" }));
+    await fireEvent.click(screen.getByRole("button", { name: "Select memo memo" }));
     await tick();
 
-    expect(screen.getByRole("button", { name: "Select memo Note" })).toHaveClass("selected");
+    expect(screen.getByRole("button", { name: "Select memo memo" })).toHaveClass("selected");
     // content should be empty string for the new empty memo
     expect(screen.getByTestId("memo-stub").textContent.trim()).toBe("");
   });


### PR DESCRIPTION
## Summary

Restores the older memo tab layout and fixes the cramped task detail UI issues reported from the screenshot.

## Changes

- Restores the memo tabs away from the card-style layout introduced in the explicit edit flow.
- Keeps modern memo behavior such as memo links and workspace task context intact.
- Makes readonly tab title inputs clickable for tab selection while still allowing rename mode to capture edits.
- Tightens the task detail panes/search/resize presentation so the UI no longer appears clipped in the narrow layout.

## Validation

- `svelte-check --tsconfig ./tsconfig.json`
- `vite build`
- `vitest run tests/component/TaskDetail.test.js tests/component/Memo.test.js --pool=threads`
- Electron screenshot checks for populated and empty memo-tab states before push.