### PR TITLE
fix: カラム設定ボタンがカラムヘッダーと重なる問題を修正

### DIFF
--- a/src/components/TreeTableHeader.svelte
+++ b/src/components/TreeTableHeader.svelte
@@ -189,6 +189,7 @@
   }
   .TableHeader:last-of-type {
     border-right: 0px;
+    padding-right: 2rem;
   }
   .TableHeader:first-of-type {
     border-left: 0px;
@@ -202,8 +203,8 @@
   .ColumnSettingsBtn {
     position: absolute;
     top: 0;
+    bottom: 0;
     right: 0;
-    height: 4rem;
     width: 2rem;
     flex-shrink: 0;
     display: flex;


### PR DESCRIPTION
- 最右カラムヘッダーに padding-right: 2rem を追加し、ボタン下にテキストが
  隠れないようにした
- ColumnSettingsBtn の height: 4rem を top/bottom: 0 に変更し、
  rem のサブピクセル誤差による高さのズレを解消した

https://claude.ai/code/session_018QyJduSDYRV5SMYqif2g55