### PR TITLE
Add platform facade and Electron startup performance improvements (issue #109/#110)

### DIFF
--- a/electron/index.js
+++ b/electron/index.js
@@ -1,4 +1,3 @@
-const _ = require("lodash");
 const { app, BrowserWindow, ipcMain, shell, dialog } = require("electron");
 const fs = require("fs");
 const path = require("path");
@@ -91,6 +90,8 @@ function shouldOpenDevTools() {
 }
 
 app.on("ready", () => {
+  const t0 = Date.now();
+
   let mainWindow = new BrowserWindow({
     webPreferences: {
       preload: path.join(__dirname, "preload.js"),
@@ -100,19 +101,16 @@ app.on("ready", () => {
     minWidth: 700,
     minHeight: 700,
   });
+  log.info(`[perf] BrowserWindow created: ${Date.now() - t0}ms`);
 
   ////////////// Low //////////////
-  // Extend Low class with a new `chain` field
-  class LowSyncWithLodash extends LowSync {
-    chain = _.chain(this).get("data");
-  }
   // init low db. read after.
   // data
   const file = resolveAppDataPath("db.json");
   log.info(file);
   const defaultData = [];
   const adapter = new JSONFileSync(file);
-  const db = new LowSyncWithLodash(adapter);
+  const db = new LowSync(adapter);
   db.read();
   db.data ||= defaultData; // initialize
   db.write();
@@ -123,10 +121,11 @@ app.on("ready", () => {
     theme: "dark",
   };
   const adapter_meta = new JSONFileSync(file_meta);
-  const db_meta = new LowSyncWithLodash(adapter_meta);
+  const db_meta = new LowSync(adapter_meta);
   db_meta.read();
   db_meta.data ||= defaultDataMeta; // initialize
   db_meta.write();
+  log.info(`[perf] DB init done: ${Date.now() - t0}ms`);
 
   const dbWriter = createAsyncWriter(db, file, "db");
   const dbMetaWriter = createAsyncWriter(db_meta, file_meta, "meta", 100);
@@ -145,7 +144,7 @@ app.on("ready", () => {
   // on get-tree-data.
   // return data to renderer.
   ipcMain.handle("get-tree-data", async (event, arg) => {
-    return db.chain.find({ data: { id: arg } }).value();
+    return db.data.find((o) => o?.data?.id === arg);
   });
   // on get-meta-data.
   // return data to renderer.
@@ -179,15 +178,13 @@ app.on("ready", () => {
   // return data to renderer.
   ipcMain.on("set-tree-data", (event, arg) => {
     if (arg) {
-      db.data = db.chain
-        .map((o) => {
-          if (o.data.id === arg.data.id) {
-            return arg;
-          } else {
-            return o;
-          }
-        })
-        .value();
+      db.data = db.data.map((o) => {
+        if (o.data.id === arg.data.id) {
+          return arg;
+        } else {
+          return o;
+        }
+      });
       dbWriter.write();
 
       BrowserWindow.getAllWindows().forEach((window) => {
@@ -200,11 +197,9 @@ app.on("ready", () => {
   // on get-project-ids.
   // return data to renderer.
   ipcMain.handle("get-project-ids", async () => {
-    return db.chain
-      .map((o) => {
-        return { name: o.data.data.name, id: o.data.id };
-      })
-      .value();
+    return db.data.map((o) => {
+      return { name: o.data.data.name, id: o.data.id };
+    });
   });
   // on add-project.
   ipcMain.on("add-project", (event, arg) => {
@@ -465,11 +460,14 @@ app.on("ready", () => {
     }
   });
 
+  log.info(`[perf] IPC handlers registered: ${Date.now() - t0}ms`);
+
   if (process.env.VITE_DEV === "true") {
     mainWindow.loadURL("http://localhost:5173");
   } else {
     mainWindow.loadFile(path.join(__dirname, "../renderer/index.html"));
   }
+  log.info(`[perf] loadURL called: ${Date.now() - t0}ms`);
   if (shouldOpenDevTools()) {
     mainWindow.webContents.openDevTools();
   }

--- a/src/App.svelte
+++ b/src/App.svelte
@@ -106,8 +106,6 @@
     try {
       performance.mark("app-mounted");
       performance.measure("renderer-to-mount", "renderer-start", "app-mounted");
-      const [entry] = performance.getEntriesByName("renderer-to-mount");
-      if (entry) console.log(`[perf] renderer-to-mount: ${entry.duration.toFixed(1)}ms`);
     } catch {
       // renderer-start not set (e.g. test environment)
     }

--- a/src/App.svelte
+++ b/src/App.svelte
@@ -13,6 +13,7 @@
     saveStatus,
   } from "./stores.ts";
   import { onMount, onDestroy } from "svelte";
+  import * as platform from "./lib/platform";
   import ProjectPage from "./components/ProjectPage.svelte";
   import Header from "./components/Header.svelte";
   import InfoPage from "./components/InfoPage.svelte";
@@ -47,7 +48,7 @@
       document.title = `${detailWindowTaskName} | Task Detail`;
       setTaskDetailWindowTarget(detailWindowProjectId, detailWindowTaskId);
 
-      const result = await window.electronAPI.getTreeData(detailWindowProjectId);
+      const result = await platform.getTreeData(detailWindowProjectId);
       if (result) {
         tree_data.set(result);
         selected_type.set("Projects");
@@ -64,13 +65,9 @@
   // 検索ウィンドウでのテーマ初期化処理
   async function initSearchWindowTheme() {
     try {
-      if (window.electronAPI && window.electronAPI.getCurrentTheme) {
-        // メインウィンドウから現在のテーマを取得
-        const currentTheme = await window.electronAPI.getCurrentTheme();
-        if (currentTheme) {
-          // テーマを設定
-          theme.set(currentTheme);
-        }
+      const currentTheme = await platform.getCurrentTheme();
+      if (currentTheme) {
+        theme.set(currentTheme);
       }
     } catch {
       // ignore theme initialization error
@@ -106,6 +103,15 @@
   }
 
   onMount(async () => {
+    try {
+      performance.mark("app-mounted");
+      performance.measure("renderer-to-mount", "renderer-start", "app-mounted");
+      const [entry] = performance.getEntriesByName("renderer-to-mount");
+      if (entry) console.log(`[perf] renderer-to-mount: ${entry.duration.toFixed(1)}ms`);
+    } catch {
+      // renderer-start not set (e.g. test environment)
+    }
+
     if (isTaskDetailWindow) {
       await initTaskDetailWindow();
     } else {
@@ -116,20 +122,16 @@
     await initSearchWindowTheme();
 
     // テーマ変更通知のリスナー登録
-    if (window.electronAPI && window.electronAPI.onThemeChanged) {
-      window.electronAPI.onThemeChanged((newTheme) => {
-        theme.set(newTheme);
-      });
-    }
+    platform.onThemeChanged((newTheme) => {
+      theme.set(newTheme);
+    });
 
     window.addEventListener("keydown", handleKeyDown, true);
 
-    if (window.electronAPI?.onSaveError) {
-      window.electronAPI.onSaveError((message) => {
-        saveErrorMessage = message;
-        saveStatus.set("error");
-      });
-    }
+    platform.onSaveError((message) => {
+      saveErrorMessage = message;
+      saveStatus.set("error");
+    });
   });
 
   onDestroy(() => {

--- a/src/components/Memo.svelte
+++ b/src/components/Memo.svelte
@@ -9,6 +9,7 @@
   import { highlightSelectionMatches, searchKeymap } from "@codemirror/search";
   import { marked } from "marked";
   import { toMarkdown } from "../common/memo_utils";
+  import * as platform from "../lib/platform";
 
   export let saveMemo: (content: string) => void;
   export let content: unknown = "";
@@ -93,7 +94,7 @@
 
   function canSavePastedImages(): boolean {
     return Boolean(
-      (workspaceProjectDir && taskId && window.electronAPI?.wsSaveMemoImage) || !workspaceProjectDir
+      (workspaceProjectDir && taskId && platform.isPlatformAvailable()) || !workspaceProjectDir
     );
   }
 
@@ -107,12 +108,12 @@
   }
 
   async function persistPastedImage(file: File): Promise<string | null> {
-    if (!workspaceProjectDir || !taskId || !window.electronAPI?.wsSaveMemoImage) {
+    if (!workspaceProjectDir || !taskId) {
       return readFileAsDataUrl(file);
     }
 
     const bytes = new Uint8Array(await file.arrayBuffer());
-    const result = await window.electronAPI.wsSaveMemoImage(
+    const result = await platform.wsSaveMemoImage(
       workspaceProjectDir,
       taskId,
       bytes,
@@ -292,7 +293,7 @@
   }
 
   async function resolveImageSources(html: string): Promise<string> {
-    if (!workspaceProjectDir || !taskId || !window.electronAPI?.wsResolveMemoAsset) {
+    if (!workspaceProjectDir || !taskId || !platform.isPlatformAvailable()) {
       return html;
     }
 
@@ -307,11 +308,7 @@
           return;
         }
 
-        const result = await window.electronAPI.wsResolveMemoAsset(
-          workspaceProjectDir,
-          taskId,
-          src
-        );
+        const result = await platform.wsResolveMemoAsset(workspaceProjectDir, taskId, src);
 
         if (result.success && result.url) {
           image.setAttribute("src", result.url);
@@ -554,7 +551,7 @@
     }
     if (link?.href) {
       e.preventDefault();
-      window.electronAPI?.openExternalLink(link.href);
+      platform.openExternalLink(link.href);
       return;
     }
   }

--- a/src/components/MigrationWizard.svelte
+++ b/src/components/MigrationWizard.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
   import Modal from "./Modal.svelte";
   import { workspace_store } from "../stores/workspace";
+  import * as platform from "../lib/platform";
 
   export let show = false;
   export let toggle: () => void;
@@ -29,7 +30,7 @@
     phase = "loading";
     loadError = "";
     try {
-      legacyProjects = (await window.electronAPI?.wsGetLegacyProjects?.()) ?? [];
+      legacyProjects = await platform.wsGetLegacyProjects();
       phase = legacyProjects.length === 0 ? "idle" : "ready";
       if (legacyProjects.length === 0) loadError = "移行対象のプロジェクトがありません。";
     } catch (e) {
@@ -50,7 +51,7 @@
     if (!targetPath) return;
     phase = "running";
     try {
-      result = (await window.electronAPI?.wsMigrateProjects?.(targetPath)) ?? null;
+      result = await platform.wsMigrateProjects(targetPath);
       if (result) {
         await workspace_store.refreshProjects();
       }

--- a/src/components/PageSearchBox.svelte
+++ b/src/components/PageSearchBox.svelte
@@ -2,6 +2,7 @@
   import { onMount, onDestroy, createEventDispatcher, tick } from "svelte";
   import IconButton from "./IconButton.svelte";
   import { pageSearchQuery } from "../stores/search";
+  import * as platform from "../lib/platform";
 
   export let show = false;
 
@@ -37,7 +38,7 @@
     searchText = ""; // search box内をクリア
     lastSearchText = ""; // ステータスをクリア
     pageSearchQuery.set("");
-    window.electronAPI.stopFindInPage(); // matchCount, activeMatchOrdinalはMainから0が通知される
+    platform.stopFindInPage(); // matchCount, activeMatchOrdinalはMainから0が通知される
   }
 
   $: pageSearchQuery.set(show && searchText.trim() ? searchText.trim() : "");
@@ -47,13 +48,13 @@
     // empty, clear
     if (!searchText || !searchText.trim()) {
       lastSearchText = ""; // ステータスをクリア
-      window.electronAPI.stopFindInPage(); // matchCount, activeMatchOrdinalはMainから0が通知される
+      platform.stopFindInPage(); // matchCount, activeMatchOrdinalはMainから0が通知される
       return;
     }
 
     try {
       // 検索キック
-      await window.electronAPI.findInPage(searchText.trim(), {});
+      await platform.findInPage(searchText.trim(), {});
       // 検索文字列を保存（検索文字列変更を判定するため）
       lastSearchText = searchText;
     } catch {
@@ -74,7 +75,7 @@
     if (searchText != lastSearchText) {
       checkAndExecuteSearch();
     }
-    window.electronAPI.findInPageNext(searchText.trim());
+    platform.findInPageNext(searchText.trim());
   }
 
   // on click prev
@@ -84,7 +85,7 @@
     if (searchText != lastSearchText) {
       checkAndExecuteSearch();
     }
-    window.electronAPI.findInPagePrevious(searchText.trim());
+    platform.findInPagePrevious(searchText.trim());
   }
 
   // キー入力ハンドラ
@@ -102,14 +103,14 @@
 
   // 検索ボックスを閉じる
   function closeSearch() {
-    window.electronAPI.stopFindInPage();
+    platform.stopFindInPage();
     show = false;
     dispatch("close");
   }
 
   // 検索結果をクリア - シンプル版
   function clearSearch() {
-    window.electronAPI.stopFindInPage();
+    platform.stopFindInPage();
     searchText = "";
     matchCount = 0;
     activeMatchOrdinal = 0;
@@ -120,7 +121,7 @@
   // コンポーネントが表示された時
   onMount(() => {
     // メインプロセスからの検索結果更新メッセージを受け取るリスナーを設定
-    window.electronAPI.onSearchResultUpdated((result) => {
+    platform.onSearchResultUpdated((result) => {
       // 検索結果の件数と現在位置を設定
       matchCount = result.matches || 0;
       activeMatchOrdinal = result.activeMatchOrdinal || 0;
@@ -129,7 +130,7 @@
 
   // コンポーネントが破棄される時
   onDestroy(() => {
-    window.electronAPI.stopFindInPage();
+    platform.stopFindInPage();
   });
 </script>
 

--- a/src/components/TreeTableRow.svelte
+++ b/src/components/TreeTableRow.svelte
@@ -6,6 +6,7 @@
   import { createEventDispatcher } from "svelte";
   import { selected_id } from "../stores.ts";
   import { ripple } from "../common/common.js";
+  import * as platform from "../lib/platform";
   import TaskName from "./TaskName.svelte";
   import StatusSelect from "./StatusSelect.svelte";
   import DateInput from "./DateInput.svelte";
@@ -68,17 +69,11 @@
   }
 
   function openTaskDetailInWindow(taskText) {
-    try {
-      if (window.electronAPI && window.electronAPI.openTaskDetailWindow) {
-        window.electronAPI.openTaskDetailWindow({
-          projectId: $selected_id,
-          taskId: id,
-          taskName: taskText,
-        });
-      }
-    } catch {
-      // ignore error opening task detail window
-    }
+    platform.openTaskDetailWindow({
+      projectId: $selected_id,
+      taskId: id,
+      taskName: taskText,
+    });
   }
 
   function dragStart(e) {

--- a/src/lib/platform.ts
+++ b/src/lib/platform.ts
@@ -1,0 +1,254 @@
+import type {
+  ElectronAPI,
+  FindInPageResult,
+  ProjectListItem,
+  TaskDetailWindowData,
+  ThemeName,
+} from "../types/app";
+import type {
+  WorkspaceInfo,
+  WorkspaceProject,
+  WorkspaceProjectListItem,
+  WorkspaceTask,
+} from "../types/workspace";
+import type { ProjectData } from "../common/tree_control";
+
+// Single point where the Electron runtime is accessed.
+// Returns Partial<ElectronAPI> so method-level guards work correctly
+// even when test mocks define only a subset of the API.
+// All exported functions are safe no-ops / return safe defaults when unavailable.
+function api(): Partial<ElectronAPI> | undefined {
+  return typeof window !== "undefined" ? window.electronAPI : undefined;
+}
+
+export function isPlatformAvailable(): boolean {
+  return api() !== undefined;
+}
+
+// ---------------------------------------------------------------------------
+// Legacy project operations
+// ---------------------------------------------------------------------------
+
+export function getTreeData(projectId?: string): Promise<ProjectData | undefined> {
+  return api()?.getTreeData?.(projectId) ?? Promise.resolve(undefined);
+}
+
+export function setTreeData(treeData: ProjectData): Promise<void> {
+  return Promise.resolve(api()?.setTreeData?.(treeData));
+}
+
+export function getInitialTreeData(): Promise<ProjectData | undefined> {
+  return api()?.getInitialTreeData?.() ?? Promise.resolve(undefined);
+}
+
+export function getProjectIDs(): Promise<ProjectListItem[]> {
+  return api()?.getProjectIDs?.() ?? Promise.resolve([]);
+}
+
+export function setProjectOrder(projects: ProjectListItem[]): void {
+  api()?.setProjectOrder?.(projects);
+}
+
+export function addProject(project: ProjectData): void {
+  api()?.addProject?.(project);
+}
+
+export function deleteProject(projectId: string): void {
+  api()?.deleteProject?.(projectId);
+}
+
+export function message(msg: string): void {
+  api()?.message?.(msg);
+}
+
+// ---------------------------------------------------------------------------
+// Metadata operations
+// ---------------------------------------------------------------------------
+
+export function getMetaData(key: string): Promise<unknown> {
+  return api()?.getMetaData?.(key) ?? Promise.resolve(undefined);
+}
+
+export function setMetaData(key: string, value: unknown): void {
+  api()?.setMetaData?.(key, value);
+}
+
+export function deleteMetaData(key: string): void {
+  api()?.deleteMetaData?.(key);
+}
+
+// ---------------------------------------------------------------------------
+// Window / navigation
+// ---------------------------------------------------------------------------
+
+export function openExternalLink(url: string): void {
+  api()?.openExternalLink?.(url);
+}
+
+export function openTaskDetailWindow(detailData: TaskDetailWindowData): void {
+  api()?.openTaskDetailWindow?.(detailData);
+}
+
+// ---------------------------------------------------------------------------
+// Theme
+// ---------------------------------------------------------------------------
+
+export function getCurrentTheme(): Promise<ThemeName | undefined> {
+  return api()?.getCurrentTheme?.() ?? Promise.resolve(undefined);
+}
+
+// ---------------------------------------------------------------------------
+// Page search (find-in-page)
+// ---------------------------------------------------------------------------
+
+export function findInPage(
+  text: string,
+  options?: Record<string, unknown>
+): Promise<FindInPageResult | void> {
+  return api()?.findInPage?.(text, options) ?? Promise.resolve();
+}
+
+export function findInPageNext(text: string): Promise<void> {
+  return api()?.findInPageNext?.(text) ?? Promise.resolve();
+}
+
+export function findInPagePrevious(text: string): Promise<FindInPageResult | void> {
+  return api()?.findInPagePrevious?.(text) ?? Promise.resolve();
+}
+
+export function stopFindInPage(): void {
+  api()?.stopFindInPage?.();
+}
+
+// ---------------------------------------------------------------------------
+// Event listeners
+// ---------------------------------------------------------------------------
+
+export function onThemeChanged(callback: (theme: ThemeName) => void): void {
+  api()?.onThemeChanged?.(callback);
+}
+
+export function onTreeDataUpdated(callback: (treeData: ProjectData) => void): void {
+  api()?.onTreeDataUpdated?.(callback);
+}
+
+export function onProjectDeleted(callback: (projectId: string) => void): void {
+  api()?.onProjectDeleted?.(callback);
+}
+
+export function onSaveError(callback: (message: string) => void): void {
+  api()?.onSaveError?.(callback);
+}
+
+export function onSearchResultUpdated(callback: (result: FindInPageResult) => void): void {
+  api()?.onSearchResultUpdated?.(callback);
+}
+
+// ---------------------------------------------------------------------------
+// Workspace operations
+// ---------------------------------------------------------------------------
+
+export function wsGetWorkspaces(): Promise<{
+  workspaces: WorkspaceInfo[];
+  activeWorkspace: string | null;
+}> {
+  return api()?.wsGetWorkspaces?.() ?? Promise.resolve({ workspaces: [], activeWorkspace: null });
+}
+
+export function wsSetWorkspaces(config: {
+  workspaces: WorkspaceInfo[];
+  activeWorkspace?: string;
+}): void {
+  api()?.wsSetWorkspaces?.(config);
+}
+
+export function wsListProjects(workspacePath: string): Promise<WorkspaceProjectListItem[]> {
+  return api()?.wsListProjects?.(workspacePath) ?? Promise.resolve([]);
+}
+
+export function wsReadProject(projectDir: string): Promise<WorkspaceProject | undefined> {
+  return api()?.wsReadProject?.(projectDir) ?? Promise.resolve(undefined);
+}
+
+export function wsWriteTask(
+  projectDir: string,
+  task: WorkspaceTask
+): Promise<{ success: boolean; error?: string }> {
+  return (
+    api()?.wsWriteTask?.(projectDir, task) ??
+    Promise.resolve({ success: false, error: "API unavailable" })
+  );
+}
+
+export function wsSaveMemoImage(
+  projectDir: string,
+  taskId: string,
+  bytes: Uint8Array,
+  mimeType?: string
+): Promise<{ success: boolean; path?: string; error?: string }> {
+  return (
+    api()?.wsSaveMemoImage?.(projectDir, taskId, bytes, mimeType) ??
+    Promise.resolve({ success: false, error: "API unavailable" })
+  );
+}
+
+export function wsResolveMemoAsset(
+  projectDir: string,
+  taskId: string,
+  assetPath: string
+): Promise<{ success: boolean; url?: string; error?: string }> {
+  return (
+    api()?.wsResolveMemoAsset?.(projectDir, taskId, assetPath) ??
+    Promise.resolve({ success: false, error: "API unavailable" })
+  );
+}
+
+export function wsWriteProject(
+  projectDir: string,
+  tasks: WorkspaceTask[]
+): Promise<{ success: boolean; error?: string }> {
+  return (
+    api()?.wsWriteProject?.(projectDir, tasks) ??
+    Promise.resolve({ success: false, error: "API unavailable" })
+  );
+}
+
+export function wsDeleteTask(
+  projectDir: string,
+  taskId: string
+): Promise<{ success: boolean; error?: string }> {
+  return (
+    api()?.wsDeleteTask?.(projectDir, taskId) ??
+    Promise.resolve({ success: false, error: "API unavailable" })
+  );
+}
+
+export function wsCreateProject(
+  workspacePath: string,
+  name: string,
+  id: string
+): Promise<{ success: boolean; projectDir?: string; dirName?: string; error?: string }> {
+  return (
+    api()?.wsCreateProject?.(workspacePath, name, id) ??
+    Promise.resolve({ success: false, error: "API unavailable" })
+  );
+}
+
+export function wsSelectDirectory(): Promise<string | null> {
+  return api()?.wsSelectDirectory?.() ?? Promise.resolve(null);
+}
+
+export function wsGetLegacyProjects(): Promise<{ id: string; name: string; taskCount: number }[]> {
+  return api()?.wsGetLegacyProjects?.() ?? Promise.resolve([]);
+}
+
+export function wsMigrateProjects(workspacePath: string): Promise<{
+  success: boolean;
+  migrated: { name: string; count: number }[];
+  errors: { name: string; error: string }[];
+}> {
+  return (
+    api()?.wsMigrateProjects?.(workspacePath) ??
+    Promise.resolve({ success: false, migrated: [], errors: [] })
+  );
+}

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,6 +1,8 @@
 import { mount } from "svelte";
 import App from "./App.svelte";
 
+performance.mark("renderer-start");
+
 const app = mount(App, {
   target: document.getElementById("app")!,
 });

--- a/src/stores/column_settings.ts
+++ b/src/stores/column_settings.ts
@@ -1,4 +1,5 @@
 import { writable, type Writable } from "svelte/store";
+import * as platform from "../lib/platform";
 
 export interface ColumnSetting {
   id: string;
@@ -42,7 +43,7 @@ function createColumnSettings(): ColumnSettingsStore {
 
   const save = (settings: ColumnSetting[]) => {
     try {
-      window.electronAPI.setMetaData(META_KEY, settings);
+      platform.setMetaData(META_KEY, settings);
     } catch {
       // ignore
     }
@@ -53,7 +54,7 @@ function createColumnSettings(): ColumnSettingsStore {
     set,
     update,
     init: () => {
-      window.electronAPI
+      platform
         .getMetaData(META_KEY)
         .then((saved) => {
           if (!isColumnSettingsArray(saved)) return;

--- a/src/stores/project.ts
+++ b/src/stores/project.ts
@@ -2,6 +2,7 @@ import { get, writable, type Writable } from "svelte/store";
 import { getDefaultProject } from "../common/tree_control";
 import type { ProjectListItem } from "../types/app";
 import { filtered_data } from "./search";
+import * as platform from "../lib/platform";
 import {
   selected_type,
   selected_id,
@@ -31,10 +32,10 @@ function createProjectIds(initialValue: ProjectListItem[] | undefined): ProjectI
     set,
     update,
     init: () => {
-      if (!projectDeleteListenerRegistered && window.electronAPI?.onProjectDeleted) {
+      if (!projectDeleteListenerRegistered) {
         projectDeleteListenerRegistered = true;
-        window.electronAPI.onProjectDeleted((deletedProjectId) => {
-          window.electronAPI.getProjectIDs().then((result) => {
+        platform.onProjectDeleted((deletedProjectId) => {
+          platform.getProjectIDs().then((result) => {
             set(result);
           });
 
@@ -54,7 +55,7 @@ function createProjectIds(initialValue: ProjectListItem[] | undefined): ProjectI
 
       subscribe((current) => {
         if (current === undefined) {
-          window.electronAPI.getProjectIDs().then((result) => {
+          platform.getProjectIDs().then((result) => {
             set(result);
           });
         }
@@ -68,19 +69,19 @@ function createProjectIds(initialValue: ProjectListItem[] | undefined): ProjectI
     },
     addProject: () => {
       const newProject = getDefaultProject();
-      window.electronAPI.addProject(newProject);
-      window.electronAPI.getProjectIDs().then((result) => {
+      platform.addProject(newProject);
+      platform.getProjectIDs().then((result) => {
         set(result);
       });
     },
     deleteProject: (projectId: string) => {
-      window.electronAPI.deleteProject(projectId);
-      window.electronAPI.getProjectIDs().then((result) => {
+      platform.deleteProject(projectId);
+      platform.getProjectIDs().then((result) => {
         set(result);
       });
 
       const metaKey = `closed_nodes_${projectId}`;
-      window.electronAPI.deleteMetaData(metaKey);
+      platform.deleteMetaData(metaKey);
 
       if (projectId === get(selected_id)) {
         selected_type.set(undefined);
@@ -88,7 +89,7 @@ function createProjectIds(initialValue: ProjectListItem[] | undefined): ProjectI
       }
     },
     setProjectOrder: (projects: ProjectListItem[]) => {
-      window.electronAPI.setProjectOrder(projects);
+      platform.setProjectOrder(projects);
     },
   };
 }

--- a/src/stores/theme.ts
+++ b/src/stores/theme.ts
@@ -1,6 +1,7 @@
 import { writable, type Writable } from "svelte/store";
 import { THEME_DARK, THEME_LIGHT } from "../common/theme";
 import type { ThemeName } from "../types/app";
+import * as platform from "../lib/platform";
 
 type ThemePalette = {
   [key: string]: string | ThemePalette;
@@ -36,7 +37,7 @@ function createTheme(initialValue: ThemeName | undefined): ThemeStore {
     init: () => {
       subscribe((current) => {
         if (current === undefined) {
-          window.electronAPI.getMetaData("theme").then((result) => {
+          platform.getMetaData("theme").then((result) => {
             if (isThemeName(result)) {
               set(result);
             }
@@ -45,10 +46,10 @@ function createTheme(initialValue: ThemeName | undefined): ThemeStore {
 
         if (current === "dark") {
           traverse(THEME_DARK as ThemePalette, "--theme");
-          window.electronAPI.setMetaData("theme", current);
+          platform.setMetaData("theme", current);
         } else if (current === "light") {
           traverse(THEME_LIGHT as ThemePalette, "--theme");
-          window.electronAPI.setMetaData("theme", current);
+          platform.setMetaData("theme", current);
         }
       });
     },

--- a/src/stores/tree.ts
+++ b/src/stores/tree.ts
@@ -1,6 +1,7 @@
 import { throttle } from "lodash";
 import _ from "lodash";
 import { get, writable, type Writable } from "svelte/store";
+import * as platform from "../lib/platform";
 import { getNode, type ProjectData, type TreeData } from "../common/tree_control";
 import { projectDataToWorkspaceTasks } from "../common/workspace_tree";
 import { filter } from "./search";
@@ -85,7 +86,7 @@ function createTreeData(initialValue: ProjectData | undefined): TreeDataStore {
       previousData = _.cloneDeep(current);
       filter.set(get(filter));
       if (!isWorkspace) {
-        window.electronAPI.getProjectIDs().then((result) => {
+        platform.getProjectIDs().then((result) => {
           project_ids.set(result);
         });
       }
@@ -111,7 +112,7 @@ function createTreeData(initialValue: ProjectData | undefined): TreeDataStore {
 
             const metaKey = `closed_nodes_${projectId}`;
             const idsArray = Array.from(newState);
-            window.electronAPI.setMetaData(metaKey, idsArray);
+            platform.setMetaData(metaKey, idsArray);
 
             return newState;
           });
@@ -128,19 +129,19 @@ function createTreeData(initialValue: ProjectData | undefined): TreeDataStore {
       const cachedTasks = get(workspace_tasks_cache);
       const tasks = projectDataToWorkspaceTasks(current, cachedTasks);
       try {
-        await window.electronAPI.wsWriteProject?.(activeProjectDir, tasks);
+        await platform.wsWriteProject(activeProjectDir, tasks);
         saveStatus.set("saved");
       } catch {
         saveStatus.set("error");
       }
     } else {
       try {
-        await window.electronAPI.setTreeData(current);
+        await platform.setTreeData(current);
         saveStatus.set("saved");
       } catch {
         saveStatus.set("error");
       }
-      window.electronAPI.getProjectIDs().then((result) => {
+      platform.getProjectIDs().then((result) => {
         project_ids.set(result);
       });
     }
@@ -151,9 +152,9 @@ function createTreeData(initialValue: ProjectData | undefined): TreeDataStore {
     set,
     update,
     init: () => {
-      if (!syncListenerRegistered && window.electronAPI?.onTreeDataUpdated) {
+      if (!syncListenerRegistered) {
         syncListenerRegistered = true;
-        window.electronAPI.onTreeDataUpdated((nextTreeData) => {
+        platform.onTreeDataUpdated((nextTreeData) => {
           if (!nextTreeData) {
             return;
           }
@@ -192,7 +193,7 @@ function createTreeData(initialValue: ProjectData | undefined): TreeDataStore {
               table_selected_id.set(pendingTaskDetailSelection.taskId);
             }
           } else {
-            window.electronAPI.getInitialTreeData().then((result) => {
+            platform.getInitialTreeData().then((result) => {
               selected_type.set("Projects");
               if (result !== undefined) {
                 selected_id.set(result.data.id);

--- a/src/stores/ui.ts
+++ b/src/stores/ui.ts
@@ -4,6 +4,7 @@ import { workspaceToProjectData } from "../common/workspace_tree";
 import type { PendingTaskDetailSelection, SelectedType } from "../types/app";
 import { clearHistory, tree_data } from "./tree";
 import { workspace_store, workspace_tasks_cache } from "./workspace";
+import * as platform from "../lib/platform";
 
 const currentHash = typeof window !== "undefined" ? window.location.hash : "";
 const currentSearch =
@@ -65,7 +66,7 @@ function createSelectedID(initialValue: string | undefined): SelectedIdStore {
         const currentSelectedType = get(selected_type);
         if (currentSelectedType === "Projects" && current) {
           clearHistory();
-          window.electronAPI.getTreeData(current).then((result) => {
+          platform.getTreeData(current).then((result) => {
             tree_data.set(result);
 
             if (
@@ -86,7 +87,7 @@ function createSelectedID(initialValue: string | undefined): SelectedIdStore {
           clearHistory();
           const { activeProjectDir } = get(workspace_store);
           if (!activeProjectDir) return;
-          window.electronAPI.wsReadProject?.(activeProjectDir).then((result) => {
+          platform.wsReadProject(activeProjectDir).then((result) => {
             if (!result) return;
             workspace_tasks_cache.set(result.tasks);
             const converted = workspaceToProjectData(result.tasks, current);
@@ -108,7 +109,7 @@ function createClosedNodeIds(initialValue: Set<string>): ClosedNodeIdsStore {
 
     try {
       const metaKey = `closed_nodes_${projectId}`;
-      const result = await window.electronAPI.getMetaData(metaKey);
+      const result = await platform.getMetaData(metaKey);
 
       const newState = isStringArray(result) ? new Set(result) : new Set<string>();
       projectExpandedStates.set(projectId, newState);
@@ -125,7 +126,7 @@ function createClosedNodeIds(initialValue: Set<string>): ClosedNodeIdsStore {
     try {
       const metaKey = `closed_nodes_${projectId}`;
       const idsArray = Array.from(state);
-      window.electronAPI.setMetaData(metaKey, idsArray);
+      platform.setMetaData(metaKey, idsArray);
     } catch {
       // ignore save error
     }
@@ -209,7 +210,7 @@ function createClosedNodeIds(initialValue: Set<string>): ClosedNodeIdsStore {
 
         const metaKey = `closed_nodes_${projectId}`;
         const idsArray = Array.from(newState);
-        window.electronAPI.setMetaData(metaKey, idsArray);
+        platform.setMetaData(metaKey, idsArray);
 
         return newState;
       });

--- a/src/stores/workspace.ts
+++ b/src/stores/workspace.ts
@@ -1,5 +1,6 @@
 import { writable, get, type Writable } from "svelte/store";
 import type { WorkspaceInfo, WorkspaceProjectListItem, WorkspaceTask } from "../types/workspace";
+import * as platform from "../lib/platform";
 
 /** Last loaded workspace tasks, keyed by task id. Used during save to preserve metadata. */
 export const workspace_tasks_cache = writable<Record<string, WorkspaceTask>>({});
@@ -34,7 +35,7 @@ function createWorkspaceStore(): WorkspaceStore {
   });
 
   function persist(workspaces: WorkspaceInfo[], activeWorkspacePath: string | null) {
-    window.electronAPI?.wsSetWorkspaces?.({
+    platform.wsSetWorkspaces({
       workspaces,
       activeWorkspace: activeWorkspacePath ?? undefined,
     });
@@ -42,7 +43,7 @@ function createWorkspaceStore(): WorkspaceStore {
 
   async function loadProjects(workspacePath: string): Promise<WorkspaceProjectListItem[]> {
     try {
-      return (await window.electronAPI?.wsListProjects?.(workspacePath)) ?? [];
+      return await platform.wsListProjects(workspacePath);
     } catch {
       return [];
     }
@@ -55,8 +56,7 @@ function createWorkspaceStore(): WorkspaceStore {
 
     init() {
       (async () => {
-        if (!window.electronAPI?.wsGetWorkspaces) return;
-        const { workspaces, activeWorkspace } = await window.electronAPI.wsGetWorkspaces();
+        const { workspaces, activeWorkspace } = await platform.wsGetWorkspaces();
         const projects = activeWorkspace ? await loadProjects(activeWorkspace) : [];
         set({
           workspaces: workspaces ?? [],
@@ -68,7 +68,7 @@ function createWorkspaceStore(): WorkspaceStore {
     },
 
     selectDirectory(): Promise<string | null> {
-      return window.electronAPI?.wsSelectDirectory?.() ?? Promise.resolve(null);
+      return platform.wsSelectDirectory();
     },
 
     addWorkspace(path: string, label: string) {
@@ -119,7 +119,7 @@ function createWorkspaceStore(): WorkspaceStore {
         return { success: false, error: "No active workspace" };
       }
 
-      const result = await window.electronAPI?.wsCreateProject?.(activeWorkspacePath, name, id);
+      const result = await platform.wsCreateProject(activeWorkspacePath, name, id);
       if (!result?.success || !result.projectDir) {
         return { success: false, error: result?.error ?? "Failed to create workspace project" };
       }


### PR DESCRIPTION
- Create src/lib/platform.ts as a single facade over window.electronAPI so
  UI code is decoupled from the Electron runtime. A future Tauri migration
  only needs to change this one file. The facade uses Partial<ElectronAPI>
  internally so partial mocks in tests work safely.

- Remove direct window.electronAPI references from all 11 frontend files
  (stores/workspace, project, tree, theme, ui, column_settings;
   App.svelte; components/TreeTableRow, Memo, PageSearchBox, MigrationWizard).

- electron/index.js: remove lodash dependency (replace _.chain() usage with
  native Array.find/map), add [perf] timing logs around BrowserWindow
  creation, DB init, IPC handler registration, and loadURL call.

- src/main.ts + App.svelte: add performance.mark/measure to measure
  renderer-to-mount time on each startup.

https://claude.ai/code/session_01PSRUdwmzhBVhCHVcabyddT