### PR TITLE
[codex] align gantt height with task tree

### DIFF
--- a/src/components/GanttPanel.svelte
+++ b/src/components/GanttPanel.svelte
@@ -388,6 +388,7 @@
     display: flex;
     flex-direction: column;
     height: 100%;
+    min-height: 0;
     overflow: hidden;
     border-left: 1px solid var(--theme-color-Shadow-main);
     background: var(--theme-color-Main-main);
@@ -469,12 +470,14 @@
 
   .GanttBody {
     flex: 1;
+    min-height: 0;
     overflow-x: auto;
     overflow-y: hidden;
   }
 
   .GanttBodyInner {
     position: relative;
+    min-height: 100%;
   }
 
   .TodayLineFull {

--- a/src/components/ProjectPage.svelte
+++ b/src/components/ProjectPage.svelte
@@ -295,10 +295,22 @@
   .TreeAndGantt {
     height: 100%;
     width: 100%;
+    min-height: 0;
+    overflow: hidden;
+  }
+  .TreeAndGantt :global(.SplitPaneRoot),
+  .TreeAndGantt :global(.Pane) {
+    min-height: 0;
+  }
+  .TreeAndGantt :global(.Pane) {
+    align-items: stretch;
+    justify-content: stretch;
+    overflow: hidden;
   }
   .TreeTable {
     height: 100%;
     width: 100%;
+    min-height: 0;
     box-sizing: border-box;
     flex: 1;
   }


### PR DESCRIPTION
## Summary

- Gantt パネルの flex 高さをタスクツリー側と揃えるため、Gantt root/body に `min-height: 0` を追加
- Gantt のチャート本体を最低でも表示領域いっぱいに伸ばし、タスクツリーの縦幅と揃うようにした
- TreeTable/Gantt を載せる内側 SplitPane の pane を stretch/overflow hidden にして、スクロール責務を各本体コンポーネントへ寄せた

## Validation

- `svelte-check --tsconfig ./tsconfig.json`
- `vitest run tests/component/ProjectPage.test.js tests/component/TreeTable.test.js`
- `vite build`