### PR TITLE
feat: タスクのコピー＆ペースト機能を追加 (issue #30)

### DIFF
--- a/src/common/tree_control.ts
+++ b/src/common/tree_control.ts
@@ -130,6 +130,14 @@ function cloneTreeWithAllChildren(tree: TreeData): TreeData {
   return { ...tree, children };
 }
 
+export function cloneWithNewIds(node: TreeData): TreeData {
+  return {
+    id: `${uuidV4()}`,
+    data: { ...node.data, memo: [...node.data.memo] },
+    children: node.children.map((child) => cloneWithNewIds(child)),
+  };
+}
+
 export function getDefaultNode(): TreeData {
   return {
     id: `${uuidV4()}`,

--- a/src/components/TaskName.svelte
+++ b/src/components/TaskName.svelte
@@ -4,6 +4,7 @@
   import { ripple, tooltip } from "../common/common.js";
   import TaskMenu from "./TaskMenu.svelte";
   import { pageSearchQuery } from "../stores/search";
+  import { copied_task } from "../stores/ui";
 
   export let text;
   export let color = "var(--theme-color-Sub-main)";
@@ -50,6 +51,27 @@
       icon: {
         viewBox: "0 0 24 24",
         path: "M5 5V14H15M11 10L15 14L11 18M19 5V9M17 7H21",
+      },
+    },
+    ...(!isRoot
+      ? [
+          {
+            title: "copy",
+            action: "copyTask",
+            icon: {
+              viewBox: "0 0 24 24",
+              path: "M8 4v12a2 2 0 0 0 2 2h8a2 2 0 0 0 2-2V7.242a2 2 0 0 0-.602-1.43L16.083 2.57A2 2 0 0 0 14.685 2H10a2 2 0 0 0-2 2ZM4 8H2v12a2 2 0 0 0 2 2h8v-2H4Z",
+            },
+          },
+        ]
+      : []),
+    {
+      title: "paste as child",
+      action: "pasteTask",
+      disabled: $copied_task === null,
+      icon: {
+        viewBox: "0 0 24 24",
+        path: "M9 5H7a2 2 0 0 0-2 2v12a2 2 0 0 0 2 2h10a2 2 0 0 0 2-2V7a2 2 0 0 0-2-2h-2M9 5a2 2 0 0 0 2 2h2a2 2 0 0 0 2-2M9 5a2 2 0 0 1 2-2h2a2 2 0 0 1 2 2",
       },
     },
     ...(hasChildren

--- a/src/components/TreeTable.svelte
+++ b/src/components/TreeTable.svelte
@@ -27,7 +27,9 @@
     moveNodeDown,
     indentNode,
     outdentNode,
+    cloneWithNewIds,
   } from "../common/tree_control.ts";
+  import { copied_task } from "../stores/ui.ts";
 
   let table_root; // Bind
 
@@ -548,6 +550,39 @@
     handleAddRelative(event.detail.id, "append");
   }
 
+  function handleCopyTask(event) {
+    const { id } = event.detail;
+    if (!id || !$tree_data?.data) return;
+    const node = getNode(id, $tree_data.data);
+    if (node) $copied_task = node;
+  }
+
+  function handlePasteTask(event) {
+    const { id } = event.detail;
+    if (!id || !$tree_data?.data || !$copied_task) return;
+    const cloned = cloneWithNewIds($copied_task);
+    const data = addNode(cloned, id, $tree_data.data, "append");
+    $tree_data = { ...$tree_data, data };
+    if ($closed_node_ids.has(id)) closed_node_ids.delete(id);
+    focusNewNode(cloned.id);
+  }
+
+  function isEditingText() {
+    const el = document.activeElement;
+    return el && (el.tagName === "INPUT" || el.tagName === "TEXTAREA" || el.isContentEditable);
+  }
+
+  function handleGlobalKeydown(e) {
+    if (!$table_selected_id || isEditingText()) return;
+    if ((e.ctrlKey || e.metaKey) && e.key === "c") {
+      e.preventDefault();
+      handleCopyTask({ detail: { id: $table_selected_id } });
+    } else if ((e.ctrlKey || e.metaKey) && e.key === "v") {
+      e.preventDefault();
+      handlePasteTask({ detail: { id: $table_selected_id } });
+    }
+  }
+
   function requestDelete(event) {
     const { id } = event.detail;
     const node = getNode(id, $tree_data.data);
@@ -578,6 +613,8 @@
     deleteTargetName = "";
   }
 </script>
+
+<svelte:window on:keydown={handleGlobalKeydown} />
 
 <div
   bind:this={table_root}
@@ -629,6 +666,8 @@
         on:addBelow={handleAddBelow}
         on:addChild={handleAddChild}
         on:deleteTask={requestDelete}
+        on:copyTask={handleCopyTask}
+        on:pasteTask={handlePasteTask}
       />
     {/each}
   {:else}

--- a/src/components/TreeTableRow.svelte
+++ b/src/components/TreeTableRow.svelte
@@ -244,6 +244,12 @@
           on:deleteTask={() => {
             dispatch("deleteTask", { id });
           }}
+          on:copyTask={() => {
+            dispatch("copyTask", { id });
+          }}
+          on:pasteTask={() => {
+            dispatch("pasteTask", { id });
+          }}
           on:menuVisibilityChange={({ detail }) => {
             isMenuOpen = detail.open;
           }}

--- a/src/stores/ui.ts
+++ b/src/stores/ui.ts
@@ -243,3 +243,5 @@ export const showPageSearch = writable(false);
 
 export type SaveStatus = "idle" | "saving" | "saved" | "error";
 export const saveStatus = writable<SaveStatus>("idle");
+
+export const copied_task = writable<TreeData | null>(null);

--- a/tests/unit/tree_control.test.js
+++ b/tests/unit/tree_control.test.js
@@ -4,6 +4,7 @@ import {
   canMoveNodeDown,
   canMoveNodeUp,
   canOutdentNode,
+  cloneWithNewIds,
   filterTree,
   flattenVisibleTree,
   getNode,
@@ -229,5 +230,50 @@ describe("tree_control", () => {
 
   test("getNode returns undefined when the target does not exist", () => {
     expect(getNode("missing", createTree())).toBeUndefined();
+  });
+});
+
+describe("cloneWithNewIds", () => {
+  test("cloned root node has a different id", () => {
+    const tree = createTree();
+    const cloned = cloneWithNewIds(tree);
+    expect(cloned.id).not.toBe(tree.id);
+  });
+
+  test("cloned node preserves name, status, and memo", () => {
+    const tree = createTree();
+    const cloned = cloneWithNewIds(tree);
+    expect(cloned.data.name).toBe(tree.data.name);
+    expect(cloned.data.status).toBe(tree.data.status);
+    expect(cloned.data.memo).toEqual(tree.data.memo);
+  });
+
+  test("cloned children all get new ids", () => {
+    const tree = createTree();
+    const cloned = cloneWithNewIds(tree);
+    expect(cloned.children.length).toBe(tree.children.length);
+    cloned.children.forEach((child, i) => {
+      expect(child.id).not.toBe(tree.children[i].id);
+    });
+  });
+
+  test("cloned grandchildren also get new ids", () => {
+    const tree = createTree();
+    const cloned = cloneWithNewIds(tree);
+    const originalGrandchild = tree.children[1].children[0];
+    const clonedGrandchild = cloned.children[1].children[0];
+    expect(clonedGrandchild.id).not.toBe(originalGrandchild.id);
+    expect(clonedGrandchild.data.name).toBe(originalGrandchild.data.name);
+  });
+
+  test("modifying cloned memo does not affect original", () => {
+    const node = {
+      id: "a",
+      data: { name: "task", status: "Open", memo: [{ text: "hello" }] },
+      children: [],
+    };
+    const cloned = cloneWithNewIds(node);
+    cloned.data.memo.push({ text: "world" });
+    expect(node.data.memo.length).toBe(1);
   });
 });


### PR DESCRIPTION
- copied_task ストアを追加（内部クリップボード）
- cloneWithNewIds 関数を追加（サブツリーを新しい UUID で深くクローン）
- 右クリックメニューに "copy" / "paste as child" を追加
- Ctrl+C / Ctrl+V ホットキー対応（ノード選択中かつ非編集時のみ）
- ペーストは選択ノードの子として挿入され、新タスクにフォーカスが移る

https://claude.ai/code/session_01JggX4aCanLq2GYZrUf2Yrx