### PR TITLE
[codex] restore legacy tabs and disabled name fields

### DIFF
--- a/src/components/MemoTab.svelte
+++ b/src/components/MemoTab.svelte
@@ -107,7 +107,7 @@
               type="text"
               value={memo.title}
               bind:this={inputs[i]}
-              readonly={!edit || i != selectedMemoIndex}
+              disabled={!edit || i != selectedMemoIndex}
               on:blur={() => {
                 edit = false;
               }}
@@ -178,7 +178,7 @@
         >
       </IconButton>
       <Button
-        {disabled}
+        disabled={disabled || memo.length === 0}
         variant={"text"}
         activeColor={"var(--theme-color-Info-dark)"}
         normalColor={"var(--theme-color-Info-main)"}
@@ -249,7 +249,6 @@
     padding: 0.5rem;
     overflow-x: auto;
     flex: 1;
-    min-width: 0;
   }
 
   .memotab-control {
@@ -261,7 +260,10 @@
   }
 
   input {
+    appearance: none;
+    background: transparent;
     border: none;
+    color: var(--theme-color-Sub-main);
     padding: 0;
     margin: 0;
     width: 100%;
@@ -273,9 +275,12 @@
     cursor: text !important;
   }
 
-  input[readonly] {
+  input:disabled {
     color: var(--theme-color-Sub-main);
+    -webkit-text-fill-color: var(--theme-color-Sub-main);
     background-color: transparent;
+    opacity: 1;
+    pointer-events: none;
   }
 
   input:hover {
@@ -316,8 +321,8 @@
   .memotab-content {
     display: flex;
     box-sizing: border-box;
+    height: calc(100% - 5.5rem);
     flex: 1;
-    min-height: 0;
     overflow: hidden;
   }
 

--- a/src/components/TaskName.svelte
+++ b/src/components/TaskName.svelte
@@ -297,8 +297,7 @@
     type="text"
     bind:this={input}
     value={draftText}
-    readonly={!isEditing}
-    aria-readonly={!isEditing}
+    disabled={!isEditing}
     draggable="true"
     class:hidden-by-highlight={highlightParts}
     on:blur={() => {
@@ -433,21 +432,27 @@
     display: none;
   }
   input {
+    appearance: none;
+    background-color: var(--backgroundColor);
     border: none;
+    color: var(--color);
     padding: 0;
     margin: 0;
     width: 100%;
     position: relative;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
   }
   input:focus-visible {
     outline: auto;
   }
-  input[readonly] {
+  input:disabled {
     background-color: var(--backgroundColor);
     color: var(--color);
-    overflow: hidden;
-    text-overflow: ellipsis;
-    white-space: nowrap;
+    -webkit-text-fill-color: var(--color);
+    opacity: 1;
+    pointer-events: none;
   }
   button {
     height: calc(100% - 0.5rem);

--- a/tests/component/TaskName.test.js
+++ b/tests/component/TaskName.test.js
@@ -4,14 +4,14 @@ import TaskNameClickHarness from "../mocks/TaskNameClickHarness.svelte";
 import TaskNameCommitHarness from "../mocks/TaskNameCommitHarness.svelte";
 
 describe("TaskName", () => {
-  test("allows click on read-only input to bubble to row selection handler", async () => {
+  test("keeps the task name disabled until editing while row clicks still select", async () => {
     render(TaskNameClickHarness);
 
     const input = screen.getByDisplayValue("Task 1");
-    expect(input).not.toBeDisabled();
-    expect(input).toHaveAttribute("readonly");
+    expect(input).toBeDisabled();
+    expect(input).not.toHaveAttribute("readonly");
 
-    await fireEvent.click(input);
+    await fireEvent.click(screen.getByTestId("row"));
 
     expect(screen.getByTestId("count")).toHaveTextContent("1");
   });
@@ -20,6 +20,7 @@ describe("TaskName", () => {
     async function enterEditingMode() {
       const editButton = screen.getByRole("button", { name: /edit task name/i });
       await fireEvent.click(editButton);
+      expect(screen.getByDisplayValue("Original")).not.toBeDisabled();
     }
 
     test("does not commit empty string on blur", async () => {


### PR DESCRIPTION
## Summary
- Restore the memo tab strip to the old flat sizing and underline selection style.
- Keep memo/task names visually stable by disabling their inputs outside edit mode while preserving text color and transparent background.
- Keep rename/delete guards when no memo is selected.

## Validation
- svelte-check --tsconfig ./tsconfig.json
- vite build
- vitest run tests/component/TaskName.test.js --pool=threads
- vitest run tests/component/TaskDetail.test.js tests/component/Memo.test.js --pool=threads