### PR TITLE
feat: メモのフロントマタータグ＆タグブラウザー (issue #136)

### DIFF
--- a/electron/workspace.js
+++ b/electron/workspace.js
@@ -116,7 +116,8 @@ function readMemos(taskDir, reservedFiles = ["_index.md"]) {
         title = data.id === fileTitle ? "memo" : fileTitle;
       }
     }
-    memos.push({ id, title, content: body.trim() });
+    const tags = Array.isArray(data.tags) ? data.tags.map(String) : [];
+    memos.push({ id, title, content: body.trim(), tags });
   }
   return memos;
 }
@@ -197,7 +198,7 @@ function writeMemoFiles(taskDir, indexFileName, memos) {
     const id = memo.id || crypto.randomUUID();
     fs.writeFileSync(
       path.join(taskDir, `${id}.md`),
-      stringifyFrontmatter({ id, title: memo.title }, memo.content)
+      stringifyFrontmatter({ id, title: memo.title, tags: memo.tags ?? [] }, memo.content)
     );
   }
 }

--- a/src/common/tree_control.ts
+++ b/src/common/tree_control.ts
@@ -7,6 +7,7 @@ export interface MemoEntry {
   id: string;
   title: string;
   content: unknown;
+  tags: string[];
 }
 
 export interface TreeNodeData {
@@ -82,6 +83,11 @@ export function filterTree(
         searchMemoEntries(tree.data.memo ?? [], keywords);
       keyMatch = nameMatch || memoMatch;
       nameFilterMatch = keyMatch; // Record if name/memo filter matched
+    } else if (key === "tags") {
+      const tag = keywords[0].toLowerCase();
+      keyMatch = (tree.data.memo ?? []).some((entry) =>
+        ((entry.tags as string[]) ?? []).some((t) => t.toLowerCase() === tag)
+      );
     } else {
       // For other filters
       keyMatch = keywords.some(

--- a/src/common/workspace_tree.ts
+++ b/src/common/workspace_tree.ts
@@ -39,7 +39,12 @@ export function workspaceToProjectData(
         status: task.status,
         "start date": task.startDate as `${string}-${string}-${string}` | undefined,
         "due date": task.dueDate as `${string}-${string}-${string}` | undefined,
-        memo: task.memos.map((m) => ({ id: m.id, title: m.title, content: m.content })),
+        memo: task.memos.map((m) => ({
+          id: m.id,
+          title: m.title,
+          content: m.content,
+          tags: m.tags,
+        })),
       },
       children: childIds.map((cid) => buildNode(cid)),
     };
@@ -89,6 +94,7 @@ export function projectDataToWorkspaceTasks(
         id: m.id || "",
         title: m.title || "",
         content: typeof m.content === "string" ? m.content : "",
+        tags: Array.isArray(m.tags) ? m.tags : [],
       })),
       createdAt: existing?.createdAt || today,
     });

--- a/src/components/MemoTab.svelte
+++ b/src/components/MemoTab.svelte
@@ -13,6 +13,8 @@
   export let deleteMemo;
   export let renameMemo;
   export let reorderMemo;
+  export let saveMemoTags = null;
+  export let allTags = [];
   export let disabled = false;
   export let workspaceProjectDir = null;
   export let taskId = null;
@@ -86,6 +88,31 @@
 
   $: editedContent = memo.length > selectedMemoIndex ? memo[selectedMemoIndex].content : "";
   $: selectedMemo = memo[selectedMemoIndex];
+  $: currentTags = selectedMemo?.tags ?? [];
+
+  let tagInput = "";
+
+  function handleTagInput(e) {
+    if (e.key === "Enter" && tagInput.trim()) {
+      e.preventDefault();
+      const newTag = tagInput.trim().toLowerCase();
+      if (!currentTags.includes(newTag) && saveMemoTags) {
+        saveMemoTags(selectedMemoIndex, [...currentTags, newTag]);
+      }
+      tagInput = "";
+    } else if (e.key === "Backspace" && tagInput === "" && currentTags.length > 0 && saveMemoTags) {
+      saveMemoTags(selectedMemoIndex, currentTags.slice(0, -1));
+    }
+  }
+
+  function removeTag(tag) {
+    if (saveMemoTags) {
+      saveMemoTags(
+        selectedMemoIndex,
+        currentTags.filter((t) => t !== tag)
+      );
+    }
+  }
 
   let draggingIndex = -1;
   let dragOverIndex = -1;
@@ -242,6 +269,30 @@
     </div>
   </div>
 
+  {#if selectedMemo}
+    <div class="tag-bar">
+      {#each currentTags as tag (tag)}
+        <span class="tag-chip">
+          {tag}
+          <button class="tag-remove" on:click={() => removeTag(tag)} aria-label="Remove tag {tag}"
+            >×</button
+          >
+        </span>
+      {/each}
+      <input
+        class="tag-input"
+        type="text"
+        list="memo-tag-suggestions"
+        bind:value={tagInput}
+        on:keydown={handleTagInput}
+        placeholder={currentTags.length === 0 ? "タグを追加..." : ""}
+      />
+      <datalist id="memo-tag-suggestions">
+        {#each allTags as t}<option value={t}></option>{/each}
+      </datalist>
+    </div>
+  {/if}
+
   <div class="memotab-content">
     {#if selectedMemo}
       {#key `${$table_selected_id ?? "none"}:${selectedMemoIndex}`}
@@ -380,10 +431,62 @@
     border-right: 0.15rem solid var(--theme-color-Accent-main);
   }
 
+  .tag-bar {
+    display: flex;
+    flex-wrap: wrap;
+    align-items: center;
+    gap: 0.25rem;
+    padding: 0.25rem 0.5rem;
+    min-height: 2rem;
+    border-bottom: 1px solid var(--theme-color-Sub-dark);
+    flex-shrink: 0;
+  }
+
+  .tag-chip {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.2rem;
+    padding: 0.1rem 0.4rem;
+    border-radius: 0.75rem;
+    background-color: var(--theme-color-Accent-dark);
+    color: var(--theme-color-Main-main);
+    font-size: 0.75rem;
+    white-space: nowrap;
+  }
+
+  .tag-remove {
+    background: none;
+    border: none;
+    color: var(--theme-color-Main-main);
+    cursor: pointer;
+    padding: 0;
+    font-size: 0.75rem;
+    line-height: 1;
+    opacity: 0.7;
+  }
+
+  .tag-remove:hover {
+    opacity: 1;
+  }
+
+  .tag-input {
+    background: transparent;
+    border: none;
+    color: var(--theme-color-Sub-main);
+    font-size: 0.8rem;
+    min-width: 6rem;
+    flex: 1;
+    outline: none;
+    padding: 0;
+  }
+
+  .tag-input::placeholder {
+    color: var(--theme-color-Sub-dark);
+  }
+
   .memotab-content {
     display: flex;
     box-sizing: border-box;
-    height: calc(100% - 5.5rem);
     flex: 1;
     overflow: hidden;
   }

--- a/src/components/MenuList.svelte
+++ b/src/components/MenuList.svelte
@@ -9,7 +9,14 @@
   import Dialog from "./Dialog.svelte";
   import WorkspaceSetup from "./WorkspaceSetup.svelte";
   import { ripple, tooltip } from "../common/common.js";
-  import { project_ids, info_ids, selected_type, selected_id } from "../stores.ts";
+  import {
+    project_ids,
+    info_ids,
+    selected_type,
+    selected_id,
+    tag_index,
+    active_tag,
+  } from "../stores.ts";
   import { workspace_store } from "../stores/workspace";
   import { getDefaultProject } from "../common/tree_control";
 
@@ -31,6 +38,7 @@
   }
 
   let show_workspace_setup = false;
+  let tagsExpanded = true;
 
   // Dialog
   let show_confirm = false;
@@ -439,6 +447,61 @@
   {:else}
     <p style="color: white;">loading...</p>
   {/if}
+
+  <!-- Tag browser -->
+  {#if $tag_index.size > 0}
+    <br />
+    <div class="Section">
+      <span class="TagLogo">#</span>
+      <span class="TextOverFlow">Tags</span>
+      <div class="AddButtonContainer">
+        <IconButton
+          ariaLabel="Toggle tags section"
+          normalColor="rgba(255,255,255,0.1)"
+          activeColor="rgba(255,255,255,0.2)"
+          on:click={() => (tagsExpanded = !tagsExpanded)}
+        >
+          {#if tagsExpanded}
+            <svg viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
+              <path
+                d="M18 15L12 9L6 15"
+                stroke="white"
+                stroke-width="2"
+                stroke-linecap="round"
+                stroke-linejoin="round"
+              />
+            </svg>
+          {:else}
+            <svg viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
+              <path
+                d="M6 9L12 15L18 9"
+                stroke="white"
+                stroke-width="2"
+                stroke-linecap="round"
+                stroke-linejoin="round"
+              />
+            </svg>
+          {/if}
+        </IconButton>
+      </div>
+    </div>
+    {#if tagsExpanded}
+      <div class="TagContents" transition:slide={{ duration: 100 }}>
+        {#each [...$tag_index.entries()].sort( ([a], [b]) => a.localeCompare(b) ) as [tag, nodes] (tag)}
+          <button
+            class="MenuRow"
+            class:Selected={$active_tag === tag}
+            use:ripple
+            on:click={() => ($active_tag = $active_tag === tag ? null : tag)}
+          >
+            <div class="TreeLine" style="flex-shrink: 0"></div>
+            <span class="TextOverFlow">{tag}</span>
+            <span class="TagBadge">{nodes.size}</span>
+          </button>
+        {/each}
+      </div>
+    {/if}
+  {/if}
 </div>
 <Dialog
   show={show_confirm}
@@ -611,5 +674,31 @@
   }
   .NoWorkspace:hover {
     text-decoration: underline;
+  }
+  .TagLogo {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    width: 1.5rem;
+    height: 1.5rem;
+    margin-right: 1rem;
+    color: white;
+    font-weight: bold;
+    font-size: 1.1rem;
+    flex-shrink: 0;
+  }
+  .TagContents {
+    display: flex;
+    flex-direction: column;
+    width: 100%;
+    max-height: 30%;
+    overflow-y: auto;
+  }
+  .TagBadge {
+    margin-left: auto;
+    margin-right: 0.5rem;
+    font-size: 0.7rem;
+    color: rgba(255, 255, 255, 0.6);
+    flex-shrink: 0;
   }
 </style>

--- a/src/components/TaskDetail.svelte
+++ b/src/components/TaskDetail.svelte
@@ -7,6 +7,7 @@
     cancelPendingOperations,
     selected_type,
     workspace_store,
+    tag_index,
   } from "../stores.ts";
   import { debounce } from "lodash";
   import { onDestroy } from "svelte";
@@ -37,9 +38,11 @@
   onDestroy(() => {
     unsubscribeCancelPending();
   });
+  $: allTags = [...$tag_index.keys()].sort();
+
   const addMemo = (newMemoTitle) => {
     if (newMemoTitle) {
-      let newMemo = { id: uuidV4(), title: newMemoTitle, content: "" };
+      let newMemo = { id: uuidV4(), title: newMemoTitle, content: "", tags: [] };
       changeData(node, "memo", [...node.data.memo, newMemo]);
       return true;
     }
@@ -76,6 +79,12 @@
     updatedMemo.splice(toIndex, 0, moved);
     changeData(node, "memo", updatedMemo);
   };
+  const saveMemoTags = (selectedMemoIndex, tags) => {
+    const updatedMemo = [...node.data["memo"]];
+    updatedMemo[selectedMemoIndex] = { ...updatedMemo[selectedMemoIndex], tags };
+    node.data["memo"] = updatedMemo;
+    changeDataDebounce(node, "memo", updatedMemo);
+  };
 </script>
 
 <div class="container">
@@ -88,6 +97,8 @@
         {deleteMemo}
         {renameMemo}
         {reorderMemo}
+        {saveMemoTags}
+        {allTags}
         {workspaceProjectDir}
         taskId={$table_selected_id ?? null}
       />

--- a/src/stores/index.ts
+++ b/src/stores/index.ts
@@ -6,6 +6,7 @@ export * from "./search";
 export * from "./ui";
 export * from "./column_settings";
 export * from "./workspace";
+export * from "./tags";
 
 import { tree_data } from "./tree";
 import { project_ids } from "./project";
@@ -14,6 +15,7 @@ import { filter } from "./search";
 import { theme } from "./theme";
 import { column_settings } from "./column_settings";
 import { workspace_store } from "./workspace";
+import { active_tag } from "./tags";
 
 export function init_store() {
   tree_data.init();
@@ -24,4 +26,16 @@ export function init_store() {
   closed_node_ids.init();
   column_settings.init();
   workspace_store.init();
+
+  active_tag.subscribe((tag) => {
+    filter.update((f) => {
+      const next = { ...f };
+      if (tag) {
+        next["tags"] = [tag];
+      } else {
+        delete next["tags"];
+      }
+      return next;
+    });
+  });
 }

--- a/src/stores/tags.ts
+++ b/src/stores/tags.ts
@@ -17,7 +17,7 @@ tree_data.subscribe((projectData) => {
         for (const tag of (memo.tags as string[]) ?? []) {
           const normalized = tag.toLowerCase();
           if (!index.has(normalized)) index.set(normalized, new Set());
-          index.get(normalized)!.add(node.data.id);
+          index.get(normalized)!.add(node.id);
         }
       }
       walk(node.children ?? []);

--- a/src/stores/tags.ts
+++ b/src/stores/tags.ts
@@ -1,0 +1,29 @@
+import { writable } from "svelte/store";
+import { tree_data } from "./tree";
+import type { TreeData } from "../common/tree_control";
+
+/** tag name (lowercase) → set of task node IDs that have a memo with this tag */
+export type TagIndex = Map<string, Set<string>>;
+
+export const tag_index = writable<TagIndex>(new Map());
+export const active_tag = writable<string | null>(null);
+
+tree_data.subscribe((projectData) => {
+  const index = new Map<string, Set<string>>();
+
+  function walk(nodes: TreeData[]) {
+    for (const node of nodes ?? []) {
+      for (const memo of node.data.memo ?? []) {
+        for (const tag of (memo.tags as string[]) ?? []) {
+          const normalized = tag.toLowerCase();
+          if (!index.has(normalized)) index.set(normalized, new Set());
+          index.get(normalized)!.add(node.data.id);
+        }
+      }
+      walk(node.children ?? []);
+    }
+  }
+
+  walk(projectData?.data ? [projectData.data] : []);
+  tag_index.set(index);
+});

--- a/src/types/workspace.ts
+++ b/src/types/workspace.ts
@@ -4,6 +4,7 @@ export interface WorkspaceMemo {
   id: string;
   title: string;
   content: string; // Markdown
+  tags: string[];
 }
 
 export interface WorkspaceTask {

--- a/tests/e2e/tags.spec.js
+++ b/tests/e2e/tags.spec.js
@@ -1,0 +1,193 @@
+import fs from "fs";
+import os from "os";
+import path from "path";
+import { test, expect, _electron as electron } from "@playwright/test";
+
+const FIXTURE_DIR = path.join(__dirname, "fixtures");
+
+const WS_PROJECT_ID = "ws-proj-tagged";
+const WS_TASK_ID = "ws-task-tagged";
+const WS_MEMO_ID = "ws-memo-tagged";
+
+/** Build workspace fixture files directly without importing the CommonJS workspace.js */
+function buildWorkspaceTempDir() {
+  const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), "tm-tags-"));
+  fs.copyFileSync(path.join(FIXTURE_DIR, "db.json"), path.join(tempDir, "db.json"));
+
+  const wsDir = path.join(tempDir, "ws");
+  const projectDir = path.join(wsDir, "tagged-project");
+  const taskDir = path.join(projectDir, WS_TASK_ID);
+  fs.mkdirSync(taskDir, { recursive: true });
+
+  fs.writeFileSync(
+    path.join(projectDir, "_project.md"),
+    "---\nid: " + WS_PROJECT_ID + "\nname: Tagged Project\nstatus: Open\ncreated: 2026-01-01\n---\n"
+  );
+
+  fs.writeFileSync(
+    path.join(taskDir, "_index.md"),
+    "---\nid: " +
+      WS_TASK_ID +
+      "\nname: Tagged Task\nstatus: Open\nparents:\n  - " +
+      WS_PROJECT_ID +
+      "\ncreated: 2026-01-01\n---\n"
+  );
+
+  fs.writeFileSync(
+    path.join(taskDir, WS_MEMO_ID + ".md"),
+    "---\nid: " +
+      WS_MEMO_ID +
+      "\ntitle: Design Notes\ntags:\n  - design\n  - frontend\n---\n\nSome design thoughts\n"
+  );
+
+  const meta = {
+    theme: "dark",
+    workspaces: [{ name: "Test Workspace", path: wsDir }],
+    activeWorkspace: wsDir,
+  };
+  fs.writeFileSync(path.join(tempDir, "meta.json"), JSON.stringify(meta));
+
+  return tempDir;
+}
+
+async function launchTagsApp() {
+  const tempDir = buildWorkspaceTempDir();
+  const launchEnv = { ...process.env };
+  delete launchEnv.ELECTRON_RUN_AS_NODE;
+
+  const electronApp = await electron.launch({
+    args: [".", "--no-sandbox"],
+    cwd: path.resolve(__dirname, "../.."),
+    env: {
+      ...launchEnv,
+      ELECTRON_DISABLE_SANDBOX: "1",
+      PLAYWRIGHT_TEST: "true",
+      TASK_MANAGE_DATA_DIR: tempDir,
+      TASK_MANAGE_OPEN_DEVTOOLS: "false",
+    },
+  });
+
+  const window = await electronApp.firstWindow();
+  await expect(window.getByText("Task Manage")).toBeVisible();
+
+  // Open the navigation drawer, then select the workspace project
+  await window.getByRole("button", { name: "Open navigation menu" }).click();
+  const projectBtn = window.locator("button.MenuRow", { hasText: "Tagged Project" });
+  await projectBtn.waitFor();
+  await projectBtn.click();
+  await expect(window.locator(`#${WS_TASK_ID}`)).toBeVisible();
+
+  return { tempDir, electronApp, window };
+}
+
+async function closeTagsApp(app) {
+  try {
+    await app.electronApp.close();
+  } finally {
+    fs.rmSync(app.tempDir, { recursive: true, force: true });
+  }
+}
+
+test("tag browser appears in sidebar when workspace project has tagged memos", async () => {
+  const app = await launchTagsApp();
+  try {
+    await expect(app.window.locator(".TagContents")).toBeVisible();
+    await expect(
+      app.window.locator(".TagContents").getByText("design", { exact: false })
+    ).toBeVisible();
+    await expect(
+      app.window.locator(".TagContents").getByText("frontend", { exact: false })
+    ).toBeVisible();
+  } finally {
+    await closeTagsApp(app);
+  }
+});
+
+test("clicking a tag in the sidebar filters to tasks with that tag", async () => {
+  const app = await launchTagsApp();
+  try {
+    await app.window.locator(".TagContents button").filter({ hasText: "design" }).click();
+    await expect(app.window.locator(`#${WS_TASK_ID}`)).toBeVisible();
+  } finally {
+    await closeTagsApp(app);
+  }
+});
+
+test("clicking the active tag again clears the filter", async () => {
+  const app = await launchTagsApp();
+  try {
+    const tagButton = app.window.locator(".TagContents button").filter({ hasText: "design" });
+    await tagButton.click();
+    await tagButton.click();
+    await expect(app.window.locator(`#${WS_TASK_ID}`)).toBeVisible();
+  } finally {
+    await closeTagsApp(app);
+  }
+});
+
+test("tag input adds a chip and the tag persists after app restart", async () => {
+  const tempDir = buildWorkspaceTempDir();
+  const launchEnv = { ...process.env };
+  delete launchEnv.ELECTRON_RUN_AS_NODE;
+
+  const launchOpts = {
+    args: [".", "--no-sandbox"],
+    cwd: path.resolve(__dirname, "../.."),
+    env: {
+      ...launchEnv,
+      ELECTRON_DISABLE_SANDBOX: "1",
+      PLAYWRIGHT_TEST: "true",
+      TASK_MANAGE_DATA_DIR: tempDir,
+      TASK_MANAGE_OPEN_DEVTOOLS: "false",
+    },
+  };
+
+  // First launch: add a tag via the tag input bar
+  const app1 = await electron.launch(launchOpts);
+  try {
+    const window1 = await app1.firstWindow();
+    await expect(window1.getByText("Task Manage")).toBeVisible();
+    await window1.getByRole("button", { name: "Open navigation menu" }).click();
+    const projectBtn1 = window1.locator("button.MenuRow", { hasText: "Tagged Project" });
+    await projectBtn1.waitFor();
+    await projectBtn1.click();
+    await expect(window1.locator(`#${WS_TASK_ID}`)).toBeVisible();
+
+    // Close the navigation drawer before interacting with task rows
+    await window1.getByRole("button", { name: "Close navigation menu" }).click();
+    await expect(window1.locator(".Mask")).not.toBeVisible();
+
+    // Dispatch click directly on the row element to avoid child stopPropagation
+    await window1.locator(`#${WS_TASK_ID}`).dispatchEvent("click");
+
+    const tagInput = window1.locator(".tag-input");
+    await tagInput.fill("ux");
+    await tagInput.press("Enter");
+    await expect(window1.locator('[aria-label="Remove tag ux"]')).toBeVisible();
+
+    // Wait for debounced save (500ms) + buffer
+    await window1.waitForTimeout(1000);
+  } finally {
+    await app1.close();
+  }
+
+  // Second launch: verify tag persisted
+  const app2 = await electron.launch(launchOpts);
+  try {
+    const window2 = await app2.firstWindow();
+    await expect(window2.getByText("Task Manage")).toBeVisible();
+    await window2.getByRole("button", { name: "Open navigation menu" }).click();
+    const projectBtn2 = window2.locator("button.MenuRow", { hasText: "Tagged Project" });
+    await projectBtn2.waitFor();
+    await projectBtn2.click();
+    await expect(window2.locator(`#${WS_TASK_ID}`)).toBeVisible();
+    await window2.getByRole("button", { name: "Close navigation menu" }).click();
+    await expect(window2.locator(".Mask")).not.toBeVisible();
+    await window2.locator(`#${WS_TASK_ID}`).dispatchEvent("click");
+
+    await expect(window2.locator('[aria-label="Remove tag ux"]')).toBeVisible();
+  } finally {
+    await app2.close();
+    fs.rmSync(tempDir, { recursive: true, force: true });
+  }
+});

--- a/tests/unit/tree_control.test.js
+++ b/tests/unit/tree_control.test.js
@@ -84,6 +84,90 @@ describe("tree_control", () => {
     expect(filtered.children[0].data.status).toBe("Pending");
   });
 
+  test("filterTree with tags filter keeps only tasks whose memos contain the tag", () => {
+    const tree = {
+      id: "root",
+      data: { name: "Root", status: "Open", memo: [] },
+      children: [
+        {
+          id: "task-a",
+          data: {
+            name: "Task A",
+            status: "Open",
+            memo: [{ id: "m1", title: "Note", content: "text", tags: ["design"] }],
+          },
+          children: [],
+        },
+        {
+          id: "task-b",
+          data: {
+            name: "Task B",
+            status: "Open",
+            memo: [{ id: "m2", title: "Note", content: "text", tags: ["backend"] }],
+          },
+          children: [],
+        },
+      ],
+    };
+
+    const filtered = filterTree(tree, { tags: ["design"] });
+
+    expect(filtered.children).toHaveLength(1);
+    expect(filtered.children[0].id).toBe("task-a");
+  });
+
+  test("filterTree with tags filter does not expand children of matching parent", () => {
+    const tree = {
+      id: "root",
+      data: { name: "Root", status: "Open", memo: [] },
+      children: [
+        {
+          id: "task-parent",
+          data: {
+            name: "Parent",
+            status: "Open",
+            memo: [{ id: "m1", title: "Note", content: "text", tags: ["design"] }],
+          },
+          children: [
+            {
+              id: "task-child",
+              data: { name: "Child", status: "Open", memo: [] },
+              children: [],
+            },
+          ],
+        },
+      ],
+    };
+
+    const filtered = filterTree(tree, { tags: ["design"] });
+
+    // Parent matches, but child has no tag — child should not be included
+    expect(filtered.children[0].id).toBe("task-parent");
+    expect(filtered.children[0].children).toHaveLength(0);
+  });
+
+  test("filterTree with tags filter returns null when no task matches", () => {
+    const tree = {
+      id: "root",
+      data: { name: "Root", status: "Open", memo: [] },
+      children: [
+        {
+          id: "task-a",
+          data: {
+            name: "Task A",
+            status: "Open",
+            memo: [{ id: "m1", title: "Note", content: "text", tags: ["frontend"] }],
+          },
+          children: [],
+        },
+      ],
+    };
+
+    const filtered = filterTree(tree, { tags: ["design"] });
+
+    expect(filtered).toBeNull();
+  });
+
   test("updateNodeDataById patches a nested node without mutating siblings", () => {
     const tree = createTree();
     const originalSibling = tree.children[0];

--- a/tests/unit/workspace.test.js
+++ b/tests/unit/workspace.test.js
@@ -291,6 +291,54 @@ describe("file system operations", () => {
     expect(loaded.memos[0].title).toBe("Notes");
   });
 
+  it("writeTask + readProject round-trips memo tags", () => {
+    const { projectDir } = createProject(tmpDir, "Proj", "root-id");
+    const taskDirs = new Map([["root-id", "_project"]]);
+    const task = {
+      id: "task-tags",
+      name: "Tagged Task",
+      status: "Open",
+      parents: ["root-id"],
+      memos: [
+        {
+          id: "memo-tagged",
+          title: "Notes",
+          content: "Some content",
+          tags: ["design", "frontend"],
+        },
+      ],
+      createdAt: "2026-04-24",
+    };
+    writeTask(projectDir, task, taskDirs);
+
+    const memoFile = fs.readFileSync(path.join(projectDir, "task-tags", "memo-tagged.md"), "utf8");
+    expect(memoFile).toContain("tags:");
+    expect(memoFile).toContain("- design");
+    expect(memoFile).toContain("- frontend");
+
+    const { tasks } = readProject(projectDir);
+    const loaded = tasks.get("task-tags");
+    expect(loaded.memos[0].tags).toEqual(["design", "frontend"]);
+  });
+
+  it("memo tags default to empty array when absent from frontmatter", () => {
+    const { projectDir } = createProject(tmpDir, "Proj", "root-id");
+    const taskDirs = new Map([["root-id", "_project"]]);
+    const task = {
+      id: "task-no-tags",
+      name: "Untagged Task",
+      status: "Open",
+      parents: ["root-id"],
+      memos: [{ id: "memo-no-tags", title: "Notes", content: "Content" }],
+      createdAt: "2026-04-24",
+    };
+    writeTask(projectDir, task, taskDirs);
+
+    const { tasks } = readProject(projectDir);
+    const loaded = tasks.get("task-no-tags");
+    expect(loaded.memos[0].tags).toEqual([]);
+  });
+
   it("preserves memo tab titles for empty workspace memos", () => {
     const { projectDir } = createProject(tmpDir, "Proj", "root-id");
     const taskDirs = new Map([["root-id", "_project"]]);


### PR DESCRIPTION
## Summary

- メモの `.md` ファイルの YAML フロントマターに `tags:` フィールドを追加し、インライン `#tagname` と Markdown の構文衝突を回避しながらタグを管理
- `MemoTab` にチップ形式のタグ入力バーを追加（`datalist` で既存タグの補完付き）
- サイドバー下部に折り畳み式タグブラウザーを追加（件数バッジ・アルファベット順表示）
- タグクリックで全プロジェクト横断フィルターを適用、再クリックで解除

## Changes

| ファイル | 内容 |
|---|---|
| `src/types/workspace.ts` | `WorkspaceMemo` に `tags: string[]` 追加 |
| `src/common/tree_control.ts` | `MemoEntry` 型拡張 + `filterTree` に `"tags"` 分岐追加 |
| `src/common/workspace_tree.ts` | `tags` フィールドの双方向マッピング |
| `electron/workspace.js` | フロントマター read/write に `tags` 対応 |
| `src/stores/tags.ts` | **新規** — `tag_index` (tree_data 派生) と `active_tag` ストア |
| `src/stores/index.ts` | `tags.ts` エクスポート + `active_tag → filter["tags"]` 連動 |
| `src/components/TaskDetail.svelte` | `saveMemoTags` ハンドラー追加 |
| `src/components/MemoTab.svelte` | タグバー UI（チップ + datalist 補完） |
| `src/components/MenuList.svelte` | タグブラウザーセクション（折り畳み式） |
| `tests/unit/workspace.test.js` | タグのフロントマター round-trip テスト追加 |
| `tests/unit/tree_control.test.js` | `filterTree` タグフィルターのテスト追加 |

## Test plan

### 自動テスト（追加済み）
- [x] `writeTask` + `readProject` でタグが frontmatter に書き込まれ、読み返せる
- [x] タグなしメモの `tags` は空配列にデフォルト
- [x] `filterTree({ tags: ["design"] })` でそのタグを持つタスクのみ残る
- [x] タグフィルターで親がマッチしても子を自動展開しない
- [x] 一致タスクがなければ `filterTree` は `null` を返す

### 手動確認
- [ ] メモを開き、タグバーにタグを入力して Enter → チップが表示される
- [ ] アプリ再起動後もタグが復元される
- [ ] サイドバーの "Tags" セクションにタグ一覧が表示される（件数バッジ付き）
- [ ] タグをクリック → そのタグを持つタスクのみにフィルターされる
- [ ] 同じタグを再クリック → フィルター解除される
- [ ] タグ入力時に datalist で既存タグの補完候補が出る

Closes #136

https://claude.ai/code/session_01UpxYRLA8Fr7sBE5PLp7ARe