### PR TITLE
[codex] limit gantt guide lines to task rows

### DIFF
--- a/src/components/GanttPanel.svelte
+++ b/src/components/GanttPanel.svelte
@@ -477,7 +477,6 @@
 
   .GanttBodyInner {
     position: relative;
-    min-height: 100%;
   }
 
   .TodayLineFull {

--- a/src/components/SplitPanes.svelte
+++ b/src/components/SplitPanes.svelte
@@ -219,7 +219,7 @@
     min-width: var(--minWidth);
     position: relative;
   }
-  .SplitPaneRoot :global(.Resizer) {
+  .SplitPaneRoot > :global(.Resizer) {
     position: absolute;
     top: 0;
     width: 5px;
@@ -227,7 +227,7 @@
     user-select: none;
     z-index: 999;
   }
-  .SplitPaneRoot :global(.Resizer::before) {
+  .SplitPaneRoot > :global(.Resizer::before) {
     content: "";
     position: absolute;
     top: 0;
@@ -237,12 +237,12 @@
     background-color: color-mix(in srgb, var(--theme-color-Sub-dark) 28%, transparent);
     opacity: 0.7;
   }
-  .SplitPaneRoot :global(.HandlingResizer),
-  .SplitPaneRoot :global(.Resizer:hover) {
+  .SplitPaneRoot > :global(.HandlingResizer),
+  .SplitPaneRoot > :global(.Resizer:hover) {
     background-color: transparent;
   }
-  .SplitPaneRoot :global(.HandlingResizer::before),
-  .SplitPaneRoot :global(.Resizer:hover::before) {
+  .SplitPaneRoot > :global(.HandlingResizer::before),
+  .SplitPaneRoot > :global(.Resizer:hover::before) {
     width: 2px;
     background-color: var(--theme-color-Accent-main);
     opacity: 0.9;

--- a/src/components/TreeTable.svelte
+++ b/src/components/TreeTable.svelte
@@ -169,6 +169,25 @@
     mutation_observer.observe(table_root, { subtree: true, childList: true });
   });
 
+  const syncResizerBounds = (targetResizers = resizers) => {
+    if (!table_root) {
+      return;
+    }
+
+    const tableRows = Array.from(table_root.querySelectorAll(".TableRow"));
+    const contentHeight = tableRows.reduce(
+      (height, row) => height + row.getBoundingClientRect().height,
+      0
+    );
+    const top = table_root.scrollTop;
+    const height = Math.max(0, Math.min(table_root.clientHeight, contentHeight - top));
+
+    targetResizers.forEach((resizer) => {
+      resizer.style.top = `${top}px`;
+      resizer.style.height = `${height}px`;
+    });
+  };
+
   const createResizers = (
     currentHeaders,
     existingResizers = [],
@@ -211,8 +230,6 @@
         }
         const resizer = document.createElement("div");
         resizer.classList.add("Resizer");
-        resizer.style.top = `${table_root.scrollTop}px`;
-        resizer.style.height = `${table_root.clientHeight}px`;
         resizer.style.left = `${left - 3}px`;
         table_root.insertBefore(resizer, tableRows[0]);
         existingResizers.push(resizer);
@@ -225,6 +242,7 @@
         });
       });
     }
+    syncResizerBounds(existingResizers);
 
     // For table_root resizing
     if (existingResizeObserver) {
@@ -232,10 +250,7 @@
     }
     const newResizeObserver = new ResizeObserver((entries) => {
       // Height setting
-      for (let resizer of existingResizers) {
-        resizer.style.top = `${table_root.scrollTop}px`;
-        resizer.style.height = `${entries[0].contentRect.height}px`;
-      }
+      syncResizerBounds(existingResizers);
       // Width setting
       let table_width = 0;
       domHeaders.forEach((header, index) => {
@@ -389,9 +404,7 @@
   function handleScroll(event) {
     scrollTop = event.currentTarget.scrollTop;
     $ganttScrollTop = scrollTop;
-    resizers.forEach((resizer) => {
-      resizer.style.top = `${scrollTop}px`;
-    });
+    syncResizerBounds(resizers);
   }
 
   function handleToggleRow(event) {


### PR DESCRIPTION
## Summary

- Gantt の body 内に出る today line を、空白領域ではなく実際のタスク行の高さで止めるようにした
- TreeTable の列リサイザー高さを、タスクツリー全体の可視高ではなく `header + 表示中のタスク行` の高さから計算するようにした
- SplitPane のリサイザー線スタイルが内側の TreeTable 列リサイザーへ漏れないよう、SplitPane 直下のリサイザーだけに CSS を限定した

## Validation

- `svelte-check --tsconfig ./tsconfig.json`
- `vitest run tests/component/ProjectPage.test.js tests/component/TreeTable.test.js`
- `vite build`