### PR TITLE
メモ内容を含む全文検索に対応 (close #142)

### DIFF
--- a/src/common/memo_utils.ts
+++ b/src/common/memo_utils.ts
@@ -1,0 +1,50 @@
+export function isQuillDelta(value: unknown): value is { ops: Array<{ insert?: unknown }> } {
+  return (
+    typeof value === "object" &&
+    value !== null &&
+    Array.isArray((value as { ops?: unknown }).ops)
+  );
+}
+
+export function quillDeltaToMarkdown(delta: { ops: Array<{ insert?: unknown }> }): string {
+  return delta.ops
+    .map((op) => {
+      if (typeof op.insert === "string") {
+        return op.insert;
+      }
+      if (
+        typeof op.insert === "object" &&
+        op.insert !== null &&
+        typeof (op.insert as { image?: unknown }).image === "string"
+      ) {
+        return `![](${(op.insert as { image: string }).image})`;
+      }
+      return "";
+    })
+    .join("")
+    .replace(/\s+$/, "");
+}
+
+export function toMarkdown(val: unknown): string {
+  if (!val) return "";
+  if (typeof val === "string") return val;
+  if (isQuillDelta(val)) return quillDeltaToMarkdown(val);
+  return JSON.stringify(val, null, 2);
+}
+
+// data URL (base64) を除去して照合コストを下げる
+export function memoContentForSearch(val: unknown): string {
+  return toMarkdown(val).replace(/data:[^)]+/g, "");
+}
+
+// 将来 elasticlunr 等のインデックス型エンジンに差し替え可能な検索ポイント
+export function searchMemoEntries(
+  memos: Array<{ content: unknown }>,
+  keywords: string[]
+): boolean {
+  return memos.some((entry) =>
+    keywords.some((keyword) =>
+      memoContentForSearch(entry.content).toLowerCase().includes(keyword.toLowerCase())
+    )
+  );
+}

--- a/src/common/memo_utils.ts
+++ b/src/common/memo_utils.ts
@@ -1,8 +1,6 @@
 export function isQuillDelta(value: unknown): value is { ops: Array<{ insert?: unknown }> } {
   return (
-    typeof value === "object" &&
-    value !== null &&
-    Array.isArray((value as { ops?: unknown }).ops)
+    typeof value === "object" && value !== null && Array.isArray((value as { ops?: unknown }).ops)
   );
 }
 
@@ -38,10 +36,7 @@ export function memoContentForSearch(val: unknown): string {
 }
 
 // 将来 elasticlunr 等のインデックス型エンジンに差し替え可能な検索ポイント
-export function searchMemoEntries(
-  memos: Array<{ content: unknown }>,
-  keywords: string[]
-): boolean {
+export function searchMemoEntries(memos: Array<{ content: unknown }>, keywords: string[]): boolean {
   return memos.some((entry) =>
     keywords.some((keyword) =>
       memoContentForSearch(entry.content).toLowerCase().includes(keyword.toLowerCase())

--- a/src/common/tree_control.ts
+++ b/src/common/tree_control.ts
@@ -1,4 +1,5 @@
 import { uuidV4 } from "./uuid";
+import { searchMemoEntries } from "./memo_utils";
 
 export type TaskStatus = "Open" | "Pending" | "In Progress" | "Completed" | "Canceled";
 
@@ -64,16 +65,23 @@ export function filterTree(
 
   // Evaluate each filter
   for (const key in filter) {
+    if (key === "search_memo") continue; // flag key, not a data field
+
     const keywords = filter[key];
     if (!keywords || keywords.length === 0) continue;
 
     let keyMatch = false;
     if (key === "name") {
       // In case of name filter
-      keyMatch = keywords.some(
+      const nameMatch = keywords.some(
         (keyword) => tree.data.name && tree.data.name.toLowerCase().includes(keyword.toLowerCase())
       );
-      nameFilterMatch = keyMatch; // Record if name filter matched
+      const memoMatch =
+        !nameMatch &&
+        (filter["search_memo"]?.length ?? 0) > 0 &&
+        searchMemoEntries(tree.data.memo ?? [], keywords);
+      keyMatch = nameMatch || memoMatch;
+      nameFilterMatch = keyMatch; // Record if name/memo filter matched
     } else {
       // For other filters
       keyMatch = keywords.some(

--- a/src/components/Memo.svelte
+++ b/src/components/Memo.svelte
@@ -8,6 +8,7 @@
   import { history, defaultKeymap, historyKeymap } from "@codemirror/commands";
   import { highlightSelectionMatches, searchKeymap } from "@codemirror/search";
   import { marked } from "marked";
+  import { toMarkdown } from "../common/memo_utils";
 
   export let saveMemo: (content: string) => void;
   export let content: unknown = "";
@@ -31,38 +32,6 @@
   let livePreviewEl: HTMLElement | null = null;
 
   const EXTERNAL_LINK_PATTERN = /^(https?:\/\/|mailto:|file:\/\/)/i;
-
-  function isQuillDelta(value: unknown): value is { ops: Array<{ insert?: unknown }> } {
-    return (
-      typeof value === "object" && value !== null && Array.isArray((value as { ops?: unknown }).ops)
-    );
-  }
-
-  function quillDeltaToMarkdown(delta: { ops: Array<{ insert?: unknown }> }): string {
-    return delta.ops
-      .map((op) => {
-        if (typeof op.insert === "string") {
-          return op.insert;
-        }
-        if (
-          typeof op.insert === "object" &&
-          op.insert !== null &&
-          typeof (op.insert as { image?: unknown }).image === "string"
-        ) {
-          return `![](${(op.insert as { image: string }).image})`;
-        }
-        return "";
-      })
-      .join("")
-      .replace(/\s+$/, "");
-  }
-
-  function toMarkdown(val: unknown): string {
-    if (!val) return "";
-    if (typeof val === "string") return val;
-    if (isQuillDelta(val)) return quillDeltaToMarkdown(val);
-    return JSON.stringify(val, null, 2);
-  }
 
   function normalizeMemoTitle(title: string): string {
     return title.trim().toLocaleLowerCase();

--- a/src/components/SearchBox.svelte
+++ b/src/components/SearchBox.svelte
@@ -5,6 +5,7 @@
 
   let search_text = "";
   let search_box; //bind
+  let memoSearchEnabled = false;
 
   const applySearch = (value = search_text) => {
     search_text = value;
@@ -14,9 +15,19 @@
     };
   };
 
+  const toggleMemoSearch = () => {
+    const next = !memoSearchEnabled;
+    $filter = {
+      ...$filter,
+      search_memo: next ? ["1"] : null,
+    };
+  };
+
   $: if (($filter?.name?.[0] ?? "") !== search_text && document.activeElement !== search_box) {
     search_text = $filter?.name?.[0] ?? "";
   }
+
+  $: memoSearchEnabled = ($filter?.search_memo?.length ?? 0) > 0;
 
   const params = {
     color: "var(--theme-color-Main-main)",
@@ -64,6 +75,27 @@
       ><path
         d="M15.7955 15.8111L21 21M18 10.5C18 14.6421 14.6421 18 10.5 18C6.35786 18 3 14.6421 3 10.5C3 6.35786 6.35786 3 10.5 3C14.6421 3 18 6.35786 18 10.5Z"
         stroke="#000000"
+        stroke-width="2"
+        stroke-linecap="round"
+        stroke-linejoin="round"
+      ></path></svg
+    >
+  </IconButton>
+  <IconButton
+    on:click={toggleMemoSearch}
+    ariaLabel={memoSearchEnabled ? "Disable memo search" : "Enable memo search"}
+    aria-pressed={memoSearchEnabled}
+    use_ripple={true}
+    normalColor={memoSearchEnabled
+      ? "var(--theme-color-Main-main)"
+      : "var(--theme-color-Shadow-sub)"}
+    activeColor="var(--theme-color-Shadow-sub-translucent)"
+    style={"box-shadow: none; width: 2rem; height: 2rem;"}
+  >
+    <svg viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg"
+      ><path
+        d="M9 12h6M9 16h6M7 4H5a2 2 0 00-2 2v14a2 2 0 002 2h14a2 2 0 002-2V6a2 2 0 00-2-2h-2M9 4h6a1 1 0 010 2H9a1 1 0 010-2z"
+        stroke="currentColor"
         stroke-width="2"
         stroke-linecap="round"
         stroke-linejoin="round"

--- a/src/stores/search.ts
+++ b/src/stores/search.ts
@@ -49,7 +49,7 @@ function createFilter(initialValue: FilterState): FilterStore {
     }
 
     filtered_data.set(filtered);
-  }, 300);
+  }, 500);
 
   const hasActiveFilters = (current: FilterState) =>
     Object.keys(current || {}).some((key) => current[key] && current[key].length > 0);


### PR DESCRIPTION
- memo_utils.ts を新規作成し toMarkdown/searchMemoEntries を共通化
  (将来 elasticlunr 等に差し替え可能な設計セアム)
- filterTree() を拡張: search_memo フラグが ON の場合に
  タスク名 OR メモ内容で OR 検索
- SearchBox にトグルボタンを追加: メモ検索の ON/OFF を制御
- filterTree の debounce を 300ms → 500ms に変更

https://claude.ai/code/session_013abGCUXuTkcK23qRForBZ9