### PR TITLE
feat: 期日継承表示とGanttチャートパネルを追加

### DIFF
--- a/src/common/tree_control.ts
+++ b/src/common/tree_control.ts
@@ -11,6 +11,7 @@ export interface MemoEntry {
 export interface TreeNodeData {
   name: string;
   status: TaskStatus;
+  "start date": `${string}-${string}-${string}` | undefined;
   "due date": `${string}-${string}-${string}` | undefined;
   memo: MemoEntry[];
   [key: string]: unknown;
@@ -127,6 +128,7 @@ export function getDefaultNode(): TreeData {
     data: {
       name: "new_task",
       status: "Open",
+      "start date": undefined,
       "due date": undefined,
       memo: [],
     },
@@ -146,6 +148,10 @@ export function getDefaultProject(): ProjectData {
         default_ratio: 4,
       },
       {
+        name: "start date",
+        default_ratio: 4,
+      },
+      {
         name: "due date",
         default_ratio: 4,
       },
@@ -159,6 +165,7 @@ export function getDefaultProject(): ProjectData {
       data: {
         name: "new_project",
         status: "Open",
+        "start date": undefined,
         "due date": undefined,
         memo: [],
       },
@@ -279,6 +286,24 @@ export function flattenVisibleTree(
   visit(tree_data, 0, undefined, 0, 1);
 
   return rows;
+}
+
+export function buildInheritedDueDateMap(rows: VisibleTreeRow[]): Map<string, string> {
+  const rowMap = new Map(rows.map((r) => [r.id, r]));
+  const result = new Map<string, string>();
+  for (const row of rows) {
+    if (row.node.data["due date"]) continue;
+    let cur = row.parentId ? rowMap.get(row.parentId) : undefined;
+    while (cur) {
+      const d = cur.node.data["due date"];
+      if (d) {
+        result.set(row.id, d);
+        break;
+      }
+      cur = cur.parentId ? rowMap.get(cur.parentId) : undefined;
+    }
+  }
+  return result;
 }
 
 export function getParent(base: string, tree_data: TreeData | undefined): TreeData | undefined {

--- a/src/common/workspace_tree.ts
+++ b/src/common/workspace_tree.ts
@@ -4,6 +4,7 @@ import type { ProjectData, TreeData } from "./tree_control";
 const DEFAULT_HEADERS = [
   { name: "name", default_ratio: 10 },
   { name: "status", default_ratio: 4 },
+  { name: "start date", default_ratio: 4 },
   { name: "due date", default_ratio: 4 },
   { name: "memo", default_ratio: 2 },
 ];
@@ -36,6 +37,7 @@ export function workspaceToProjectData(
       data: {
         name: task.name,
         status: task.status,
+        "start date": task.startDate as `${string}-${string}-${string}` | undefined,
         "due date": task.dueDate as `${string}-${string}-${string}` | undefined,
         memo: task.memos.map((m) => ({ id: m.id, title: m.title, content: m.content })),
       },
@@ -48,7 +50,13 @@ export function workspaceToProjectData(
       headers: DEFAULT_HEADERS,
       data: {
         id: rootId,
-        data: { name: "unknown", status: "Open", "due date": undefined, memo: [] },
+        data: {
+          name: "unknown",
+          status: "Open",
+          "start date": undefined,
+          "due date": undefined,
+          memo: [],
+        },
         children: [],
       },
     };
@@ -74,6 +82,7 @@ export function projectDataToWorkspaceTasks(
       id: node.id,
       name: node.data.name,
       status: (node.data.status as WorkspaceTaskStatus) || "Open",
+      startDate: node.data["start date"] || undefined,
       dueDate: node.data["due date"] || undefined,
       parents: parentIds,
       memos: (node.data.memo || []).map((m) => ({

--- a/src/components/DateInput.svelte
+++ b/src/components/DateInput.svelte
@@ -6,6 +6,8 @@
   export let value = "";
   export let id = "";
   export let style = "";
+  export let inheritedDate = "";
+
   const return_color = (value, default_value) => {
     const days = 5;
     const v = new Date(value);
@@ -18,22 +20,26 @@
     }
     return default_value;
   };
+
+  $: displayDate = value || inheritedDate || "";
+  $: isInherited = !value && !!inheritedDate;
+  $: borderColor = return_color(displayDate, backgroundColor);
+  $: inputTitle = isInherited ? `親タスクの期限: ${inheritedDate}` : undefined;
 </script>
 
 <div
   class="Container"
-  style="--dark:{is_dark ? 'dark' : ''}; --borderColor: {return_color(
-    value,
-    backgroundColor
-  )}; --color-datetime: {color};"
+  style="--dark:{is_dark ? 'dark' : ''}; --borderColor: {borderColor}; --color-datetime: {color};"
 >
   <input
     {style}
     class="Date"
+    class:Inherited={isInherited}
     {id}
     type="date"
     {disabled}
     {value}
+    title={inputTitle}
     on:change
     on:click={(e) => {
       e.stopPropagation();
@@ -60,6 +66,10 @@
     margin: 0;
     padding: 0;
     box-sizing: border-box;
+  }
+  .Date.Inherited {
+    opacity: 0.55;
+    border-style: dashed;
   }
   .Date::-webkit-calendar-picker-indicator {
     background-color: var(--backgroundColor);

--- a/src/components/GanttPanel.svelte
+++ b/src/components/GanttPanel.svelte
@@ -1,0 +1,306 @@
+<script>
+  import { onMount, afterUpdate } from "svelte";
+  import { filtered_data, closed_node_ids, ganttScrollTop, ganttScale } from "../stores.ts";
+  import { flattenVisibleTree, buildInheritedDueDateMap } from "../common/tree_control.ts";
+
+  let bodyEl;
+
+  $: rows = $filtered_data ? flattenVisibleTree($filtered_data, $closed_node_ids) : [];
+  $: inheritedMap = buildInheritedDueDateMap(rows);
+
+  // Sync scroll position from TreeTable
+  $: if (bodyEl) bodyEl.scrollTop = $ganttScrollTop;
+
+  // ── Timeline range ──────────────────────────────────────────────
+
+  const DAY_MS = 24 * 60 * 60 * 1000;
+
+  function parseDate(s) {
+    return s ? new Date(s).getTime() : null;
+  }
+
+  $: {
+    let minTs = null;
+    let maxTs = null;
+    for (const row of rows) {
+      const sd = parseDate(row.node.data["start date"]);
+      const dd = parseDate(row.node.data["due date"]) || parseDate(inheritedMap.get(row.id));
+      if (sd && (minTs === null || sd < minTs)) minTs = sd;
+      if (dd && (maxTs === null || dd > maxTs)) maxTs = dd;
+    }
+    const today = Date.now();
+    const pad = 14 * DAY_MS;
+    timelineStart = new Date(Math.floor(((minTs ?? today) - pad) / DAY_MS) * DAY_MS);
+    timelineEnd = new Date(Math.ceil(((maxTs ?? today) + pad * 4) / DAY_MS) * DAY_MS);
+  }
+
+  let timelineStart = new Date();
+  let timelineEnd = new Date();
+
+  // ── Scale helpers ────────────────────────────────────────────────
+
+  const CELL_PX = { day: 28, week: 80, month: 90 };
+
+  function dayOffset(date) {
+    return Math.floor((new Date(date).getTime() - timelineStart.getTime()) / DAY_MS);
+  }
+
+  function pxFromDate(date) {
+    return dayOffset(date) * pixelsPerDay;
+  }
+
+  $: pixelsPerDay =
+    $ganttScale === "day"
+      ? CELL_PX.day
+      : $ganttScale === "week"
+        ? CELL_PX.week / 7
+        : CELL_PX.month / 30;
+
+  $: totalDays = Math.ceil((timelineEnd.getTime() - timelineStart.getTime()) / DAY_MS);
+  $: totalWidth = totalDays * pixelsPerDay;
+  $: todayPx = pxFromDate(new Date());
+
+  // ── Header cells ─────────────────────────────────────────────────
+
+  function buildHeaderCells(scale, start, end) {
+    const cells = [];
+    const cur = new Date(start);
+    while (cur < end) {
+      const cellStart = new Date(cur);
+      let label = "";
+      let next;
+      if (scale === "day") {
+        label = `${cur.getMonth() + 1}/${cur.getDate()}`;
+        next = new Date(cur.getTime() + DAY_MS);
+      } else if (scale === "week") {
+        const d = cur.getDay();
+        const monday = new Date(cur.getTime() - (d === 0 ? 6 : d - 1) * DAY_MS);
+        label = `${monday.getMonth() + 1}/${monday.getDate()}`;
+        next = new Date(monday.getTime() + 7 * DAY_MS);
+        cur.setTime(monday.getTime());
+      } else {
+        label = `${cur.getFullYear()}/${cur.getMonth() + 1}`;
+        next = new Date(cur.getFullYear(), cur.getMonth() + 1, 1);
+      }
+      const widthPx = ((next.getTime() - cellStart.getTime()) / DAY_MS) * pixelsPerDay;
+      const leftPx = pxFromDate(cellStart);
+      cells.push({ label, leftPx, widthPx });
+      cur.setTime(next.getTime());
+    }
+    return cells;
+  }
+
+  $: headerCells = buildHeaderCells($ganttScale, timelineStart, timelineEnd);
+
+  // ── Bar helpers ──────────────────────────────────────────────────
+
+  function getBarStyle(row) {
+    const sd = row.node.data["start date"];
+    const dd = row.node.data["due date"];
+    const idd = inheritedMap.get(row.id);
+    const status = row.node.data["status"];
+
+    if (!sd && !dd && !idd) return null;
+
+    const effectiveDue = dd || idd;
+    const isInherited = !dd && !!idd;
+    const color = barColor(status, effectiveDue, isInherited);
+
+    if (sd && effectiveDue) {
+      const left = pxFromDate(sd);
+      const width = Math.max(2, pxFromDate(effectiveDue) - left);
+      return { left, width, color, opacity: isInherited ? 0.35 : 1, isDue: false };
+    } else if (effectiveDue) {
+      const left = pxFromDate(effectiveDue) - 1;
+      return { left, width: 2, color, opacity: isInherited ? 0.35 : 1, isDue: true };
+    } else if (sd) {
+      const left = pxFromDate(sd);
+      const width = Math.max(2, todayPx - left);
+      return { left, width, color, opacity: 1, isDue: false };
+    }
+    return null;
+  }
+
+  const DAY_MS_5 = 5 * DAY_MS;
+
+  function barColor(status, dueDate, isInherited) {
+    if (status === "Completed") return "var(--theme-color-Success-main)";
+    if (status === "Canceled") return "var(--theme-color-Sub-light)";
+    if (dueDate && status !== "Completed" && status !== "Canceled") {
+      const diff = new Date(dueDate).getTime() - Date.now() + DAY_MS - 1;
+      if (diff < 0) return "var(--theme-color-Error-main)";
+      if (diff < DAY_MS_5) return "var(--theme-color-Warning-main)";
+    }
+    if (status === "In Progress") return "var(--theme-color-Accent-main)";
+    return "var(--theme-color-Sub-light)";
+  }
+</script>
+
+<div class="GanttRoot">
+  <!-- Scale toggle + header -->
+  <div class="GanttHeader">
+    <div class="ScaleButtons">
+      <button class:active={$ganttScale === "day"} on:click={() => ($ganttScale = "day")}>日</button
+      >
+      <button class:active={$ganttScale === "week"} on:click={() => ($ganttScale = "week")}
+        >週</button
+      >
+      <button class:active={$ganttScale === "month"} on:click={() => ($ganttScale = "month")}
+        >月</button
+      >
+    </div>
+    <div class="TimelineHeader" style="width:{totalWidth}px; position:relative;">
+      {#each headerCells as cell}
+        <div class="HeaderCell" style="left:{cell.leftPx}px; width:{cell.widthPx}px;">
+          {cell.label}
+        </div>
+      {/each}
+      <!-- Today line in header -->
+      {#if todayPx >= 0 && todayPx <= totalWidth}
+        <div class="TodayLine" style="left:{todayPx}px;"></div>
+      {/if}
+    </div>
+  </div>
+
+  <!-- Body: rows synced with TreeTable -->
+  <div class="GanttBody" bind:this={bodyEl}>
+    <div class="GanttBodyInner" style="width:{totalWidth}px;">
+      <!-- Today line in body -->
+      {#if todayPx >= 0 && todayPx <= totalWidth}
+        <div class="TodayLineFull" style="left:{todayPx}px;"></div>
+      {/if}
+      {#each rows as row (row.id)}
+        {@const bar = getBarStyle(row)}
+        <div class="GanttRow">
+          {#if bar}
+            <div
+              class="Bar"
+              class:DueMarker={bar.isDue}
+              style="left:{bar.left}px; width:{bar.width}px; background:{bar.color}; opacity:{bar.opacity};"
+            ></div>
+          {/if}
+        </div>
+      {/each}
+    </div>
+  </div>
+</div>
+
+<style>
+  .GanttRoot {
+    display: flex;
+    flex-direction: column;
+    height: 100%;
+    overflow: hidden;
+    border-left: 1px solid var(--theme-color-Shadow-main);
+    background: var(--theme-color-Main-main);
+    min-width: 120px;
+  }
+
+  .GanttHeader {
+    display: flex;
+    flex-direction: column;
+    flex-shrink: 0;
+    height: 4rem;
+    border-bottom: 1px solid var(--theme-color-Shadow-main);
+    background: var(--theme-color-Main-main);
+    position: sticky;
+    top: 0;
+    z-index: 10;
+    overflow: hidden;
+  }
+
+  .ScaleButtons {
+    display: flex;
+    gap: 2px;
+    padding: 2px 4px;
+    flex-shrink: 0;
+  }
+
+  .ScaleButtons button {
+    font-size: 0.7rem;
+    padding: 1px 6px;
+    border: 1px solid var(--theme-color-Shadow-main);
+    border-radius: 3px;
+    background: transparent;
+    color: var(--theme-color-Sub-main);
+    cursor: pointer;
+  }
+
+  .ScaleButtons button.active {
+    background: var(--theme-color-Accent-main);
+    color: var(--theme-color-Main-main);
+    border-color: var(--theme-color-Accent-main);
+  }
+
+  .TimelineHeader {
+    flex: 1;
+    overflow: hidden;
+    position: relative;
+  }
+
+  .HeaderCell {
+    position: absolute;
+    top: 0;
+    bottom: 0;
+    display: flex;
+    align-items: center;
+    padding: 0 2px;
+    font-size: 0.65rem;
+    color: var(--theme-color-Sub-main);
+    border-right: 1px solid var(--theme-color-Shadow-main);
+    white-space: nowrap;
+    overflow: hidden;
+    box-sizing: border-box;
+  }
+
+  .TodayLine {
+    position: absolute;
+    top: 0;
+    bottom: 0;
+    width: 1px;
+    background: var(--theme-color-Accent-main);
+    opacity: 0.8;
+    z-index: 1;
+  }
+
+  .GanttBody {
+    flex: 1;
+    overflow-x: auto;
+    overflow-y: hidden;
+  }
+
+  .GanttBodyInner {
+    position: relative;
+  }
+
+  .TodayLineFull {
+    position: absolute;
+    top: 0;
+    bottom: 0;
+    width: 1px;
+    background: var(--theme-color-Accent-main);
+    opacity: 0.4;
+    pointer-events: none;
+    z-index: 1;
+  }
+
+  .GanttRow {
+    height: 2rem;
+    position: relative;
+    border-bottom: 1px solid color-mix(in srgb, var(--theme-color-Shadow-main) 50%, transparent);
+  }
+
+  .Bar {
+    position: absolute;
+    top: 25%;
+    height: 50%;
+    border-radius: 3px;
+    min-width: 2px;
+  }
+
+  .Bar.DueMarker {
+    top: 15%;
+    height: 70%;
+    border-radius: 1px;
+  }
+</style>

--- a/src/components/ProjectPage.svelte
+++ b/src/components/ProjectPage.svelte
@@ -2,13 +2,14 @@
   import Pane from "./Pane.svelte";
   import SplitPanes from "./SplitPanes.svelte";
   import TreeTable from "./TreeTable.svelte";
+  import GanttPanel from "./GanttPanel.svelte";
   import TaskDetail from "./TaskDetail.svelte";
   import IconButton from "./IconButton.svelte";
   import Card from "./Card.svelte";
   import Dialog from "./Dialog.svelte";
   import SearchBox from "./SearchBox.svelte";
   import { tick } from "svelte";
-  import { table_selected_id, tree_data, closed_node_ids } from "../stores.ts";
+  import { table_selected_id, tree_data, closed_node_ids, ganttVisible } from "../stores.ts";
   import { getNode, addNode, rmNode, getParent } from "../common/tree_control.ts";
   import { getDefaultNode } from "../common/tree_control.ts";
 
@@ -158,10 +159,57 @@
             <div class:SearchBox={true}>
               <SearchBox />
             </div>
+            <IconButton
+              tooltipContent={$ganttVisible ? "ガントチャートを閉じる" : "ガントチャートを表示"}
+              ariaLabel="ガントチャートの表示切替"
+              activeColor={"var(--theme-color-Accent-dark)"}
+              normalColor={$ganttVisible
+                ? "var(--theme-color-Accent-main)"
+                : "var(--theme-color-Sub-main)"}
+              on:click={() => ($ganttVisible = !$ganttVisible)}
+            >
+              <svg viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
+                <rect
+                  x="3"
+                  y="4"
+                  width="4"
+                  height="3"
+                  rx="0.5"
+                  fill="var(--theme-color-Main-main)"
+                />
+                <rect
+                  x="3"
+                  y="10.5"
+                  width="7"
+                  height="3"
+                  rx="0.5"
+                  fill="var(--theme-color-Main-main)"
+                />
+                <rect
+                  x="3"
+                  y="17"
+                  width="5"
+                  height="3"
+                  rx="0.5"
+                  fill="var(--theme-color-Main-main)"
+                />
+              </svg>
+            </IconButton>
           </div>
-          <Card>
-            <div class:TreeTable={true}>
-              <TreeTable />
+          <Card style={"flex: 1; overflow: hidden; padding: 0;"}>
+            <div class="TreeAndGantt">
+              <SplitPanes defaultRatio={$ganttVisible ? [3, 2] : [1]}>
+                <Pane style={"height: 100%; min-width: 6rem;"}>
+                  <div class:TreeTable={true}>
+                    <TreeTable />
+                  </div>
+                </Pane>
+                {#if $ganttVisible}
+                  <Pane style={"height: 100%; min-width: 120px;"}>
+                    <GanttPanel />
+                  </Pane>
+                {/if}
+              </SplitPanes>
             </div>
           </Card>
         </Card>
@@ -240,8 +288,12 @@
     box-sizing: border-box;
     flex-wrap: wrap;
   }
+  .TreeAndGantt {
+    height: 100%;
+    width: 100%;
+  }
   .TreeTable {
-    height: calc(100% - 4rem);
+    height: 100%;
     width: 100%;
     box-sizing: border-box;
     flex: 1;

--- a/src/components/TreeTable.svelte
+++ b/src/components/TreeTable.svelte
@@ -10,9 +10,11 @@
     table_selected_id,
     theme,
     column_settings,
+    ganttScrollTop,
   } from "../stores.ts";
   import {
     flattenVisibleTree,
+    buildInheritedDueDateMap,
     updateNodeDataById,
     isChild,
     reorderTree,
@@ -35,6 +37,7 @@
     resize_observer;
 
   $: rows = $filtered_data ? flattenVisibleTree($filtered_data, $closed_node_ids) : [];
+  $: inheritedDueDateMap = buildInheritedDueDateMap(rows);
   $: isDark = $theme == "dark";
   $: hasNoTasks = !$tree_data?.data?.children?.length;
   let scrollTop = 0;
@@ -360,6 +363,7 @@
 
   function handleScroll(event) {
     scrollTop = event.currentTarget.scrollTop;
+    $ganttScrollTop = scrollTop;
   }
 
   function handleToggleRow(event) {
@@ -572,6 +576,7 @@
         canMoveDown={row.canMoveDown}
         canIndent={row.canIndent}
         canOutdent={row.canOutdent}
+        inheritedDueDate={inheritedDueDateMap.get(row.id) ?? ""}
         on:select={handleSelectRow}
         on:toggle={handleToggleRow}
         on:commit={handleCommit}

--- a/src/components/TreeTableRow.svelte
+++ b/src/components/TreeTableRow.svelte
@@ -19,6 +19,7 @@
   export let canMoveDown = false;
   export let canIndent = false;
   export let canOutdent = false;
+  export let inheritedDueDate = "";
 
   const dispatch = createEventDispatcher();
   let taskName;
@@ -45,7 +46,7 @@
     return null;
   }
 
-  $: dueDateUrgency = getDueDateUrgency(data["due date"], data["status"]);
+  $: dueDateUrgency = getDueDateUrgency(data["due date"] || inheritedDueDate, data["status"]);
 
   function select(e) {
     e.stopPropagation();
@@ -257,12 +258,23 @@
             commitData("status", e.target.value);
           }}
         />
+      {:else if header.name == "start date"}
+        <DateInput
+          is_dark={isDark}
+          id="start-date"
+          backgroundColor={"var(--backgroundColor)"}
+          value={data[header.name]}
+          on:change={(e) => {
+            commitData("start date", e.target.value);
+          }}
+        />
       {:else if header.name == "due date"}
         <DateInput
           is_dark={isDark}
           id="due-date"
           backgroundColor={"var(--backgroundColor)"}
           value={data[header.name]}
+          inheritedDate={inheritedDueDate}
           on:change={(e) => {
             commitData("due date", e.target.value);
           }}

--- a/src/stores/gantt.ts
+++ b/src/stores/gantt.ts
@@ -1,0 +1,7 @@
+import { writable } from "svelte/store";
+
+export type GanttScale = "day" | "week" | "month";
+
+export const ganttVisible = writable(false);
+export const ganttScrollTop = writable(0);
+export const ganttScale = writable<GanttScale>("week");

--- a/src/stores/index.ts
+++ b/src/stores/index.ts
@@ -1,5 +1,6 @@
 export * from "./theme";
 export * from "./tree";
+export * from "./gantt";
 export * from "./project";
 export * from "./search";
 export * from "./ui";

--- a/src/types/workspace.ts
+++ b/src/types/workspace.ts
@@ -10,6 +10,7 @@ export interface WorkspaceTask {
   id: string;
   name: string;
   status: WorkspaceTaskStatus;
+  startDate?: string; // YYYY-MM-DD
   dueDate?: string; // YYYY-MM-DD
   /** Empty array means this is the root task (project itself). */
   parents: string[];


### PR DESCRIPTION
- start date フィールドをデータモデルに追加（tree_control/workspace/workspace_tree）
- 親タスクの due date を子孫に破線・薄表示で継承表示（DateInput, TreeTableRow, TreeTable）
- GanttPanel: タスクリスト右側にバー表示（開始日〜期日、日/週/月スケール切替）
- SplitPanes を使ったリサイズ可能なGanttパネル（ProjectPage）
- ガントチャートのON/OFFトグルボタンをツールバーに追加

https://claude.ai/code/session_01LrbsusG1yJ8Qi17arJWhxN