### PR TITLE
feat: タスクツリーの全展開・全折り畳みボタンを追加 (#85)

### DIFF
--- a/src/components/TreeTableHeader.svelte
+++ b/src/components/TreeTableHeader.svelte
@@ -72,10 +72,30 @@
             on:click={() => closed_node_ids.expandAll()}
           >
             <svg viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
-              <path d="M8 3H5a2 2 0 0 0-2 2v3" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
-              <path d="M21 8V5a2 2 0 0 0-2-2h-3" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
-              <path d="M3 16v3a2 2 0 0 0 2 2h3" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
-              <path d="M16 21h3a2 2 0 0 0 2-2v-3" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
+              <path
+                d="M8 3H5a2 2 0 0 0-2 2v3"
+                stroke-width="2"
+                stroke-linecap="round"
+                stroke-linejoin="round"
+              />
+              <path
+                d="M21 8V5a2 2 0 0 0-2-2h-3"
+                stroke-width="2"
+                stroke-linecap="round"
+                stroke-linejoin="round"
+              />
+              <path
+                d="M3 16v3a2 2 0 0 0 2 2h3"
+                stroke-width="2"
+                stroke-linecap="round"
+                stroke-linejoin="round"
+              />
+              <path
+                d="M16 21h3a2 2 0 0 0 2-2v-3"
+                stroke-width="2"
+                stroke-linecap="round"
+                stroke-linejoin="round"
+              />
             </svg>
           </button>
           <button
@@ -85,10 +105,30 @@
             on:click={() => closed_node_ids.collapseAll()}
           >
             <svg viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
-              <path d="M8 3v3a2 2 0 0 1-2 2H3" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
-              <path d="M21 8h-3a2 2 0 0 1-2-2V3" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
-              <path d="M3 16h3a2 2 0 0 1 2 2v3" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
-              <path d="M16 21v-3a2 2 0 0 1 2-2h3" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
+              <path
+                d="M8 3v3a2 2 0 0 1-2 2H3"
+                stroke-width="2"
+                stroke-linecap="round"
+                stroke-linejoin="round"
+              />
+              <path
+                d="M21 8h-3a2 2 0 0 1-2-2V3"
+                stroke-width="2"
+                stroke-linecap="round"
+                stroke-linejoin="round"
+              />
+              <path
+                d="M3 16h3a2 2 0 0 1 2 2v3"
+                stroke-width="2"
+                stroke-linecap="round"
+                stroke-linejoin="round"
+              />
+              <path
+                d="M16 21v-3a2 2 0 0 1 2-2h3"
+                stroke-width="2"
+                stroke-linecap="round"
+                stroke-linejoin="round"
+              />
             </svg>
           </button>
         </div>

--- a/src/components/TreeTableHeader.svelte
+++ b/src/components/TreeTableHeader.svelte
@@ -1,6 +1,7 @@
 <script>
   import { filter } from "../stores.ts";
   import { column_settings } from "../stores/column_settings.ts";
+  import { closed_node_ids } from "../stores/ui.ts";
   import MultiSelect from "./MultiSelect.svelte";
 
   export let headers;
@@ -60,6 +61,36 @@
             list={["Open", "Pending", "In Progress", "Completed", "Canceled"]}
             placeholder="No filter."
           />
+        </div>
+      {/if}
+      {#if header.name == "name"}
+        <div class="ExpandCollapseButtons">
+          <button
+            class="ExpandCollapseBtn"
+            aria-label="すべて展開"
+            title="すべて展開"
+            on:click={() => closed_node_ids.expandAll()}
+          >
+            <svg viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
+              <path d="M8 3H5a2 2 0 0 0-2 2v3" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
+              <path d="M21 8V5a2 2 0 0 0-2-2h-3" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
+              <path d="M3 16v3a2 2 0 0 0 2 2h3" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
+              <path d="M16 21h3a2 2 0 0 0 2-2v-3" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
+            </svg>
+          </button>
+          <button
+            class="ExpandCollapseBtn"
+            aria-label="すべて折り畳み"
+            title="すべて折り畳み"
+            on:click={() => closed_node_ids.collapseAll()}
+          >
+            <svg viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
+              <path d="M8 3v3a2 2 0 0 1-2 2H3" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
+              <path d="M21 8h-3a2 2 0 0 1-2-2V3" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
+              <path d="M3 16h3a2 2 0 0 1 2 2v3" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
+              <path d="M16 21v-3a2 2 0 0 1 2-2h3" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
+            </svg>
+          </button>
         </div>
       {/if}
     </div>
@@ -198,6 +229,36 @@
     text-overflow: ellipsis;
     overflow: hidden;
     white-space: nowrap;
+  }
+
+  .ExpandCollapseButtons {
+    display: flex;
+    gap: 0.15rem;
+    align-items: center;
+    padding: 0 0.3rem;
+  }
+  .ExpandCollapseBtn {
+    width: 1.4rem;
+    height: 1.4rem;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    background: transparent;
+    border: none;
+    cursor: pointer;
+    border-radius: 0.25rem;
+    padding: 0.2rem;
+    opacity: 0.5;
+    flex-shrink: 0;
+  }
+  .ExpandCollapseBtn:hover {
+    background-color: var(--theme-color-Accent-dark);
+    opacity: 1;
+  }
+  .ExpandCollapseBtn svg {
+    width: 100%;
+    height: 100%;
+    stroke: var(--theme-color-Main-light);
   }
 
   .ColumnSettingsBtn {

--- a/src/stores/ui.ts
+++ b/src/stores/ui.ts
@@ -36,6 +36,8 @@ export interface ClosedNodeIdsStore extends Writable<Set<string>> {
   add: (nodeId: string) => void;
   delete: (nodeId: string) => void;
   cleanupNodeMetadata: (nodeId: string) => void;
+  expandAll: () => void;
+  collapseAll: () => void;
 }
 
 function collectNodeAndDescendantIds(node: TreeData | undefined): string[] {
@@ -167,6 +169,25 @@ function createClosedNodeIds(initialValue: Set<string>): ClosedNodeIdsStore {
           }
         }
       });
+    },
+    expandAll: () => {
+      const projectId = get(selected_id);
+      if (!projectId) return;
+      const newState = new Set<string>();
+      projectExpandedStates.set(projectId, newState);
+      saveState(projectId, newState);
+      set(newState);
+    },
+    collapseAll: () => {
+      const projectId = get(selected_id);
+      if (!projectId) return;
+      const currentTreeData = get(tree_data);
+      if (!currentTreeData?.data) return;
+      const allIds = collectNodeAndDescendantIds(currentTreeData.data);
+      const newState = new Set<string>(allIds);
+      projectExpandedStates.set(projectId, newState);
+      saveState(projectId, newState);
+      set(newState);
     },
     cleanupNodeMetadata: (nodeId: string) => {
       const projectId = get(selected_id);


### PR DESCRIPTION
- closed_node_ids ストアに expandAll / collapseAll メソッドを追加
- TreeTableHeader の name カラムに全展開・全折り畳みアイコンボタンを配置
- 既存の永続化機構（プロジェクトごとの electron metadata）と整合

https://claude.ai/code/session_014deewhnq4oMU5XC8GzmXGi