### PR TITLE
Add column-based filtering and sorting to tree table

### DIFF
--- a/src/common/tree_control.ts
+++ b/src/common/tree_control.ts
@@ -1,5 +1,6 @@
 import { uuidV4 } from "./uuid";
 import { searchMemoEntries } from "./memo_utils";
+import type { SortState } from "../types/app";
 
 export type TaskStatus = "Open" | "Pending" | "In Progress" | "Completed" | "Canceled";
 
@@ -88,6 +89,15 @@ export function filterTree(
       keyMatch = (tree.data.memo ?? []).some((entry) =>
         ((entry.tags as string[]) ?? []).some((t) => t.toLowerCase() === tag)
       );
+    } else if (key === "start date" || key === "due date") {
+      const from = keywords[0] ?? "";
+      const to = keywords[1] ?? "";
+      const nodeDate = (tree.data[key] as string | undefined) ?? "";
+      if (!nodeDate) {
+        keyMatch = !from && !to;
+      } else {
+        keyMatch = (!from || nodeDate >= from) && (!to || nodeDate <= to);
+      }
     } else {
       // For other filters
       keyMatch = keywords.some(
@@ -523,6 +533,49 @@ export function indentNode(target: string, tree_data: TreeData): TreeData {
   newParent.children.push(node);
 
   return tree_data;
+}
+
+const STATUS_ORDER: Record<TaskStatus, number> = {
+  Open: 0,
+  "In Progress": 1,
+  Pending: 2,
+  Completed: 3,
+  Canceled: 4,
+};
+
+export function sortTree(
+  tree: TreeData | null | undefined,
+  sort: SortState | null | undefined
+): TreeData | null | undefined {
+  if (!tree || !sort) return tree;
+
+  const compare = (a: TreeData, b: TreeData): number => {
+    const { column, direction } = sort;
+    let result = 0;
+
+    if (column === "status") {
+      const aOrder = STATUS_ORDER[a.data.status] ?? 99;
+      const bOrder = STATUS_ORDER[b.data.status] ?? 99;
+      result = aOrder - bOrder;
+    } else if (column === "name") {
+      result = (a.data.name ?? "").localeCompare(b.data.name ?? "");
+    } else if (column === "start date" || column === "due date") {
+      const aVal = (a.data[column] as string | undefined) ?? "";
+      const bVal = (b.data[column] as string | undefined) ?? "";
+      if (!aVal && !bVal) result = 0;
+      else if (!aVal) result = 1;
+      else if (!bVal) result = -1;
+      else result = aVal < bVal ? -1 : aVal > bVal ? 1 : 0;
+    }
+
+    return direction === "desc" ? -result : result;
+  };
+
+  const sortedChildren = [...tree.children]
+    .map((child) => sortTree(child, sort) as TreeData)
+    .sort(compare);
+
+  return { ...tree, children: sortedChildren };
 }
 
 export function outdentNode(target: string, tree_data: TreeData): TreeData {

--- a/src/components/DateRangePanel.svelte
+++ b/src/components/DateRangePanel.svelte
@@ -1,0 +1,128 @@
+<script lang="ts">
+  import { createEventDispatcher } from "svelte";
+
+  export let column: string;
+  export let from: string = "";
+  export let to: string = "";
+  export let anchorRect: DOMRect | null = null;
+
+  const dispatch = createEventDispatcher<{ change: { from: string; to: string } }>();
+
+  $: panelStyle = anchorRect ? `top: ${anchorRect.bottom + 2}px; left: ${anchorRect.left}px;` : "";
+
+  function handleChange() {
+    dispatch("change", { from, to });
+  }
+
+  function handleClear() {
+    from = "";
+    to = "";
+    dispatch("change", { from: "", to: "" });
+  }
+
+  function portal(node: HTMLElement) {
+    document.body.appendChild(node);
+    return {
+      destroy() {
+        if (node.parentNode) node.parentNode.removeChild(node);
+      },
+    };
+  }
+</script>
+
+<!-- svelte-ignore a11y-no-noninteractive-element-interactions -->
+<div
+  class="DateRangePanel"
+  style={panelStyle}
+  role="dialog"
+  tabindex="-1"
+  aria-label="{column} 日付フィルター"
+  on:click|stopPropagation
+  on:keydown|stopPropagation
+  use:portal
+>
+  <div class="PanelTitle">{column} フィルター</div>
+  <div class="DateRow">
+    <label for="dr-from-{column.replace(' ', '-')}">From</label>
+    <input
+      id="dr-from-{column.replace(' ', '-')}"
+      type="date"
+      bind:value={from}
+      on:change={handleChange}
+    />
+  </div>
+  <div class="DateRow">
+    <label for="dr-to-{column.replace(' ', '-')}">To</label>
+    <input
+      id="dr-to-{column.replace(' ', '-')}"
+      type="date"
+      bind:value={to}
+      on:change={handleChange}
+    />
+  </div>
+  {#if from || to}
+    <button class="ClearBtn" on:click={handleClear}>クリア</button>
+  {/if}
+</div>
+
+<style>
+  .DateRangePanel {
+    position: fixed;
+    z-index: 99999999;
+    background: var(--theme-color-Main-main);
+    border: 1px solid var(--theme-color-Sub-dark);
+    border-radius: 0.5rem;
+    box-shadow: 0 0.25rem 0.75rem rgba(0, 0, 0, 0.25);
+    padding: 0.5rem 0;
+    min-width: 13rem;
+  }
+  .PanelTitle {
+    font-size: 0.75rem;
+    font-weight: bold;
+    color: var(--theme-color-Sub-dark);
+    padding: 0.25rem 0.75rem 0.5rem;
+    border-bottom: 1px solid var(--theme-color-Sub-dark);
+    margin-bottom: 0.25rem;
+  }
+  .DateRow {
+    display: flex;
+    align-items: center;
+    padding: 0.3rem 0.75rem;
+    gap: 0.5rem;
+    color: var(--theme-color-Sub-light);
+    font-size: 0.875rem;
+  }
+  .DateRow label {
+    width: 2.5rem;
+    flex-shrink: 0;
+    user-select: none;
+  }
+  .DateRow input[type="date"] {
+    flex: 1;
+    background: var(--theme-color-Main-dark);
+    color: var(--theme-color-Main-light);
+    border: 1px solid var(--theme-color-Sub-dark);
+    border-radius: 0.25rem;
+    padding: 0.2rem 0.3rem;
+    font-size: 0.8rem;
+    color-scheme: dark;
+    box-sizing: border-box;
+    min-width: 0;
+  }
+  .ClearBtn {
+    display: block;
+    margin: 0.25rem 0.75rem 0;
+    background: transparent;
+    border: 1px solid var(--theme-color-Sub-dark);
+    border-radius: 0.25rem;
+    color: var(--theme-color-Sub-light);
+    cursor: pointer;
+    font-size: 0.75rem;
+    padding: 0.2rem 0.6rem;
+  }
+  .ClearBtn:hover {
+    background-color: var(--theme-color-Accent-dark);
+    color: var(--theme-color-Main-light);
+    opacity: 1;
+  }
+</style>

--- a/src/components/DateRangePanel.svelte
+++ b/src/components/DateRangePanel.svelte
@@ -30,7 +30,6 @@
   }
 </script>
 
-<!-- svelte-ignore a11y-no-noninteractive-element-interactions -->
 <div
   class="DateRangePanel"
   style={panelStyle}

--- a/src/components/TreeTableHeader.svelte
+++ b/src/components/TreeTableHeader.svelte
@@ -2,7 +2,9 @@
   import { filter } from "../stores.ts";
   import { column_settings } from "../stores/column_settings.ts";
   import { closed_node_ids } from "../stores/ui.ts";
+  import { sort_state, SORTABLE_COLUMNS } from "../stores/sort.ts";
   import MultiSelect from "./MultiSelect.svelte";
+  import DateRangePanel from "./DateRangePanel.svelte";
 
   export let headers;
   export let allHeaders = [];
@@ -17,7 +19,14 @@
   let panelElement;
   let panelStyle = "";
 
+  let openDatePanel = null;
+  let datePanelAnchorRect = null;
+  let datePanelElement = null;
+
   $: availableIds = new Set(allHeaders.map((h) => h.name));
+
+  $: startDateFilter = $filter["start date"] ?? ["", ""];
+  $: dueDateFilter = $filter["due date"] ?? ["", ""];
 
   function openPanel(e) {
     e.stopPropagation();
@@ -26,9 +35,40 @@
     showPanel = !showPanel;
   }
 
+  function handleSortClick(e, headerName) {
+    if (!SORTABLE_COLUMNS.has(headerName)) return;
+    sort_state.cycle(headerName);
+  }
+
+  function toggleDatePanel(e, headerName) {
+    e.stopPropagation();
+    if (openDatePanel === headerName) {
+      openDatePanel = null;
+    } else {
+      datePanelAnchorRect = e.currentTarget.getBoundingClientRect();
+      openDatePanel = headerName;
+    }
+  }
+
+  function handleDateRangeChange(headerName, detail) {
+    const { from, to } = detail;
+    filter.update((f) => {
+      const next = { ...f };
+      if (!from && !to) {
+        delete next[headerName];
+      } else {
+        next[headerName] = [from, to];
+      }
+      return next;
+    });
+  }
+
   function handleWindowClick(e) {
     if (showPanel && panelElement && !panelElement.contains(e.target)) {
       showPanel = false;
+    }
+    if (openDatePanel && datePanelElement && !datePanelElement.contains(e.target)) {
+      openDatePanel = null;
     }
   }
 
@@ -47,10 +87,50 @@
 <div class:TableRow={true} role="row">
   {#each headers as header}
     <div class:TableHeader={true} role="columnheader">
+      <!-- Label row: clickable for sort on sortable columns -->
+      <!-- svelte-ignore a11y-no-static-element-interactions -->
       <div
-        style="display: flex; flex: 1; width:100%; height:100%; justify-content: center; align-items: center;"
+        class="HeaderLabelRow"
+        class:sortable={SORTABLE_COLUMNS.has(header.name)}
+        class:sortActive={$sort_state?.column === header.name}
+        on:click={(e) => handleSortClick(e, header.name)}
+        on:keydown={(e) => {
+          if (e.key === "Enter" || e.key === " ") handleSortClick(e, header.name);
+        }}
       >
         <span class:TextOverFlow={true}>{header.name}</span>
+        {#if $sort_state?.column === header.name}
+          <span class="SortIndicator">
+            {$sort_state.direction === "asc" ? "▲" : "▼"}
+          </span>
+        {/if}
+        {#if header.name === "start date" || header.name === "due date"}
+          <button
+            class="DateFilterBtn"
+            class:active={!!$filter[header.name]}
+            on:click|stopPropagation={(e) => toggleDatePanel(e, header.name)}
+            aria-label="{header.name} 日付フィルター"
+            aria-expanded={openDatePanel === header.name}
+            title="日付フィルター"
+          >
+            <svg viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
+              <rect
+                x="3"
+                y="4"
+                width="18"
+                height="18"
+                rx="2"
+                ry="2"
+                stroke-width="2"
+                stroke-linecap="round"
+                stroke-linejoin="round"
+              />
+              <line x1="16" y1="2" x2="16" y2="6" stroke-width="2" stroke-linecap="round" />
+              <line x1="8" y1="2" x2="8" y2="6" stroke-width="2" stroke-linecap="round" />
+              <line x1="3" y1="10" x2="21" y2="10" stroke-width="2" stroke-linecap="round" />
+            </svg>
+          </button>
+        {/if}
       </div>
       {#if header.name == "status"}
         <div
@@ -230,6 +310,28 @@
   </div>
 {/if}
 
+{#if openDatePanel === "start date"}
+  <DateRangePanel
+    bind:this={datePanelElement}
+    column="start date"
+    from={startDateFilter[0]}
+    to={startDateFilter[1]}
+    anchorRect={datePanelAnchorRect}
+    on:change={(e) => handleDateRangeChange("start date", e.detail)}
+  />
+{/if}
+
+{#if openDatePanel === "due date"}
+  <DateRangePanel
+    bind:this={datePanelElement}
+    column="due date"
+    from={dueDateFilter[0]}
+    to={dueDateFilter[1]}
+    anchorRect={datePanelAnchorRect}
+    on:change={(e) => handleDateRangeChange("due date", e.detail)}
+  />
+{/if}
+
 <style>
   .TableRow {
     position: sticky;
@@ -269,6 +371,60 @@
     text-overflow: ellipsis;
     overflow: hidden;
     white-space: nowrap;
+  }
+
+  .HeaderLabelRow {
+    display: flex;
+    flex: 1;
+    width: 100%;
+    height: 100%;
+    justify-content: center;
+    align-items: center;
+    gap: 0.2rem;
+    padding: 0 0.3rem;
+    overflow: hidden;
+    box-sizing: border-box;
+  }
+  .HeaderLabelRow.sortable {
+    cursor: pointer;
+    user-select: none;
+  }
+  .HeaderLabelRow.sortable:hover {
+    background-color: var(--theme-color-Accent-dark);
+  }
+  .HeaderLabelRow.sortActive {
+    color: var(--theme-color-Accent-main);
+  }
+  .SortIndicator {
+    font-size: 0.7rem;
+    flex-shrink: 0;
+    color: var(--theme-color-Accent-main);
+  }
+
+  .DateFilterBtn {
+    width: 1.4rem;
+    height: 1.4rem;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    background: transparent;
+    border: none;
+    cursor: pointer;
+    border-radius: 0.25rem;
+    padding: 0.2rem;
+    opacity: 0.5;
+    flex-shrink: 0;
+  }
+  .DateFilterBtn:hover,
+  .DateFilterBtn.active,
+  .DateFilterBtn[aria-expanded="true"] {
+    background-color: var(--theme-color-Accent-dark);
+    opacity: 1;
+  }
+  .DateFilterBtn svg {
+    width: 100%;
+    height: 100%;
+    stroke: var(--theme-color-Main-light);
   }
 
   .ExpandCollapseButtons {

--- a/src/stores/index.ts
+++ b/src/stores/index.ts
@@ -7,6 +7,7 @@ export * from "./ui";
 export * from "./column_settings";
 export * from "./workspace";
 export * from "./tags";
+export * from "./sort";
 
 import { tree_data } from "./tree";
 import { project_ids } from "./project";
@@ -16,11 +17,13 @@ import { theme } from "./theme";
 import { column_settings } from "./column_settings";
 import { workspace_store } from "./workspace";
 import { active_tag } from "./tags";
+import { sort_state } from "./sort";
 
 export function init_store() {
   tree_data.init();
   project_ids.init();
   selected_id.init();
+  sort_state.init();
   filter.init();
   theme.init();
   closed_node_ids.init();

--- a/src/stores/search.ts
+++ b/src/stores/search.ts
@@ -1,9 +1,16 @@
 import { debounce } from "lodash";
 import { get, writable, type Writable } from "svelte/store";
-import { filterTree, getNode, type ProjectData, type TreeData } from "../common/tree_control";
-import type { FilterState } from "../types/app";
+import {
+  filterTree,
+  getNode,
+  sortTree,
+  type ProjectData,
+  type TreeData,
+} from "../common/tree_control";
+import type { FilterState, SortState } from "../types/app";
 import { tree_data } from "./tree";
 import { table_selected_id } from "./ui";
+import { sort_state } from "./sort";
 
 export interface FilterStore extends Writable<FilterState> {
   init: () => void;
@@ -12,7 +19,11 @@ export interface FilterStore extends Writable<FilterState> {
 function createFilter(initialValue: FilterState): FilterStore {
   const { subscribe, set, update } = writable<FilterState>(initialValue);
 
-  const syncFilteredData = (current: FilterState, currentTreeData: ProjectData | undefined) => {
+  const syncFilteredData = (
+    current: FilterState,
+    currentTreeData: ProjectData | undefined,
+    currentSort: SortState | null
+  ) => {
     if (!currentTreeData) {
       applyFilteredData.cancel();
       filtered_data.set(undefined);
@@ -22,7 +33,8 @@ function createFilter(initialValue: FilterState): FilterStore {
 
     if (!hasActiveFilters(current)) {
       applyFilteredData.cancel();
-      const nextTree = currentTreeData.data;
+      const nextTree = (sortTree(currentTreeData.data, currentSort) ??
+        currentTreeData.data) as TreeData;
       if (
         !get(table_selected_id) ||
         !nextTree ||
@@ -35,21 +47,25 @@ function createFilter(initialValue: FilterState): FilterStore {
       return;
     }
 
-    applyFilteredData(current, currentTreeData);
+    applyFilteredData(current, currentTreeData, currentSort);
   };
 
-  const applyFilteredData = debounce((current: FilterState, currentTreeData: ProjectData) => {
-    const filtered = filterTree(currentTreeData.data, current);
-    if (
-      !get(table_selected_id) ||
-      !filtered ||
-      !getNode(get(table_selected_id) as string, filtered)
-    ) {
-      table_selected_id.set(undefined);
-    }
+  const applyFilteredData = debounce(
+    (current: FilterState, currentTreeData: ProjectData, currentSort: SortState | null) => {
+      const filtered = filterTree(currentTreeData.data, current);
+      const sorted = (sortTree(filtered, currentSort) ?? filtered) as TreeData | null | undefined;
+      if (
+        !get(table_selected_id) ||
+        !sorted ||
+        !getNode(get(table_selected_id) as string, sorted)
+      ) {
+        table_selected_id.set(undefined);
+      }
 
-    filtered_data.set(filtered);
-  }, 500);
+      filtered_data.set(sorted);
+    },
+    500
+  );
 
   const hasActiveFilters = (current: FilterState) =>
     Object.keys(current || {}).some((key) => current[key] && current[key].length > 0);
@@ -60,11 +76,19 @@ function createFilter(initialValue: FilterState): FilterStore {
     update,
     init: () => {
       subscribe((current) => {
-        syncFilteredData(current, get(tree_data));
+        syncFilteredData(current, get(tree_data), get(sort_state));
       });
 
       tree_data.subscribe((currentTreeData) => {
-        syncFilteredData(get({ subscribe } as Writable<FilterState>), currentTreeData);
+        syncFilteredData(
+          get({ subscribe } as Writable<FilterState>),
+          currentTreeData,
+          get(sort_state)
+        );
+      });
+
+      sort_state.subscribe((currentSort) => {
+        syncFilteredData(get({ subscribe } as Writable<FilterState>), get(tree_data), currentSort);
       });
     },
   };

--- a/src/stores/sort.ts
+++ b/src/stores/sort.ts
@@ -1,0 +1,32 @@
+import { writable, type Writable } from "svelte/store";
+import type { SortState } from "../types/app";
+
+export const SORTABLE_COLUMNS = new Set(["name", "status", "start date", "due date"]);
+
+export interface SortStore extends Writable<SortState | null> {
+  init: () => void;
+  cycle: (column: string) => void;
+  clear: () => void;
+}
+
+function createSort(): SortStore {
+  const { subscribe, set, update } = writable<SortState | null>(null);
+
+  return {
+    subscribe,
+    set,
+    update,
+    init: () => {},
+    cycle: (column: string) => {
+      if (!SORTABLE_COLUMNS.has(column)) return;
+      update((current) => {
+        if (!current || current.column !== column) return { column, direction: "asc" };
+        if (current.direction === "asc") return { column, direction: "desc" };
+        return null;
+      });
+    },
+    clear: () => set(null),
+  };
+}
+
+export const sort_state = createSort();

--- a/src/types/app.ts
+++ b/src/types/app.ts
@@ -9,6 +9,11 @@ import type {
 export type ThemeName = "dark" | "light";
 export type SelectedType = "Projects" | "Info" | "WorkspaceProject" | undefined;
 export type FilterState = Record<string, string[]>;
+export type SortDirection = "asc" | "desc";
+export interface SortState {
+  column: string;
+  direction: SortDirection;
+}
 
 export interface ProjectListItem {
   id: string;


### PR DESCRIPTION
- Add SortState type and sort store with asc/desc/clear cycle
- Add sortTree() that recursively sorts siblings while preserving hierarchy
- Extend filterTree() with date range filtering for start/due date columns
- Wire sort into the filter pipeline so filtered_data includes sort
- Add sort indicators (▲/▼) to sortable column headers (name, status, dates)
- Add date range filter panels for start date and due date columns

Closes #149
https://claude.ai/code/session_0162oXu4qu7Br9Mc2ujC3FTo