### PR TITLE
[codex] enrich gantt grid interactions

### DIFF
--- a/src/components/GanttPanel.svelte
+++ b/src/components/GanttPanel.svelte
@@ -16,6 +16,8 @@
   let bodyEl;
   let headerScrollLeft = 0;
   let dragState;
+  let locale =
+    typeof navigator !== "undefined" && navigator.language ? navigator.language : undefined;
 
   $: rows = $filtered_data ? flattenVisibleTree($filtered_data, $closed_node_ids) : [];
   $: inheritedMap = buildInheritedDueDateMap(rows);
@@ -28,7 +30,9 @@
   const DAY_MS = 24 * 60 * 60 * 1000;
 
   function parseDate(s) {
-    return s ? new Date(s).getTime() : null;
+    if (!s) return null;
+    const [year, month, day] = s.split("-").map(Number);
+    return new Date(year, month - 1, day).getTime();
   }
 
   function formatDate(ts) {
@@ -37,6 +41,24 @@
     const month = String(date.getMonth() + 1).padStart(2, "0");
     const day = String(date.getDate()).padStart(2, "0");
     return `${year}-${month}-${day}`;
+  }
+
+  function startOfDay(ts = Date.now()) {
+    const date = new Date(ts);
+    date.setHours(0, 0, 0, 0);
+    return date.getTime();
+  }
+
+  function getPeriodTone(startTs, endTs) {
+    const todayStart = startOfDay();
+    const todayEnd = todayStart + DAY_MS;
+    if (endTs <= todayStart) return "past";
+    if (startTs < todayEnd && endTs > todayStart) return "today";
+    return "future";
+  }
+
+  function formatLocalDate(date, options) {
+    return new Intl.DateTimeFormat(locale, options).format(date);
   }
 
   $: {
@@ -48,10 +70,10 @@
       if (sd && (minTs === null || sd < minTs)) minTs = sd;
       if (dd && (maxTs === null || dd > maxTs)) maxTs = dd;
     }
-    const today = Date.now();
+    const today = startOfDay();
     const pad = 14 * DAY_MS;
-    timelineStart = new Date(Math.floor(((minTs ?? today) - pad) / DAY_MS) * DAY_MS);
-    timelineEnd = new Date(Math.ceil(((maxTs ?? today) + pad * 4) / DAY_MS) * DAY_MS);
+    timelineStart = new Date(startOfDay((minTs ?? today) - pad));
+    timelineEnd = new Date(startOfDay((maxTs ?? today) + pad * 4) + DAY_MS);
   }
 
   let timelineStart = new Date();
@@ -59,7 +81,7 @@
 
   // ── Scale helpers ────────────────────────────────────────────────
 
-  const CELL_PX = { day: 28, week: 80, month: 90 };
+  const CELL_PX = { day: 46, week: 96, month: 110 };
 
   function dayOffset(date) {
     return Math.floor((new Date(date).getTime() - timelineStart.getTime()) / DAY_MS);
@@ -78,7 +100,8 @@
 
   $: totalDays = Math.ceil((timelineEnd.getTime() - timelineStart.getTime()) / DAY_MS);
   $: totalWidth = totalDays * pixelsPerDay;
-  $: todayPx = pxFromDate(new Date());
+  $: todayTs = startOfDay();
+  $: todayPx = pxFromDate(todayTs);
 
   // ── Header cells ─────────────────────────────────────────────────
 
@@ -90,21 +113,37 @@
       let label = "";
       let next;
       if (scale === "day") {
-        label = `${cur.getMonth() + 1}/${cur.getDate()}`;
+        label = formatLocalDate(cur, {
+          month: "numeric",
+          day: "numeric",
+          weekday: "short",
+        });
         next = new Date(cur.getTime() + DAY_MS);
       } else if (scale === "week") {
         const d = cur.getDay();
         const monday = new Date(cur.getTime() - (d === 0 ? 6 : d - 1) * DAY_MS);
-        label = `${monday.getMonth() + 1}/${monday.getDate()}`;
+        label = formatLocalDate(monday, {
+          month: "numeric",
+          day: "numeric",
+          weekday: "short",
+        });
         next = new Date(monday.getTime() + 7 * DAY_MS);
         cur.setTime(monday.getTime());
       } else {
-        label = `${cur.getFullYear()}/${cur.getMonth() + 1}`;
+        label = formatLocalDate(cur, { year: "numeric", month: "short" });
         next = new Date(cur.getFullYear(), cur.getMonth() + 1, 1);
       }
       const widthPx = ((next.getTime() - cellStart.getTime()) / DAY_MS) * pixelsPerDay;
       const leftPx = pxFromDate(cellStart);
-      cells.push({ label, leftPx, widthPx });
+      const startTs = cellStart.getTime();
+      const endTs = next.getTime();
+      cells.push({
+        label,
+        leftPx,
+        widthPx,
+        tone: getPeriodTone(startTs, endTs),
+        weekend: scale === "day" && (cellStart.getDay() === 0 || cellStart.getDay() === 6),
+      });
       cur.setTime(next.getTime());
     }
     return cells;
@@ -166,7 +205,7 @@
       const width = Math.max(2, todayPx - left);
       return {
         ...dateState,
-        effectiveDueTs: Date.now(),
+        effectiveDueTs: todayTs,
         left,
         width,
         color,
@@ -205,8 +244,23 @@
   function dateFromPointer(event) {
     const rect = bodyEl.getBoundingClientRect();
     const x = Math.max(0, event.clientX - rect.left + bodyEl.scrollLeft);
-    const day = Math.round(x / Math.max(pixelsPerDay, 1));
+    const day = Math.max(0, Math.min(totalDays - 1, Math.floor(x / Math.max(pixelsPerDay, 1))));
     return timelineStart.getTime() + day * DAY_MS;
+  }
+
+  function getRangeGeometry(startTs, endTs) {
+    const start = Math.min(startTs, endTs);
+    const end = Math.max(startTs, endTs);
+    const left = pxFromDate(start);
+    const width = Math.max(6, pxFromDate(end + DAY_MS) - left);
+    return { start, end, left, width };
+  }
+
+  function getCreatePreview(row) {
+    if (dragState?.mode !== "create" || dragState.id !== row.id) {
+      return null;
+    }
+    return getRangeGeometry(dragState.anchorTs, dragState.currentTs);
   }
 
   function createRange(event, row, bar) {
@@ -226,6 +280,26 @@
       "start date": formatDate(startTs),
       "due date": formatDate(dueTs),
     });
+  }
+
+  function startCreateDrag(event, row) {
+    if (event.button !== 0) {
+      return;
+    }
+
+    event.preventDefault();
+    event.stopPropagation();
+
+    const ts = dateFromPointer(event);
+    dragState = {
+      id: row.id,
+      mode: "create",
+      anchorTs: ts,
+      currentTs: ts,
+    };
+
+    document.addEventListener("pointermove", handlePointerMove);
+    document.addEventListener("pointerup", stopDrag);
   }
 
   function startDrag(event, row, mode, bar) {
@@ -252,6 +326,11 @@
 
   function handlePointerMove(event) {
     if (!dragState) {
+      return;
+    }
+
+    if (dragState.mode === "create") {
+      dragState.currentTs = dateFromPointer(event);
       return;
     }
 
@@ -289,6 +368,14 @@
   }
 
   function stopDrag() {
+    if (dragState?.mode === "create") {
+      const range = getRangeGeometry(dragState.anchorTs, dragState.currentTs);
+      commitTaskDates(dragState.id, {
+        "start date": formatDate(range.start),
+        "due date": formatDate(range.end),
+      });
+    }
+
     dragState = undefined;
     document.removeEventListener("pointermove", handlePointerMove);
     document.removeEventListener("pointerup", stopDrag);
@@ -322,7 +409,14 @@
         style="width:{totalWidth}px; transform: translateX(-{headerScrollLeft}px);"
       >
         {#each headerCells as cell}
-          <div class="HeaderCell" style="left:{cell.leftPx}px; width:{cell.widthPx}px;">
+          <div
+            class="HeaderCell"
+            class:PastCell={cell.tone === "past"}
+            class:TodayCell={cell.tone === "today"}
+            class:FutureCell={cell.tone === "future"}
+            class:WeekendCell={cell.weekend}
+            style="left:{cell.leftPx}px; width:{cell.widthPx}px;"
+          >
             {cell.label}
           </div>
         {/each}
@@ -336,18 +430,36 @@
 
   <!-- Body: rows synced with TreeTable -->
   <div class="GanttBody" bind:this={bodyEl} on:scroll={handleBodyScroll}>
-    <div class="GanttBodyInner" style="width:{totalWidth}px;">
+    <div class="GanttBodyInner" style="width:{totalWidth}px; height:{rows.length * 2}rem;">
+      {#each headerCells as cell}
+        <div
+          class="GridCell"
+          class:PastCell={cell.tone === "past"}
+          class:TodayCell={cell.tone === "today"}
+          class:FutureCell={cell.tone === "future"}
+          class:WeekendCell={cell.weekend}
+          style="left:{cell.leftPx}px; width:{cell.widthPx}px;"
+        ></div>
+      {/each}
       <!-- Today line in body -->
       {#if todayPx >= 0 && todayPx <= totalWidth}
         <div class="TodayLineFull" style="left:{todayPx}px;"></div>
       {/if}
       {#each rows as row (row.id)}
         {@const bar = getBarStyle(row)}
+        {@const preview = getCreatePreview(row)}
         <div
           class="GanttRow"
           role="presentation"
+          on:pointerdown={(event) => startCreateDrag(event, row)}
           on:dblclick={(event) => createRange(event, row, bar)}
         >
+          {#if preview}
+            <div
+              class="CreatePreview"
+              style="left:{preview.left}px; width:{preview.width}px;"
+            ></div>
+          {/if}
           {#if bar}
             <button
               type="button"
@@ -457,6 +569,22 @@
     overflow: hidden;
     box-sizing: border-box;
   }
+  .HeaderCell.PastCell,
+  .GridCell.PastCell {
+    background-color: color-mix(in srgb, var(--theme-color-Sub-main) 7%, transparent);
+  }
+  .HeaderCell.FutureCell,
+  .GridCell.FutureCell {
+    background-color: color-mix(in srgb, var(--theme-color-Main-main) 80%, transparent);
+  }
+  .HeaderCell.WeekendCell,
+  .GridCell.WeekendCell {
+    background-color: color-mix(in srgb, var(--theme-color-Sub-main) 12%, transparent);
+  }
+  .HeaderCell.TodayCell,
+  .GridCell.TodayCell {
+    background-color: color-mix(in srgb, var(--theme-color-Accent-main) 18%, transparent);
+  }
 
   .TodayLine {
     position: absolute;
@@ -479,6 +607,16 @@
     position: relative;
   }
 
+  .GridCell {
+    position: absolute;
+    top: 0;
+    bottom: 0;
+    border-right: 1px solid color-mix(in srgb, var(--theme-color-Shadow-main) 72%, transparent);
+    box-sizing: border-box;
+    pointer-events: none;
+    z-index: 0;
+  }
+
   .TodayLineFull {
     position: absolute;
     top: 0;
@@ -494,6 +632,19 @@
     height: 2rem;
     position: relative;
     border-bottom: 1px solid color-mix(in srgb, var(--theme-color-Shadow-main) 50%, transparent);
+    cursor: crosshair;
+    z-index: 1;
+  }
+
+  .CreatePreview {
+    position: absolute;
+    top: 20%;
+    height: 60%;
+    border: 1px solid var(--theme-color-Accent-main);
+    border-radius: 3px;
+    background-color: color-mix(in srgb, var(--theme-color-Accent-main) 42%, transparent);
+    pointer-events: none;
+    z-index: 2;
   }
 
   .Bar {
@@ -504,7 +655,7 @@
     border-radius: 3px;
     min-width: 2px;
     cursor: grab;
-    z-index: 2;
+    z-index: 3;
     padding: 0;
   }
 
@@ -532,7 +683,7 @@
     background: color-mix(in srgb, var(--theme-color-Main-main) 70%, transparent);
     cursor: ew-resize;
     padding: 0;
-    z-index: 3;
+    z-index: 4;
   }
 
   .StartHandle {


### PR DESCRIPTION
## Summary

- Gantt ヘッダーの日付をブラウザのローカルロケール表示にし、日/週表示では曜日も表示するようにした
- 日/週/月スケールごとに縦グリッド線を追加し、過去・今日・未来・週末の背景を色分けした
- タスク行の空白部分をドラッグして、開始日/期日の範囲を直接作成できるようにした
- ドラッグ中は半透明のプレビュー範囲を表示し、逆方向ドラッグでも開始日/期日を正規化して保存する

## Validation

- `svelte-check --tsconfig ./tsconfig.json`
- `eslint src/components/GanttPanel.svelte`
- `vitest run tests/component/ProjectPage.test.js tests/component/TreeTable.test.js`
- `vite build`