### PR TITLE
feat: 複数タスクdetailウィンドウの同時表示に対応

### DIFF
--- a/electron/index.js
+++ b/electron/index.js
@@ -238,7 +238,7 @@ app.on("ready", () => {
   });
 
   // 繧ｿ繧ｹ繧ｯ隧ｳ邏ｰ繧ｦ繧｣繝ｳ繝峨え縺ｮ螟画焚
-  let taskDetailWindow = null;
+  const taskDetailWindows = new Map(); // taskId -> BrowserWindow
 
   function bindFindInPageEvents(targetWebContents) {
     targetWebContents.on("found-in-page", (event, result) => {
@@ -365,11 +365,13 @@ app.on("ready", () => {
         taskName: detailData?.taskName ? String(detailData.taskName) : "Task Detail",
       };
 
-      if (taskDetailWindow && !taskDetailWindow.isDestroyed()) {
-        taskDetailWindow.close();
+      const existing = taskDetailWindows.get(safeDetailData.taskId);
+      if (existing && !existing.isDestroyed()) {
+        existing.focus();
+        return existing;
       }
 
-      taskDetailWindow = new BrowserWindow({
+      const win = new BrowserWindow({
         width: 960,
         height: 720,
         modal: false,
@@ -388,9 +390,9 @@ app.on("ready", () => {
 
       if (process.env.VITE_DEV === "true") {
         const params = new URLSearchParams(safeDetailData);
-        taskDetailWindow.loadURL(`http://localhost:5173/?${params.toString()}#task-detail-window`);
+        win.loadURL(`http://localhost:5173/?${params.toString()}#task-detail-window`);
       } else {
-        taskDetailWindow.loadFile(path.join(__dirname, "../renderer/index.html"), {
+        win.loadFile(path.join(__dirname, "../renderer/index.html"), {
           hash: "#task-detail-window",
           query: {
             projectId: safeDetailData.projectId,
@@ -400,36 +402,23 @@ app.on("ready", () => {
         });
       }
 
-      bindFindInPageEvents(taskDetailWindow.webContents);
+      bindFindInPageEvents(win.webContents);
+      taskDetailWindows.set(safeDetailData.taskId, win);
 
-      global.currentTaskDetailWindowData = safeDetailData;
-
-      taskDetailWindow.on("closed", () => {
-        taskDetailWindow = null;
-        global.currentTaskDetailWindowData = null;
+      win.on("closed", () => {
+        taskDetailWindows.delete(safeDetailData.taskId);
       });
 
       log.info(`Task detail window created for task: ${safeDetailData.taskId}`);
-      return taskDetailWindow;
+      return win;
     } catch (error) {
       log.error("Failed to create task detail window:", error);
       return null;
     }
   }
 
-  ipcMain.handle("get-task-detail-window-data", async () => {
-    return (
-      global.currentTaskDetailWindowData || {
-        projectId: "",
-        taskId: "",
-        taskName: "Task Detail",
-      }
-    );
-  });
-
   ipcMain.on("open-task-detail-window", async (_event, detailData) => {
     try {
-      global.currentTaskDetailWindowData = detailData;
       const window = createTaskDetailWindow(detailData);
 
       await new Promise((resolve) => setTimeout(resolve, 500));
@@ -454,9 +443,10 @@ app.on("ready", () => {
   }
   mainWindow.on("closed", () => {
     mainWindow = null;
-    if (taskDetailWindow && !taskDetailWindow.isDestroyed()) {
-      taskDetailWindow.destroy();
+    for (const win of taskDetailWindows.values()) {
+      if (!win.isDestroyed()) win.destroy();
     }
+    taskDetailWindows.clear();
   });
 
   ipcMain.handle("get-current-theme", async () => {

--- a/electron/preload.js
+++ b/electron/preload.js
@@ -27,9 +27,6 @@ const electronAPI = {
   openTaskDetailWindow: (detailData) => {
     ipcRenderer.send("open-task-detail-window", detailData);
   },
-  getTaskDetailWindowData: () => {
-    return ipcRenderer.invoke("get-task-detail-window-data");
-  },
   // 画面内検索機能 - シンプル実装
   findInPage: (text, options) => {
     return ipcRenderer.invoke("find-in-page", text, options);

--- a/src/App.svelte
+++ b/src/App.svelte
@@ -42,24 +42,17 @@
 
   async function initTaskDetailWindow() {
     try {
-      const detailData = await window.electronAPI?.getTaskDetailWindowData?.();
-      if (!detailData?.projectId || !detailData?.taskId) {
-        return;
-      }
+      if (!detailWindowProjectId || !detailWindowTaskId) return;
 
-      detailWindowProjectId = detailData.projectId;
-      detailWindowTaskId = detailData.taskId;
-      detailWindowTaskName = detailData.taskName || detailWindowTaskName;
       document.title = `${detailWindowTaskName} | Task Detail`;
+      setTaskDetailWindowTarget(detailWindowProjectId, detailWindowTaskId);
 
-      setTaskDetailWindowTarget(detailData.projectId, detailData.taskId);
-
-      const result = await window.electronAPI.getTreeData(detailData.projectId);
+      const result = await window.electronAPI.getTreeData(detailWindowProjectId);
       if (result) {
         tree_data.set(result);
         selected_type.set("Projects");
-        selected_id.set(detailData.projectId);
-        table_selected_id.set(detailData.taskId);
+        selected_id.set(detailWindowProjectId);
+        table_selected_id.set(detailWindowTaskId);
       }
     } catch {
       // ignore initialization error

--- a/src/types/app.ts
+++ b/src/types/app.ts
@@ -43,7 +43,6 @@ export interface ElectronAPI {
   message: (message: string) => void;
   openExternalLink: (url: string) => void;
   openTaskDetailWindow: (detailData: TaskDetailWindowData) => void;
-  getTaskDetailWindowData: () => Promise<TaskDetailWindowData>;
   findInPage: (text: string, options?: Record<string, unknown>) => Promise<FindInPageResult | void>;
   findInPageNext: (text: string) => Promise<void>;
   findInPagePrevious: (text: string) => Promise<FindInPageResult | void>;


### PR DESCRIPTION
- taskDetailWindow (単一変数) → taskDetailWindows (Map<taskId, BrowserWindow>) に変更
- 同じタスクIDのウィンドウが既に開いている場合はフォーカスして再利用
- global.currentTaskDetailWindowData および get-task-detail-window-data IPC を削除
- App.svelte の initTaskDetailWindow を URL params 直接参照に簡略化（競合リスク解消）
- mainWindow close 時に全 detail ウィンドウをまとめて破棄

https://claude.ai/code/session_01KJjBj1zkb8gQSV8azCmv2J