### PR TITLE
Fix context menu clipping at viewport edges

### DIFF
--- a/src/components/TaskName.svelte
+++ b/src/components/TaskName.svelte
@@ -230,7 +230,7 @@
 
   const getMenuPosition = (x, y) => {
     const viewportWidth = window.innerWidth;
-    const menuWidth = 180;
+    const menuWidth = 224; // 14rem at 16px base font, matches actual CSS min-width
 
     if (x + menuWidth > viewportWidth) {
       return {
@@ -270,7 +270,7 @@
     window.addEventListener("task-menu-opened", handleTaskMenuOpened);
   });
 
-  export function openMenuAt(position) {
+  export async function openMenuAt(position) {
     window.dispatchEvent(
       new CustomEvent("task-menu-opened", {
         detail: { ownerId: menuOwnerId },
@@ -278,6 +278,18 @@
     );
     menuPosition = getMenuPosition(position.x, position.y);
     setMenuVisibility(true);
+
+    await tick();
+
+    const menuEl = document.getElementById("task-menu");
+    if (menuEl) {
+      const rect = menuEl.getBoundingClientRect();
+      const viewportHeight = window.innerHeight;
+      if (rect.bottom > viewportHeight) {
+        const adjustedY = Math.max(0, menuPosition.y - (rect.bottom - viewportHeight));
+        menuPosition = { ...menuPosition, y: adjustedY };
+      }
+    }
   }
 
   onDestroy(() => {


### PR DESCRIPTION
Prevent the right-click context menu from being cut off near the bottom
of the screen by measuring the rendered menu height via tick() and
pulling it upward when it overflows the viewport. Also corrects the
horizontal overflow threshold from 180px to 224px to match the actual
CSS min-width of 14rem.

https://claude.ai/code/session_01ThhqwWSThKBu3J8cdYy4m6