### PR TITLE
[codex] restore task pane and gantt interactions

### DIFF
--- a/electron/index.js
+++ b/electron/index.js
@@ -106,8 +106,10 @@ app.on("ready", () => {
 
       // 繝・・繝槭′螟画峩縺輔ｌ縺溷ｴ蜷医∽ｻ悶・繧ｦ繧｣繝ｳ繝峨え縺ｫ繧る夂衍
       if (key === "theme") {
-        if (taskDetailWindow && !taskDetailWindow.isDestroyed()) {
-          taskDetailWindow.webContents.send("theme-changed", value);
+        for (const win of taskDetailWindows.values()) {
+          if (!win.isDestroyed()) {
+            win.webContents.send("theme-changed", value);
+          }
         }
       }
     } catch (err) {

--- a/electron/workspace.js
+++ b/electron/workspace.js
@@ -129,6 +129,7 @@ function readRootTask(projectDir) {
     id: data.id,
     name: data.name || "",
     status: data.status || "Open",
+    startDate: data.start || undefined,
     dueDate: data.due || undefined,
     parents: [],
     memos: readMemos(projectDir, ["_project.md"]),
@@ -145,6 +146,7 @@ function readTaskDir(taskDir) {
     id: data.id,
     name: data.name || "",
     status: data.status || "Open",
+    startDate: data.start || undefined,
     dueDate: data.due || undefined,
     parents,
     memos: readMemos(taskDir),
@@ -204,6 +206,7 @@ function writeMemoFiles(taskDir, indexFileName, memos) {
 function writeRootTask(projectDir, task) {
   fs.mkdirSync(projectDir, { recursive: true });
   const data = { id: task.id, name: task.name, status: task.status };
+  if (task.startDate) data.start = task.startDate;
   if (task.dueDate) data.due = task.dueDate;
   data.created = task.createdAt || new Date().toISOString().slice(0, 10);
   fs.writeFileSync(path.join(projectDir, "_project.md"), stringifyFrontmatter(data));
@@ -230,6 +233,7 @@ function writeTask(projectDir, task, taskDirs) {
   fs.mkdirSync(taskDir, { recursive: true });
 
   const data = { id: task.id, name: task.name, status: task.status };
+  if (task.startDate) data.start = task.startDate;
   if (task.dueDate) data.due = task.dueDate;
   if (task.parents.length > 0) data.parents = task.parents;
   data.created = task.createdAt || new Date().toISOString().slice(0, 10);
@@ -425,6 +429,7 @@ function migrateProjectData(workspacePath, projectData) {
       id: node.id,
       name: node.data.name || "",
       status: node.data.status || "Open",
+      startDate: node.data["start date"] || undefined,
       dueDate: node.data["due date"] || undefined,
       parents: [...parentIds],
       memos,

--- a/electron/workspace.js
+++ b/electron/workspace.js
@@ -107,7 +107,15 @@ function readMemos(taskDir, reservedFiles = ["_index.md"]) {
     const { data, body } = parseFrontmatter(raw);
     const id = data.id || crypto.randomUUID();
     const headingMatch = body.match(/^#\s+(.+)/m);
-    const title = headingMatch ? headingMatch[1].trim() : file.replace(/\.md$/, "");
+    const fileTitle = file.replace(/\.md$/, "");
+    let title = data.title;
+    if (!title) {
+      if (headingMatch) {
+        title = headingMatch[1].trim();
+      } else {
+        title = data.id === fileTitle ? "memo" : fileTitle;
+      }
+    }
     memos.push({ id, title, content: body.trim() });
   }
   return memos;
@@ -185,7 +193,10 @@ function writeMemoFiles(taskDir, indexFileName, memos) {
   for (const f of existing) fs.unlinkSync(path.join(taskDir, f));
   for (const memo of memos || []) {
     const id = memo.id || crypto.randomUUID();
-    fs.writeFileSync(path.join(taskDir, `${id}.md`), stringifyFrontmatter({ id }, memo.content));
+    fs.writeFileSync(
+      path.join(taskDir, `${id}.md`),
+      stringifyFrontmatter({ id, title: memo.title }, memo.content)
+    );
   }
 }
 

--- a/src/components/DateInput.svelte
+++ b/src/components/DateInput.svelte
@@ -38,7 +38,7 @@
     {id}
     type="date"
     {disabled}
-    {value}
+    value={displayDate}
     title={inputTitle}
     on:change
     on:click={(e) => {

--- a/src/components/GanttPanel.svelte
+++ b/src/components/GanttPanel.svelte
@@ -1,9 +1,21 @@
 <script>
-  import { onMount, afterUpdate } from "svelte";
-  import { filtered_data, closed_node_ids, ganttScrollTop, ganttScale } from "../stores.ts";
-  import { flattenVisibleTree, buildInheritedDueDateMap } from "../common/tree_control.ts";
+  import { onDestroy } from "svelte";
+  import {
+    filtered_data,
+    closed_node_ids,
+    ganttScrollTop,
+    ganttScale,
+    tree_data,
+  } from "../stores.ts";
+  import {
+    flattenVisibleTree,
+    buildInheritedDueDateMap,
+    updateNodeDataById,
+  } from "../common/tree_control.ts";
 
   let bodyEl;
+  let headerScrollLeft = 0;
+  let dragState;
 
   $: rows = $filtered_data ? flattenVisibleTree($filtered_data, $closed_node_ids) : [];
   $: inheritedMap = buildInheritedDueDateMap(rows);
@@ -17,6 +29,14 @@
 
   function parseDate(s) {
     return s ? new Date(s).getTime() : null;
+  }
+
+  function formatDate(ts) {
+    const date = new Date(ts);
+    const year = date.getFullYear();
+    const month = String(date.getMonth() + 1).padStart(2, "0");
+    const day = String(date.getDate()).padStart(2, "0");
+    return `${year}-${month}-${day}`;
   }
 
   $: {
@@ -94,36 +114,72 @@
 
   // ── Bar helpers ──────────────────────────────────────────────────
 
+  function getRowDateState(row) {
+    const startTs = parseDate(row.node.data["start date"]);
+    const dueTs = parseDate(row.node.data["due date"]);
+    const inheritedDueTs = parseDate(inheritedMap.get(row.id));
+    const effectiveDueTs = dueTs || inheritedDueTs;
+
+    return {
+      startTs,
+      dueTs,
+      inheritedDueTs,
+      effectiveDueTs,
+      isInherited: !dueTs && !!inheritedDueTs,
+    };
+  }
+
   function getBarStyle(row) {
-    const sd = row.node.data["start date"];
-    const dd = row.node.data["due date"];
-    const idd = inheritedMap.get(row.id);
+    const dateState = getRowDateState(row);
     const status = row.node.data["status"];
 
-    if (!sd && !dd && !idd) return null;
+    if (!dateState.startTs && !dateState.effectiveDueTs) return null;
 
-    const effectiveDue = dd || idd;
-    const isInherited = !dd && !!idd;
-    const color = barColor(status, effectiveDue, isInherited);
+    const color = barColor(
+      status,
+      dateState.effectiveDueTs ? formatDate(dateState.effectiveDueTs) : undefined
+    );
 
-    if (sd && effectiveDue) {
-      const left = pxFromDate(sd);
-      const width = Math.max(2, pxFromDate(effectiveDue) - left);
-      return { left, width, color, opacity: isInherited ? 0.35 : 1, isDue: false };
-    } else if (effectiveDue) {
-      const left = pxFromDate(effectiveDue) - 1;
-      return { left, width: 2, color, opacity: isInherited ? 0.35 : 1, isDue: true };
-    } else if (sd) {
-      const left = pxFromDate(sd);
+    if (dateState.startTs && dateState.effectiveDueTs) {
+      const left = pxFromDate(dateState.startTs);
+      const width = Math.max(6, pxFromDate(dateState.effectiveDueTs + DAY_MS) - left);
+      return {
+        ...dateState,
+        left,
+        width,
+        color,
+        opacity: dateState.isInherited ? 0.35 : 1,
+        isDue: false,
+      };
+    } else if (dateState.effectiveDueTs) {
+      const left = pxFromDate(dateState.effectiveDueTs) - 2;
+      return {
+        ...dateState,
+        left,
+        width: 4,
+        color,
+        opacity: dateState.isInherited ? 0.35 : 1,
+        isDue: true,
+      };
+    } else if (dateState.startTs) {
+      const left = pxFromDate(dateState.startTs);
       const width = Math.max(2, todayPx - left);
-      return { left, width, color, opacity: 1, isDue: false };
+      return {
+        ...dateState,
+        effectiveDueTs: Date.now(),
+        left,
+        width,
+        color,
+        opacity: 1,
+        isDue: false,
+      };
     }
     return null;
   }
 
   const DAY_MS_5 = 5 * DAY_MS;
 
-  function barColor(status, dueDate, isInherited) {
+  function barColor(status, dueDate) {
     if (status === "Completed") return "var(--theme-color-Success-main)";
     if (status === "Canceled") return "var(--theme-color-Sub-light)";
     if (dueDate && status !== "Completed" && status !== "Canceled") {
@@ -134,6 +190,117 @@
     if (status === "In Progress") return "var(--theme-color-Accent-main)";
     return "var(--theme-color-Sub-light)";
   }
+
+  function commitTaskDates(id, patch) {
+    if (!$tree_data?.data) {
+      return;
+    }
+
+    const data = updateNodeDataById($tree_data.data, id, patch);
+    if (data !== $tree_data.data) {
+      $tree_data = { ...$tree_data, data };
+    }
+  }
+
+  function dateFromPointer(event) {
+    const rect = bodyEl.getBoundingClientRect();
+    const x = Math.max(0, event.clientX - rect.left + bodyEl.scrollLeft);
+    const day = Math.round(x / Math.max(pixelsPerDay, 1));
+    return timelineStart.getTime() + day * DAY_MS;
+  }
+
+  function createRange(event, row, bar) {
+    if (bar && !bar.isInherited) {
+      return;
+    }
+
+    event.preventDefault();
+    event.stopPropagation();
+
+    const startTs = dateFromPointer(event);
+    const dueTs =
+      bar?.effectiveDueTs && bar.effectiveDueTs >= startTs
+        ? bar.effectiveDueTs
+        : startTs + 2 * DAY_MS;
+    commitTaskDates(row.id, {
+      "start date": formatDate(startTs),
+      "due date": formatDate(dueTs),
+    });
+  }
+
+  function startDrag(event, row, mode, bar) {
+    if (!bar || bar.isInherited) {
+      return;
+    }
+
+    event.preventDefault();
+    event.stopPropagation();
+
+    dragState = {
+      id: row.id,
+      mode,
+      startX: event.clientX,
+      startTs: bar.startTs,
+      dueTs: bar.dueTs,
+      effectiveDueTs: bar.effectiveDueTs,
+      lastDelta: undefined,
+    };
+
+    document.addEventListener("pointermove", handlePointerMove);
+    document.addEventListener("pointerup", stopDrag);
+  }
+
+  function handlePointerMove(event) {
+    if (!dragState) {
+      return;
+    }
+
+    const delta = Math.round((event.clientX - dragState.startX) / Math.max(pixelsPerDay, 1));
+    if (delta === dragState.lastDelta) {
+      return;
+    }
+
+    dragState.lastDelta = delta;
+    const deltaMs = delta * DAY_MS;
+
+    if (dragState.mode === "move") {
+      const patch = {};
+      if (dragState.startTs) {
+        patch["start date"] = formatDate(dragState.startTs + deltaMs);
+      }
+      if (dragState.dueTs || !dragState.startTs) {
+        patch["due date"] = formatDate((dragState.dueTs || dragState.effectiveDueTs) + deltaMs);
+      }
+      commitTaskDates(dragState.id, patch);
+      return;
+    }
+
+    if (dragState.mode === "start") {
+      const dueTs = dragState.dueTs || dragState.effectiveDueTs || dragState.startTs || Date.now();
+      const nextStartTs = Math.min((dragState.startTs || dueTs) + deltaMs, dueTs);
+      commitTaskDates(dragState.id, { "start date": formatDate(nextStartTs) });
+      return;
+    }
+
+    const startTs = dragState.startTs || dragState.dueTs || dragState.effectiveDueTs || Date.now();
+    const baseDueTs = dragState.dueTs || dragState.effectiveDueTs || startTs;
+    const nextDueTs = Math.max(baseDueTs + deltaMs, startTs);
+    commitTaskDates(dragState.id, { "due date": formatDate(nextDueTs) });
+  }
+
+  function stopDrag() {
+    dragState = undefined;
+    document.removeEventListener("pointermove", handlePointerMove);
+    document.removeEventListener("pointerup", stopDrag);
+  }
+
+  function handleBodyScroll(event) {
+    headerScrollLeft = event.currentTarget.scrollLeft;
+  }
+
+  onDestroy(() => {
+    stopDrag();
+  });
 </script>
 
 <div class="GanttRoot">
@@ -149,21 +316,26 @@
         >月</button
       >
     </div>
-    <div class="TimelineHeader" style="width:{totalWidth}px; position:relative;">
-      {#each headerCells as cell}
-        <div class="HeaderCell" style="left:{cell.leftPx}px; width:{cell.widthPx}px;">
-          {cell.label}
-        </div>
-      {/each}
-      <!-- Today line in header -->
-      {#if todayPx >= 0 && todayPx <= totalWidth}
-        <div class="TodayLine" style="left:{todayPx}px;"></div>
-      {/if}
+    <div class="TimelineHeaderViewport">
+      <div
+        class="TimelineHeader"
+        style="width:{totalWidth}px; transform: translateX(-{headerScrollLeft}px);"
+      >
+        {#each headerCells as cell}
+          <div class="HeaderCell" style="left:{cell.leftPx}px; width:{cell.widthPx}px;">
+            {cell.label}
+          </div>
+        {/each}
+        <!-- Today line in header -->
+        {#if todayPx >= 0 && todayPx <= totalWidth}
+          <div class="TodayLine" style="left:{todayPx}px;"></div>
+        {/if}
+      </div>
     </div>
   </div>
 
   <!-- Body: rows synced with TreeTable -->
-  <div class="GanttBody" bind:this={bodyEl}>
+  <div class="GanttBody" bind:this={bodyEl} on:scroll={handleBodyScroll}>
     <div class="GanttBodyInner" style="width:{totalWidth}px;">
       <!-- Today line in body -->
       {#if todayPx >= 0 && todayPx <= totalWidth}
@@ -171,13 +343,39 @@
       {/if}
       {#each rows as row (row.id)}
         {@const bar = getBarStyle(row)}
-        <div class="GanttRow">
+        <div
+          class="GanttRow"
+          role="presentation"
+          on:dblclick={(event) => createRange(event, row, bar)}
+        >
           {#if bar}
-            <div
+            <button
+              type="button"
               class="Bar"
               class:DueMarker={bar.isDue}
+              class:Inherited={bar.isInherited}
               style="left:{bar.left}px; width:{bar.width}px; background:{bar.color}; opacity:{bar.opacity};"
-            ></div>
+              aria-label={bar.isDue ? "期限日を変更" : "期間を移動"}
+              title={bar.isDue ? "期限日を変更" : "期間を移動"}
+              disabled={bar.isInherited}
+              on:pointerdown={(event) => startDrag(event, row, "move", bar)}
+            ></button>
+            {#if !bar.isDue && !bar.isInherited}
+              <button
+                class="BarHandle StartHandle"
+                aria-label="開始日を変更"
+                title="開始日を変更"
+                style="left:{bar.left}px;"
+                on:pointerdown={(event) => startDrag(event, row, "start", bar)}
+              ></button>
+              <button
+                class="BarHandle EndHandle"
+                aria-label="期限日を変更"
+                title="期限日を変更"
+                style="left:{bar.left + bar.width}px;"
+                on:pointerdown={(event) => startDrag(event, row, "end", bar)}
+              ></button>
+            {/if}
           {/if}
         </div>
       {/each}
@@ -232,10 +430,16 @@
     border-color: var(--theme-color-Accent-main);
   }
 
-  .TimelineHeader {
+  .TimelineHeaderViewport {
     flex: 1;
     overflow: hidden;
     position: relative;
+  }
+
+  .TimelineHeader {
+    height: 100%;
+    position: relative;
+    will-change: transform;
   }
 
   .HeaderCell {
@@ -294,13 +498,46 @@
     position: absolute;
     top: 25%;
     height: 50%;
+    border: none;
     border-radius: 3px;
     min-width: 2px;
+    cursor: grab;
+    z-index: 2;
+    padding: 0;
+  }
+
+  .Bar:not(.Inherited):active {
+    cursor: grabbing;
+  }
+
+  .Bar.Inherited {
+    pointer-events: none;
   }
 
   .Bar.DueMarker {
     top: 15%;
     height: 70%;
     border-radius: 1px;
+  }
+
+  .BarHandle {
+    position: absolute;
+    top: 20%;
+    width: 0.5rem;
+    height: 60%;
+    border: none;
+    border-radius: 2px;
+    background: color-mix(in srgb, var(--theme-color-Main-main) 70%, transparent);
+    cursor: ew-resize;
+    padding: 0;
+    z-index: 3;
+  }
+
+  .StartHandle {
+    transform: translateX(-50%);
+  }
+
+  .EndHandle {
+    transform: translateX(-50%);
   }
 </style>

--- a/src/components/ProjectPage.svelte
+++ b/src/components/ProjectPage.svelte
@@ -198,18 +198,22 @@
           </div>
           <Card style={"flex: 1; overflow: hidden; padding: 0;"}>
             <div class="TreeAndGantt">
-              <SplitPanes defaultRatio={$ganttVisible ? [3, 2] : [1]}>
-                <Pane style={"height: 100%; min-width: 6rem;"}>
-                  <div class:TreeTable={true}>
-                    <TreeTable />
-                  </div>
-                </Pane>
-                {#if $ganttVisible}
+              {#if $ganttVisible}
+                <SplitPanes defaultRatio={[3, 2]}>
+                  <Pane style={"height: 100%; min-width: 6rem;"}>
+                    <div class="TreeTable">
+                      <TreeTable />
+                    </div>
+                  </Pane>
                   <Pane style={"height: 100%; min-width: 120px;"}>
                     <GanttPanel />
                   </Pane>
-                {/if}
-              </SplitPanes>
+                </SplitPanes>
+              {:else}
+                <div class="TreeTable">
+                  <TreeTable />
+                </div>
+              {/if}
             </div>
           </Card>
         </Card>

--- a/src/components/SplitPanes.svelte
+++ b/src/components/SplitPanes.svelte
@@ -39,7 +39,7 @@
 
   const createResizers = (resizers = [], is_default = true, resize_observer = null) => {
     // Get elms
-    let panes = split_pane_root.querySelectorAll(".Pane");
+    let panes = split_pane_root.querySelectorAll(":scope > .Pane");
     // Default
     if (is_default) {
       // Set width
@@ -197,6 +197,9 @@
     return handlers;
   };
   const unsetResizerEvents = (resizers, handlers) => {
+    if (!handlers) {
+      return;
+    }
     resizers.forEach((resizer, index) => {
       resizer.removeEventListener("mousedown", handlers[index]);
     });

--- a/src/components/TreeTable.svelte
+++ b/src/components/TreeTable.svelte
@@ -36,6 +36,14 @@
     handlers,
     resize_observer;
 
+  const BUILT_IN_HEADERS = [
+    { name: "name", default_ratio: 10 },
+    { name: "status", default_ratio: 4 },
+    { name: "start date", default_ratio: 4 },
+    { name: "due date", default_ratio: 4 },
+    { name: "memo", default_ratio: 2 },
+  ];
+
   $: rows = $filtered_data ? flattenVisibleTree($filtered_data, $closed_node_ids) : [];
   $: inheritedDueDateMap = buildInheritedDueDateMap(rows);
   $: isDark = $theme == "dark";
@@ -43,21 +51,29 @@
   let scrollTop = 0;
 
   // Compute visible headers from tree_data.headers filtered/ordered by column_settings
+  function mergeBuiltInHeaders(treeHeaders = []) {
+    const byName = new Map(BUILT_IN_HEADERS.map((header) => [header.name, header]));
+    for (const header of treeHeaders ?? []) {
+      byName.set(header.name, header);
+    }
+    return Array.from(byName.values());
+  }
+
   function computeVisibleHeaders(treeHeaders, settings) {
-    if (!treeHeaders) return [];
-    if (!settings) return treeHeaders;
+    const availableHeaders = mergeBuiltInHeaders(treeHeaders);
+    if (!settings) return availableHeaders;
 
     const result = [];
     for (const setting of settings) {
       if (setting.id === "name" || setting.visible) {
-        const header = treeHeaders.find((h) => h.name === setting.id);
+        const header = availableHeaders.find((h) => h.name === setting.id);
         if (header) result.push(header);
       }
     }
 
     // Include any headers not covered by settings
     const settingIds = new Set(settings.map((s) => s.id));
-    for (const header of treeHeaders) {
+    for (const header of availableHeaders) {
       if (!settingIds.has(header.name)) result.push(header);
     }
 
@@ -65,6 +81,7 @@
   }
 
   $: visibleHeaders = computeVisibleHeaders($tree_data?.headers, $column_settings);
+  $: allHeaders = mergeBuiltInHeaders($tree_data?.headers);
   $: minWidth = visibleHeaders.length ? `${4 * visibleHeaders.length}rem` : "auto";
 
   const getRowHeightPx = () => {
@@ -128,9 +145,9 @@
 
       if (columnCountChanged && currentDomHeaderCount > 0) {
         // Column was added or removed — full reinit
+        unsetResizerEvents(resizers, handlers);
         resizers.forEach((r) => r.parentNode?.removeChild(r));
         resizers = [];
-        unsetResizerEvents(resizers, handlers);
         [resizers, newDomHeaders, newDataRows, resize_observer] = createResizers(
           visibleHeaders,
           [],
@@ -186,16 +203,20 @@
       });
 
       // Create resizer elements
+      let left = 0;
       domHeaders.forEach((header, index) => {
-        if (index == 0) {
+        if (index === 0) {
+          left += default_data_widths[index];
           return;
         }
         const resizer = document.createElement("div");
         resizer.classList.add("Resizer");
-        resizer.style.height = `${table_root.offsetHeight}px`;
-        resizer.style.left = `calc(${default_data_widths.reduce((partialSum, width) => partialSum + width, 0) - 3}px)`;
-        header.parentNode.insertBefore(resizer, header);
+        resizer.style.top = `${table_root.scrollTop}px`;
+        resizer.style.height = `${table_root.clientHeight}px`;
+        resizer.style.left = `${left - 3}px`;
+        table_root.insertBefore(resizer, tableRows[0]);
         existingResizers.push(resizer);
+        left += default_data_widths[index];
       });
     } else {
       domHeaders.forEach((header, index) => {
@@ -212,6 +233,7 @@
     const newResizeObserver = new ResizeObserver((entries) => {
       // Height setting
       for (let resizer of existingResizers) {
+        resizer.style.top = `${table_root.scrollTop}px`;
         resizer.style.height = `${entries[0].contentRect.height}px`;
       }
       // Width setting
@@ -352,6 +374,9 @@
   };
 
   const unsetResizerEvents = (resizers, handlers) => {
+    if (!handlers) {
+      return;
+    }
     resizers.forEach((resizer, index) => {
       resizer.removeEventListener("mousedown", handlers[index]);
     });
@@ -364,6 +389,9 @@
   function handleScroll(event) {
     scrollTop = event.currentTarget.scrollTop;
     $ganttScrollTop = scrollTop;
+    resizers.forEach((resizer) => {
+      resizer.style.top = `${scrollTop}px`;
+    });
   }
 
   function handleToggleRow(event) {
@@ -546,7 +574,7 @@
   aria-label="Task tree"
   on:scroll={handleScroll}
 >
-  <TreeTableHeader headers={visibleHeaders} allHeaders={$tree_data?.headers ?? []} />
+  <TreeTableHeader headers={visibleHeaders} {allHeaders} />
   {#if stickyTrail.length > 0}
     <div class="StickyTrail" aria-hidden="true">
       <div class="StickyTrailContent">
@@ -691,7 +719,7 @@
     width: 5px;
     cursor: col-resize;
     user-select: none;
-    z-index: 999;
+    z-index: 10000;
   }
   .TableRoot :global(.HandlingResizer),
   .TableRoot :global(.Resizer:hover) {

--- a/src/stores/column_settings.ts
+++ b/src/stores/column_settings.ts
@@ -18,6 +18,7 @@ const META_KEY = "column_settings";
 export const DEFAULT_COLUMN_SETTINGS: ColumnSetting[] = [
   { id: "name", label: "タスク名", visible: true },
   { id: "status", label: "ステータス", visible: true },
+  { id: "start date", label: "開始日", visible: true },
   { id: "due date", label: "期限日", visible: true },
   { id: "memo", label: "メモ数", visible: false },
 ];

--- a/tests/unit/column_settings.test.js
+++ b/tests/unit/column_settings.test.js
@@ -25,6 +25,7 @@ describe("column_settings store", () => {
     const settings = get(column_settings);
     expect(settings.find((s) => s.id === "name").visible).toBe(true);
     expect(settings.find((s) => s.id === "status").visible).toBe(true);
+    expect(settings.find((s) => s.id === "start date").visible).toBe(true);
     expect(settings.find((s) => s.id === "due date").visible).toBe(true);
     expect(settings.find((s) => s.id === "memo").visible).toBe(false);
   });
@@ -108,6 +109,7 @@ describe("column_settings store", () => {
 
     const settings = get(column_settings);
     expect(settings.find((s) => s.id === "status").visible).toBe(false);
+    expect(settings.find((s) => s.id === "start date").visible).toBe(true);
     expect(settings.find((s) => s.id === "memo").visible).toBe(true);
   });
 

--- a/tests/unit/workspace.test.js
+++ b/tests/unit/workspace.test.js
@@ -265,6 +265,7 @@ describe("file system operations", () => {
       id: "task-1",
       name: "First Task",
       status: "In Progress",
+      startDate: "2026-05-20",
       dueDate: "2026-06-01",
       parents: ["root-id"],
       memos: [{ id: "memo-uuid-1", title: "Notes", content: "# Notes\n\nSome content" }],
@@ -282,6 +283,7 @@ describe("file system operations", () => {
     expect(loaded).toBeDefined();
     expect(loaded.name).toBe("First Task");
     expect(loaded.status).toBe("In Progress");
+    expect(loaded.startDate).toBe("2026-05-20");
     expect(loaded.dueDate).toBe("2026-06-01");
     expect(loaded.parents).toEqual(["root-id"]);
     expect(loaded.memos).toHaveLength(1);
@@ -483,7 +485,13 @@ describe("migrateProjectData", () => {
         children: [
           {
             id: "child-a",
-            data: { name: "Child A", status: "In Progress", "due date": "2026-05-01", memo: [] },
+            data: {
+              name: "Child A",
+              status: "In Progress",
+              "start date": "2026-04-20",
+              "due date": "2026-05-01",
+              memo: [],
+            },
             children: [],
           },
           {
@@ -512,6 +520,7 @@ describe("migrateProjectData", () => {
     expect(tasks.get("child-a").parents).toEqual(["root-2"]);
     expect(tasks.get("child-b").parents).toEqual(["root-2"]);
     expect(tasks.get("grandchild").parents).toEqual(["child-b"]);
+    expect(tasks.get("child-a").startDate).toBe("2026-04-20");
     expect(tasks.get("child-a").dueDate).toBe("2026-05-01");
     expect(tasks.get("child-b").status).toBe("Completed");
   });

--- a/tests/unit/workspace.test.js
+++ b/tests/unit/workspace.test.js
@@ -289,6 +289,54 @@ describe("file system operations", () => {
     expect(loaded.memos[0].title).toBe("Notes");
   });
 
+  it("preserves memo tab titles for empty workspace memos", () => {
+    const { projectDir } = createProject(tmpDir, "Proj", "root-id");
+    const taskDirs = new Map([["root-id", "_project"]]);
+    const task = {
+      id: "task-empty-memo",
+      name: "Task With Empty Memo",
+      status: "Open",
+      parents: ["root-id"],
+      memos: [{ id: "memo-uuid-empty", title: "Scratch", content: "" }],
+      createdAt: "2026-04-24",
+    };
+
+    writeTask(projectDir, task, taskDirs);
+
+    const memoFile = fs.readFileSync(
+      path.join(projectDir, "task-empty-memo", "memo-uuid-empty.md"),
+      "utf8"
+    );
+    expect(memoFile).toContain("title: Scratch");
+
+    const { tasks } = readProject(projectDir);
+    const loaded = tasks.get("task-empty-memo");
+    expect(loaded.memos[0].id).toBe("memo-uuid-empty");
+    expect(loaded.memos[0].title).toBe("Scratch");
+  });
+
+  it("does not expose ids as tab titles for old empty workspace memos", () => {
+    const { projectDir } = createProject(tmpDir, "Proj", "root-id");
+    const taskDirs = new Map([["root-id", "_project"]]);
+    const task = {
+      id: "task-old-empty-memo",
+      name: "Task With Old Empty Memo",
+      status: "Open",
+      parents: ["root-id"],
+      memos: [],
+      createdAt: "2026-04-24",
+    };
+    writeTask(projectDir, task, taskDirs);
+
+    const taskDir = path.join(projectDir, "task-old-empty-memo");
+    fs.writeFileSync(path.join(taskDir, "memo-uuid-old.md"), "---\nid: memo-uuid-old\n---\n");
+
+    const { tasks } = readProject(projectDir);
+    const loaded = tasks.get("task-old-empty-memo");
+    expect(loaded.memos[0].id).toBe("memo-uuid-old");
+    expect(loaded.memos[0].title).toBe("memo");
+  });
+
   it("readMemos assigns a generated id to legacy memo files without frontmatter", () => {
     const { projectDir } = createProject(tmpDir, "Proj", "root-id");
     const taskDirs = new Map([["root-id", "_project"]]);


### PR DESCRIPTION
## Summary

- タスク詳細ウィンドウ保存時の `taskDetailWindow is not defined` を修正
- Gantt 表示時の SplitPane/TreeTable レイアウト崩れを修正
- タスクに開始日を保存・表示できるようにし、Gantt 上でバーの作成、移動、期間調整をできるようにした
- タスクツリー列リサイザーがツリー領域外へ伸びる問題を修正

## Root Cause

直近の Gantt 追加で、ネストした SplitPane の `.Pane` 検出が外側/内側の pane を混同しやすくなっていました。また、Gantt は表示だけ追加されていて開始日の永続化と編集 UI が揃っておらず、TreeTable の列リサイザーはヘッダー行の子要素なのにテーブル全体の高さを持つため、表示領域からはみ出していました。

## Validation

- `svelte-check --tsconfig ./tsconfig.json`
- `vitest run tests/component/TreeTable.test.js tests/unit/column_settings.test.js`
- `vitest run tests/unit/workspace.test.js tests/unit/column_settings.test.js tests/component/TreeTable.test.js`
- `vite build`
- Electron e2e smoke: 9 passed