### PR TITLE
fix: unify tree table header controls

### DIFF
--- a/src/common/tree_control.ts
+++ b/src/common/tree_control.ts
@@ -1,5 +1,5 @@
 import { uuidV4 } from "./uuid";
-import { searchMemoEntries } from "./memo_utils";
+import { memoContentForSearch } from "./memo_utils";
 import type { SortState } from "../types/app";
 
 export type TaskStatus = "Open" | "Pending" | "In Progress" | "Completed" | "Canceled";
@@ -51,6 +51,33 @@ export interface VisibleTreeRow {
   canOutdent: boolean;
 }
 
+const FILTER_FLAG_KEYS = new Set(["search_memo"]);
+
+function valueForFullText(value: unknown): string {
+  if (value == null) return "";
+  if (typeof value === "string") return value;
+  if (typeof value === "number" || typeof value === "boolean") return String(value);
+  return JSON.stringify(value);
+}
+
+function fullTextMatches(data: TreeNodeData, keywords: string[], includeMemo: boolean): boolean {
+  const fieldText = Object.entries(data)
+    .filter(([key]) => key !== "memo")
+    .map(([, value]) => valueForFullText(value))
+    .join(" ");
+  const memoText = includeMemo
+    ? (data.memo ?? [])
+        .map((entry) =>
+          [entry.title, memoContentForSearch(entry.content), (entry.tags ?? []).join(" ")]
+            .filter(Boolean)
+            .join(" ")
+        )
+        .join(" ")
+    : "";
+  const text = `${fieldText} ${memoText}`.toLowerCase();
+  return keywords.some((keyword) => text.includes(keyword.toLowerCase()));
+}
+
 export function filterTree(
   tree: TreeData | null | undefined,
   filter: Record<string, string[]> | null | undefined
@@ -60,30 +87,31 @@ export function filterTree(
   // Check match against all filters
   let allFiltersMatch = true;
   let nameFilterMatch = false;
+  let fullTextFilterMatch = false;
 
   // Check if filter is empty
-  const hasFilters = Object.keys(filter).some((key) => filter[key] && filter[key].length > 0);
+  const hasFilters = Object.keys(filter).some(
+    (key) => !FILTER_FLAG_KEYS.has(key) && filter[key] && filter[key].length > 0
+  );
   if (!hasFilters) return tree; // Return tree as is if no filters
 
   // Evaluate each filter
   for (const key in filter) {
-    if (key === "search_memo") continue; // flag key, not a data field
+    if (FILTER_FLAG_KEYS.has(key)) continue; // flag key, not a data field
 
     const keywords = filter[key];
     if (!keywords || keywords.length === 0) continue;
 
     let keyMatch = false;
-    if (key === "name") {
+    if (key === "full_text") {
+      keyMatch = fullTextMatches(tree.data, keywords, (filter["search_memo"]?.length ?? 0) > 0);
+      fullTextFilterMatch = keyMatch;
+    } else if (key === "name") {
       // In case of name filter
-      const nameMatch = keywords.some(
+      keyMatch = keywords.some(
         (keyword) => tree.data.name && tree.data.name.toLowerCase().includes(keyword.toLowerCase())
       );
-      const memoMatch =
-        !nameMatch &&
-        (filter["search_memo"]?.length ?? 0) > 0 &&
-        searchMemoEntries(tree.data.memo ?? [], keywords);
-      keyMatch = nameMatch || memoMatch;
-      nameFilterMatch = keyMatch; // Record if name/memo filter matched
+      nameFilterMatch = keyMatch; // Record if name filter matched
     } else if (key === "tags") {
       const tag = keywords[0].toLowerCase();
       keyMatch = (tree.data.memo ?? []).some((entry) =>
@@ -117,8 +145,8 @@ export function filterTree(
   // Process child nodes
   const matchedChildren: TreeData[] = [];
   for (const child of tree.children || []) {
-    if (nameFilterMatch && allFiltersMatch) {
-      // If name filter matches and all filters match,
+    if ((nameFilterMatch || fullTextFilterMatch) && allFiltersMatch) {
+      // If name/full-text filter matches and all filters match,
       // include all child nodes (no filtering)
       matchedChildren.push(cloneTreeWithAllChildren(child));
     } else {

--- a/src/components/MultiSelect.svelte
+++ b/src/components/MultiSelect.svelte
@@ -1,29 +1,92 @@
 <script>
+  import { createEventDispatcher } from "svelte";
   import IconButton from "./IconButton.svelte";
-  import { clickOutside, ripple } from "../common/common.js";
+  import { ripple } from "../common/common.js";
+
   export let list = ["first", "second", "third"];
   export let selected = [];
   export let placeholder = "Not selected.";
+  export let summary = "";
+
   let checked = Array.from(list).fill(false);
   let expanded = false;
-  $: selected = list.filter((elm, i) => checked[i]);
+  let containerElement;
+  let listElement;
+  let anchorRect = null;
+  let selectedKey = "";
+
+  const dispatch = createEventDispatcher();
+
+  function keyOf(values) {
+    return (values ?? []).join("\u001f");
+  }
+
+  $: {
+    const nextKey = keyOf(selected);
+    if (nextKey !== selectedKey) {
+      checked = list.map((elm) => selected.includes(elm));
+      selectedKey = nextKey;
+    }
+  }
+
+  $: selectionLabel =
+    summary ||
+    (selected.length == 0
+      ? placeholder
+      : selected.length == 1
+        ? selected[0]
+        : `${selected.length} selected.`);
+
+  $: listStyle = anchorRect
+    ? `top: ${anchorRect.bottom + 2}px; left: ${anchorRect.left}px; min-width: max(${anchorRect.width}px, 14rem);`
+    : "";
+
+  function updateSelected() {
+    const next = list.filter((elm, i) => checked[i]);
+    selected = next;
+    selectedKey = keyOf(next);
+    dispatch("change", { selected: next });
+  }
+
+  function toggleExpanded(event) {
+    event.stopPropagation();
+    anchorRect = event.currentTarget.getBoundingClientRect();
+    expanded = !expanded;
+  }
+
+  function handleWindowClick(event) {
+    if (
+      expanded &&
+      containerElement &&
+      listElement &&
+      !containerElement.contains(event.target) &&
+      !listElement.contains(event.target)
+    ) {
+      expanded = false;
+    }
+  }
+
+  function handleWindowKeydown(event) {
+    if (expanded && event.key === "Escape") {
+      expanded = false;
+    }
+  }
+
+  function portal(node) {
+    document.body.appendChild(node);
+    return {
+      destroy() {
+        if (node.parentNode) node.parentNode.removeChild(node);
+      },
+    };
+  }
 </script>
 
-<div
-  class="container"
-  use:clickOutside
-  on:outclick={() => {
-    expanded = false;
-  }}
->
+<svelte:window on:click={handleWindowClick} on:keydown={handleWindowKeydown} />
+
+<div class="container" bind:this={containerElement}>
   <div class="selectContainer">
-    <button
-      on:click={(e) => {
-        expanded = !expanded;
-        e.stopPropagation();
-      }}
-      use:ripple
-    >
+    <button on:click={toggleExpanded} use:ripple>
       <div class="svgContainer">
         <svg
           class:emphasized={selected.length > 0}
@@ -37,11 +100,7 @@
         >
       </div>
       <div class="selection" class:expanded>
-        {selected.length == 0
-          ? placeholder
-          : selected.length == 1
-            ? selected[0]
-            : `${selected.length} selected.`}
+        {selectionLabel}
       </div>
       {#if selected.length > 0}
         <IconButton
@@ -49,7 +108,8 @@
           ariaLabel="Clear filter selection"
           on:click={(e) => {
             expanded = false;
-            checked = checked.fill(false);
+            checked = list.map(() => false);
+            updateSelected();
             e.stopPropagation();
           }}
           activeColor={"transparent"}
@@ -68,12 +128,17 @@
     </button>
   </div>
   {#if expanded}
-    <div class="listContainer">
+    <div bind:this={listElement} class="listContainer" style={listStyle} use:portal>
       {#each list as elm, i}
-        <div class="elmContainer">
-          <input style="margin: auto 0.25rem;" id={elm} type="checkbox" bind:checked={checked[i]} />
-          <label style="margin: auto 0.25rem;" for={elm}>{elm}</label>
-        </div>
+        <label class="elmContainer" for={`multi-select-${i}`}>
+          <input
+            id={`multi-select-${i}`}
+            type="checkbox"
+            bind:checked={checked[i]}
+            on:change={updateSelected}
+          />
+          <span>{elm}</span>
+        </label>
       {/each}
     </div>
   {/if}
@@ -134,20 +199,37 @@
     flex: 1;
   }
   .listContainer {
-    padding: 1rem;
     position: fixed;
+    z-index: 99999999;
     display: flex;
     flex-direction: column;
-    justify-content: center;
-    z-index: 999999999999;
-    background-color: var(--theme-color-Sub-light);
-    color: var(--theme-color-Main-light);
+    background: var(--theme-color-Main-main);
+    border-radius: 0.5rem;
+    box-shadow: 0 0.2rem 0.5rem rgba(0, 0, 0, 0.25);
+    padding: 4px 0;
+    color: var(--theme-color-Sub-light);
+    box-sizing: border-box;
   }
   .elmContainer {
     display: flex;
-    flex-direction: row;
     align-items: center;
-    margin: 0.25rem;
+    gap: 0.5rem;
+    margin: 0;
+    padding: 0.45rem 0.75rem;
+    color: var(--theme-color-Sub-light);
+    font-size: 0.85rem;
+    cursor: pointer;
+    user-select: none;
+  }
+  .elmContainer:hover {
+    background-color: var(--theme-color-Accent-dark);
+  }
+  .elmContainer input[type="checkbox"] {
+    width: 0.9rem;
+    height: 0.9rem;
+    margin: 0;
+    flex-shrink: 0;
+    accent-color: var(--theme-color-Accent-dark);
   }
   .selection {
     padding: 0 0.25rem;

--- a/src/components/NameFilterPanel.svelte
+++ b/src/components/NameFilterPanel.svelte
@@ -1,16 +1,15 @@
 <script lang="ts">
   import { createEventDispatcher } from "svelte";
 
-  export let column: string;
-  export let from: string = "";
-  export let to: string = "";
+  export let value: string = "";
   export let anchorRect: DOMRect | null = null;
 
   const dispatch = createEventDispatcher<{
-    change: { from: string; to: string };
+    change: { name: string };
     close: void;
   }>();
   let panelElement: HTMLElement;
+  let inputElement: HTMLInputElement;
 
   $: panelStyle = anchorRect ? `top: ${anchorRect.bottom + 2}px; left: ${anchorRect.left}px;` : "";
 
@@ -28,17 +27,18 @@
   }
 
   function handleChange() {
-    dispatch("change", { from, to });
+    dispatch("change", { name: value });
   }
 
   function handleClear() {
-    from = "";
-    to = "";
-    dispatch("change", { from: "", to: "" });
+    value = "";
+    dispatch("change", { name: "" });
+    inputElement?.focus();
   }
 
   function portal(node: HTMLElement) {
     document.body.appendChild(node);
+    inputElement?.focus();
     return {
       destroy() {
         if (node.parentNode) node.parentNode.removeChild(node);
@@ -51,41 +51,34 @@
 
 <div
   bind:this={panelElement}
-  class="DateRangePanel"
+  class="NameFilterPanel"
   style={panelStyle}
   role="dialog"
   tabindex="-1"
-  aria-label="{column} 日付フィルター"
+  aria-label="Name フィルター"
   on:click|stopPropagation
   on:keydown={handleKeydown}
   use:portal
 >
-  <div class="PanelTitle">{column} フィルター</div>
-  <div class="DateRow">
-    <label for="dr-from-{column.replace(' ', '-')}">From</label>
+  <div class="PanelTitle">Name フィルター</div>
+  <label class="TextRow" for="name-filter-input">
+    <span>Name</span>
     <input
-      id="dr-from-{column.replace(' ', '-')}"
-      type="date"
-      bind:value={from}
-      on:change={handleChange}
+      bind:this={inputElement}
+      id="name-filter-input"
+      type="text"
+      bind:value
+      placeholder="filter tasks..."
+      on:input={handleChange}
     />
-  </div>
-  <div class="DateRow">
-    <label for="dr-to-{column.replace(' ', '-')}">To</label>
-    <input
-      id="dr-to-{column.replace(' ', '-')}"
-      type="date"
-      bind:value={to}
-      on:change={handleChange}
-    />
-  </div>
-  {#if from || to}
+  </label>
+  {#if value}
     <button class="ClearBtn" on:click={handleClear}>クリア</button>
   {/if}
 </div>
 
 <style>
-  .DateRangePanel {
+  .NameFilterPanel {
     position: fixed;
     z-index: 99999999;
     background: var(--theme-color-Main-main);
@@ -102,7 +95,7 @@
     padding: 0.45rem 0.75rem 0.35rem;
     opacity: 0.75;
   }
-  .DateRow {
+  .TextRow {
     display: flex;
     align-items: center;
     padding: 0.45rem 0.75rem;
@@ -110,12 +103,12 @@
     color: var(--theme-color-Sub-light);
     font-size: 0.85rem;
   }
-  .DateRow label {
+  .TextRow span {
     width: 2.5rem;
     flex-shrink: 0;
     user-select: none;
   }
-  .DateRow input[type="date"] {
+  .TextRow input[type="text"] {
     flex: 1;
     background: var(--theme-color-Main-dark);
     color: var(--theme-color-Sub-light);
@@ -123,7 +116,6 @@
     border-radius: 0.25rem;
     padding: 0.2rem 0.3rem;
     font-size: 0.8rem;
-    color-scheme: dark;
     box-sizing: border-box;
     min-width: 0;
   }

--- a/src/components/SearchBox.svelte
+++ b/src/components/SearchBox.svelte
@@ -11,7 +11,7 @@
     search_text = value;
     $filter = {
       ...$filter,
-      name: search_text !== "" ? [search_text] : null,
+      full_text: search_text !== "" ? [search_text] : null,
     };
   };
 
@@ -23,8 +23,8 @@
     };
   };
 
-  $: if (($filter?.name?.[0] ?? "") !== search_text && document.activeElement !== search_box) {
-    search_text = $filter?.name?.[0] ?? "";
+  $: if (($filter?.full_text?.[0] ?? "") !== search_text && document.activeElement !== search_box) {
+    search_text = $filter?.full_text?.[0] ?? "";
   }
 
   $: memoSearchEnabled = ($filter?.search_memo?.length ?? 0) > 0;

--- a/src/components/TreeTableHeader.svelte
+++ b/src/components/TreeTableHeader.svelte
@@ -3,33 +3,52 @@
   import { column_settings } from "../stores/column_settings.ts";
   import { closed_node_ids } from "../stores/ui.ts";
   import { sort_state, SORTABLE_COLUMNS } from "../stores/sort.ts";
+  import IconButton from "./IconButton.svelte";
   import MultiSelect from "./MultiSelect.svelte";
   import DateRangePanel from "./DateRangePanel.svelte";
+  import NameFilterPanel from "./NameFilterPanel.svelte";
 
   export let headers;
   export let allHeaders = [];
 
-  let selected = [];
-  $: $filter = {
-    ...$filter,
-    status: selected.length > 0 ? selected : undefined,
-  };
+  const STATUS_OPTIONS = ["Open", "Pending", "In Progress", "Completed", "Canceled"];
+  const EMPTY_FILTER_LABEL = "No filter";
+  const FILTER_ICON_PATH =
+    "M3 7C3 6.44772 3.44772 6 4 6H20C20.5523 6 21 6.44772 21 7C21 7.55228 20.5523 8 20 8H4C3.44772 8 3 7.55228 3 7ZM6 12C6 11.4477 6.44772 11 7 11H17C17.5523 11 18 11.4477 18 12C18 12.5523 17.5523 13 17 13H7C6.44772 13 6 12.5523 6 12ZM9 17C9 16.4477 9.44772 16 10 16H14C14.5523 16 15 16.4477 15 17C15 17.5523 14.5523 18 14 18H10C9.44772 18 9 17.5523 9 17Z";
+  const FILTER_CLEAR_ICON_PATH =
+    "M9.291,10.352l-4-4-4.005,4A.75.75,0,1,1,.22,9.291l4.005-4L.22,1.281A.75.75,0,0,1,1.281.22L5.286,4.225l4-4.005a.75.75,0,1,1,1.061,1.061l-4,4.005,4,4a.75.75,0,0,1-1.061,1.061Z";
 
+  let statusSelected = [];
   let showPanel = false;
   let panelElement;
   let panelStyle = "";
 
   let openDatePanel = null;
   let datePanelAnchorRect = null;
-  let datePanelElement = null;
+  let openNamePanel = false;
+  let namePanelAnchorRect = null;
 
   $: availableIds = new Set(allHeaders.map((h) => h.name));
 
   $: startDateFilter = $filter["start date"] ?? ["", ""];
   $: dueDateFilter = $filter["due date"] ?? ["", ""];
+  $: nameFilterValue = $filter?.name?.[0] ?? "";
+  $: statusSelected = $filter?.status?.filter(Boolean) ?? [];
+  $: filterSummaries = Object.fromEntries(
+    (headers ?? []).map((header) => [header.name, getFilterSummary(header.name, $filter)])
+  );
+  $: filterActive = Object.fromEntries(
+    (headers ?? []).map((header) => [header.name, isFilterActive(header.name, $filter)])
+  );
+
+  function isDateColumn(headerName) {
+    return headerName === "start date" || headerName === "due date";
+  }
 
   function openPanel(e) {
     e.stopPropagation();
+    openDatePanel = null;
+    openNamePanel = false;
     const rect = e.currentTarget.getBoundingClientRect();
     panelStyle = `top: ${rect.bottom}px; right: calc(100vw - ${rect.right}px);`;
     showPanel = !showPanel;
@@ -40,14 +59,74 @@
     sort_state.cycle(headerName);
   }
 
+  function getSortDirection(headerName) {
+    return $sort_state?.column === headerName ? $sort_state.direction : null;
+  }
+
+  function getSortButtonLabel(headerName) {
+    const direction = getSortDirection(headerName);
+    if (direction === "asc") return `${headerName} sorted ascending`;
+    if (direction === "desc") return `${headerName} sorted descending`;
+    return `Sort ${headerName}`;
+  }
+
+  function isFilterActive(headerName, currentFilter = $filter) {
+    if (headerName === "name") {
+      return Boolean(currentFilter?.name?.[0]);
+    }
+    if (headerName === "status") {
+      return (currentFilter?.status?.filter(Boolean).length ?? 0) > 0;
+    }
+    return (currentFilter?.[headerName]?.filter(Boolean).length ?? 0) > 0;
+  }
+
+  function getDateFilterSummary(headerName, currentFilter = $filter) {
+    const [from = "", to = ""] = currentFilter?.[headerName] ?? [];
+    if (from && to) return `${from} - ${to}`;
+    if (from) return `From ${from}`;
+    if (to) return `To ${to}`;
+    return EMPTY_FILTER_LABEL;
+  }
+
+  function getFilterSummary(headerName, currentFilter = $filter) {
+    if (headerName === "name") {
+      const nameQuery = currentFilter?.name?.[0] ?? "";
+      if (nameQuery) return nameQuery;
+      return EMPTY_FILTER_LABEL;
+    }
+    if (isDateColumn(headerName)) {
+      return getDateFilterSummary(headerName, currentFilter);
+    }
+    if (headerName === "status") {
+      const statusValues = currentFilter?.status?.filter(Boolean) ?? [];
+      if (statusValues.length === 1) return statusValues[0];
+      if (statusValues.length > 1) return `${statusValues.length} selected.`;
+      return EMPTY_FILTER_LABEL;
+    }
+    const values = currentFilter?.[headerName]?.filter(Boolean) ?? [];
+    if (values.length === 1) return values[0];
+    if (values.length > 1) return `${values.length} selected.`;
+    return EMPTY_FILTER_LABEL;
+  }
+
   function toggleDatePanel(e, headerName) {
     e.stopPropagation();
+    showPanel = false;
+    openNamePanel = false;
     if (openDatePanel === headerName) {
       openDatePanel = null;
     } else {
       datePanelAnchorRect = e.currentTarget.getBoundingClientRect();
       openDatePanel = headerName;
     }
+  }
+
+  function toggleNamePanel(e) {
+    e.stopPropagation();
+    showPanel = false;
+    openDatePanel = null;
+    namePanelAnchorRect = e.currentTarget.getBoundingClientRect();
+    openNamePanel = !openNamePanel;
   }
 
   function handleDateRangeChange(headerName, detail) {
@@ -63,12 +142,50 @@
     });
   }
 
+  function handleStatusFilterChange(detail) {
+    const nextSelected = detail.selected ?? [];
+    filter.update((f) => {
+      const next = { ...f };
+      if (nextSelected.length > 0) {
+        next.status = nextSelected;
+      } else {
+        delete next.status;
+      }
+      return next;
+    });
+  }
+
+  function handleNameFilterChange(detail) {
+    const { name } = detail;
+    filter.update((f) => {
+      const next = { ...f };
+      if (name) {
+        next.name = [name];
+      } else {
+        delete next.name;
+      }
+      return next;
+    });
+  }
+
+  function clearColumnFilter(headerName) {
+    if (openDatePanel === headerName) {
+      openDatePanel = null;
+    }
+    if (headerName === "name") {
+      openNamePanel = false;
+    }
+
+    filter.update((f) => {
+      const next = { ...f };
+      delete next[headerName];
+      return next;
+    });
+  }
+
   function handleWindowClick(e) {
     if (showPanel && panelElement && !panelElement.contains(e.target)) {
       showPanel = false;
-    }
-    if (openDatePanel && datePanelElement && !datePanelElement.contains(e.target)) {
-      openDatePanel = null;
     }
   }
 
@@ -87,132 +204,228 @@
 <div class:TableRow={true} role="row">
   {#each headers as header}
     <div class:TableHeader={true} role="columnheader">
-      <!-- Label row: clickable for sort on sortable columns -->
-      <!-- svelte-ignore a11y-no-static-element-interactions -->
-      <div
-        class="HeaderLabelRow"
-        class:sortable={SORTABLE_COLUMNS.has(header.name)}
-        class:sortActive={$sort_state?.column === header.name}
-        on:click={(e) => handleSortClick(e, header.name)}
-        on:keydown={(e) => {
-          if (e.key === "Enter" || e.key === " ") handleSortClick(e, header.name);
-        }}
-      >
-        <span class:TextOverFlow={true}>{header.name}</span>
-        {#if $sort_state?.column === header.name}
-          <span class="SortIndicator">
-            {$sort_state.direction === "asc" ? "▲" : "▼"}
-          </span>
-        {/if}
-        {#if header.name === "start date" || header.name === "due date"}
+      <div class="HeaderLabelRow" class:sortActive={$sort_state?.column === header.name}>
+        <span class="HeaderLabelText TextOverFlow">{header.name}</span>
+        {#if SORTABLE_COLUMNS.has(header.name)}
           <button
-            class="DateFilterBtn"
-            class:active={!!$filter[header.name]}
-            on:click|stopPropagation={(e) => toggleDatePanel(e, header.name)}
-            aria-label="{header.name} 日付フィルター"
-            aria-expanded={openDatePanel === header.name}
-            title="日付フィルター"
+            class="SortButton"
+            class:active={$sort_state?.column === header.name}
+            aria-label={getSortButtonLabel(header.name)}
+            title={getSortButtonLabel(header.name)}
+            on:click|stopPropagation={(e) => handleSortClick(e, header.name)}
           >
             <svg viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
-              <rect
-                x="3"
-                y="4"
-                width="18"
-                height="18"
-                rx="2"
-                ry="2"
-                stroke-width="2"
-                stroke-linecap="round"
-                stroke-linejoin="round"
-              />
-              <line x1="16" y1="2" x2="16" y2="6" stroke-width="2" stroke-linecap="round" />
-              <line x1="8" y1="2" x2="8" y2="6" stroke-width="2" stroke-linecap="round" />
-              <line x1="3" y1="10" x2="21" y2="10" stroke-width="2" stroke-linecap="round" />
+              {#if getSortDirection(header.name) === "asc"}
+                <path
+                  d="M6 15l6-6 6 6"
+                  stroke-width="2.4"
+                  stroke-linecap="round"
+                  stroke-linejoin="round"
+                />
+              {:else}
+                <path
+                  d="M6 9l6 6 6-6"
+                  stroke-width="2.4"
+                  stroke-linecap="round"
+                  stroke-linejoin="round"
+                />
+              {/if}
             </svg>
           </button>
+        {/if}
+        {#if header.name == "name"}
+          <div class="HeaderUtilityButtons">
+            <button
+              class="ExpandCollapseBtn"
+              aria-label="すべて展開"
+              title="すべて展開"
+              on:click={() => closed_node_ids.expandAll()}
+            >
+              <svg viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
+                <path
+                  d="M8 3H5a2 2 0 0 0-2 2v3"
+                  stroke-width="2"
+                  stroke-linecap="round"
+                  stroke-linejoin="round"
+                />
+                <path
+                  d="M21 8V5a2 2 0 0 0-2-2h-3"
+                  stroke-width="2"
+                  stroke-linecap="round"
+                  stroke-linejoin="round"
+                />
+                <path
+                  d="M3 16v3a2 2 0 0 0 2 2h3"
+                  stroke-width="2"
+                  stroke-linecap="round"
+                  stroke-linejoin="round"
+                />
+                <path
+                  d="M16 21h3a2 2 0 0 0 2-2v-3"
+                  stroke-width="2"
+                  stroke-linecap="round"
+                  stroke-linejoin="round"
+                />
+              </svg>
+            </button>
+            <button
+              class="ExpandCollapseBtn"
+              aria-label="すべて折り畳み"
+              title="すべて折り畳み"
+              on:click={() => closed_node_ids.collapseAll()}
+            >
+              <svg viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
+                <path
+                  d="M8 3v3a2 2 0 0 1-2 2H3"
+                  stroke-width="2"
+                  stroke-linecap="round"
+                  stroke-linejoin="round"
+                />
+                <path
+                  d="M21 8h-3a2 2 0 0 1-2-2V3"
+                  stroke-width="2"
+                  stroke-linecap="round"
+                  stroke-linejoin="round"
+                />
+                <path
+                  d="M3 16h3a2 2 0 0 1 2 2v3"
+                  stroke-width="2"
+                  stroke-linecap="round"
+                  stroke-linejoin="round"
+                />
+                <path
+                  d="M16 21v-3a2 2 0 0 1 2-2h3"
+                  stroke-width="2"
+                  stroke-linecap="round"
+                  stroke-linejoin="round"
+                />
+              </svg>
+            </button>
+          </div>
         {/if}
       </div>
-      {#if header.name == "status"}
-        <div
-          style="display: flex; flex: 1; width:100%; height:100%; justify-content: center; align-items: center;"
-        >
+      <div class="HeaderControlRow">
+        {#if header.name == "status"}
           <MultiSelect
-            bind:selected
-            list={["Open", "Pending", "In Progress", "Completed", "Canceled"]}
-            placeholder="No filter."
+            selected={statusSelected}
+            list={STATUS_OPTIONS}
+            placeholder={EMPTY_FILTER_LABEL}
+            summary={filterSummaries.status}
+            on:change={(e) => handleStatusFilterChange(e.detail)}
           />
-        </div>
-      {/if}
-      {#if header.name == "name"}
-        <div class="ExpandCollapseButtons">
-          <button
-            class="ExpandCollapseBtn"
-            aria-label="すべて展開"
-            title="すべて展開"
-            on:click={() => closed_node_ids.expandAll()}
-          >
-            <svg viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
-              <path
-                d="M8 3H5a2 2 0 0 0-2 2v3"
-                stroke-width="2"
-                stroke-linecap="round"
-                stroke-linejoin="round"
-              />
-              <path
-                d="M21 8V5a2 2 0 0 0-2-2h-3"
-                stroke-width="2"
-                stroke-linecap="round"
-                stroke-linejoin="round"
-              />
-              <path
-                d="M3 16v3a2 2 0 0 0 2 2h3"
-                stroke-width="2"
-                stroke-linecap="round"
-                stroke-linejoin="round"
-              />
-              <path
-                d="M16 21h3a2 2 0 0 0 2-2v-3"
-                stroke-width="2"
-                stroke-linecap="round"
-                stroke-linejoin="round"
-              />
-            </svg>
-          </button>
-          <button
-            class="ExpandCollapseBtn"
-            aria-label="すべて折り畳み"
-            title="すべて折り畳み"
-            on:click={() => closed_node_ids.collapseAll()}
-          >
-            <svg viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
-              <path
-                d="M8 3v3a2 2 0 0 1-2 2H3"
-                stroke-width="2"
-                stroke-linecap="round"
-                stroke-linejoin="round"
-              />
-              <path
-                d="M21 8h-3a2 2 0 0 1-2-2V3"
-                stroke-width="2"
-                stroke-linecap="round"
-                stroke-linejoin="round"
-              />
-              <path
-                d="M3 16h3a2 2 0 0 1 2 2v3"
-                stroke-width="2"
-                stroke-linecap="round"
-                stroke-linejoin="round"
-              />
-              <path
-                d="M16 21v-3a2 2 0 0 1 2-2h3"
-                stroke-width="2"
-                stroke-linecap="round"
-                stroke-linejoin="round"
-              />
-            </svg>
-          </button>
-        </div>
-      {/if}
+        {:else if header.name == "name"}
+          <div class="HeaderFilterGroup">
+            <button
+              class="HeaderFilterControl"
+              class:active={filterActive[header.name]}
+              on:click|stopPropagation={toggleNamePanel}
+              aria-label="{header.name} フィルター"
+              aria-expanded={openNamePanel}
+              title="Name フィルター"
+            >
+              <span class="FilterIcon" aria-hidden="true">
+                <svg viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg">
+                  <path d={FILTER_ICON_PATH} />
+                </svg>
+              </span>
+              <span class="FilterSelection">{filterSummaries[header.name]}</span>
+            </button>
+            {#if filterActive[header.name]}
+              <IconButton
+                style={"margin: 0rem; padding: 0.25rem; margin-left: auto; width: 1.5rem; height: 1.5rem; flex-shrink: 0;"}
+                ariaLabel={`${header.name} フィルターをクリア`}
+                on:click={(e) => {
+                  clearColumnFilter(header.name);
+                  e.stopPropagation();
+                }}
+                activeColor={"transparent"}
+                normalColor={"transparent"}
+              >
+                <svg viewBox="4 4 16 16" xmlns="http://www.w3.org/2000/svg" aria-hidden="true">
+                  <path
+                    d={FILTER_CLEAR_ICON_PATH}
+                    fill="currentColor"
+                    transform="translate(6.629 6.8)"
+                  />
+                </svg>
+              </IconButton>
+            {/if}
+          </div>
+        {:else if isDateColumn(header.name)}
+          <div class="HeaderFilterGroup">
+            <button
+              class="HeaderFilterControl"
+              class:active={filterActive[header.name]}
+              on:click|stopPropagation={(e) => toggleDatePanel(e, header.name)}
+              aria-label="{header.name} 日付フィルター"
+              aria-expanded={openDatePanel === header.name}
+              title="日付フィルター"
+            >
+              <span class="FilterIcon" aria-hidden="true">
+                <svg viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg">
+                  <path d={FILTER_ICON_PATH} />
+                </svg>
+              </span>
+              <span class="FilterSelection">{filterSummaries[header.name]}</span>
+            </button>
+            {#if filterActive[header.name]}
+              <IconButton
+                style={"margin: 0rem; padding: 0.25rem; margin-left: auto; width: 1.5rem; height: 1.5rem; flex-shrink: 0;"}
+                ariaLabel={`${header.name} フィルターをクリア`}
+                on:click={(e) => {
+                  clearColumnFilter(header.name);
+                  e.stopPropagation();
+                }}
+                activeColor={"transparent"}
+                normalColor={"transparent"}
+              >
+                <svg viewBox="4 4 16 16" xmlns="http://www.w3.org/2000/svg" aria-hidden="true">
+                  <path
+                    d={FILTER_CLEAR_ICON_PATH}
+                    fill="currentColor"
+                    transform="translate(6.629 6.8)"
+                  />
+                </svg>
+              </IconButton>
+            {/if}
+          </div>
+        {:else}
+          <div class="HeaderFilterGroup">
+            <div
+              class="HeaderFilterControl HeaderFilterSummary"
+              class:active={filterActive[header.name]}
+              aria-label="{header.name} filter: {filterSummaries[header.name]}"
+            >
+              <span class="FilterIcon" aria-hidden="true">
+                <svg viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg">
+                  <path d={FILTER_ICON_PATH} />
+                </svg>
+              </span>
+              <span class="FilterSelection">{filterSummaries[header.name]}</span>
+            </div>
+            {#if filterActive[header.name]}
+              <IconButton
+                style={"margin: 0rem; padding: 0.25rem; margin-left: auto; width: 1.5rem; height: 1.5rem; flex-shrink: 0;"}
+                ariaLabel={`${header.name} フィルターをクリア`}
+                on:click={(e) => {
+                  clearColumnFilter(header.name);
+                  e.stopPropagation();
+                }}
+                activeColor={"transparent"}
+                normalColor={"transparent"}
+              >
+                <svg viewBox="4 4 16 16" xmlns="http://www.w3.org/2000/svg" aria-hidden="true">
+                  <path
+                    d={FILTER_CLEAR_ICON_PATH}
+                    fill="currentColor"
+                    transform="translate(6.629 6.8)"
+                  />
+                </svg>
+              </IconButton>
+            {/if}
+          </div>
+        {/if}
+      </div>
     </div>
   {/each}
 
@@ -312,28 +525,46 @@
 
 {#if openDatePanel === "start date"}
   <DateRangePanel
-    bind:this={datePanelElement}
     column="start date"
     from={startDateFilter[0]}
     to={startDateFilter[1]}
     anchorRect={datePanelAnchorRect}
     on:change={(e) => handleDateRangeChange("start date", e.detail)}
+    on:close={() => (openDatePanel = null)}
   />
 {/if}
 
 {#if openDatePanel === "due date"}
   <DateRangePanel
-    bind:this={datePanelElement}
     column="due date"
     from={dueDateFilter[0]}
     to={dueDateFilter[1]}
     anchorRect={datePanelAnchorRect}
     on:change={(e) => handleDateRangeChange("due date", e.detail)}
+    on:close={() => (openDatePanel = null)}
+  />
+{/if}
+
+{#if openNamePanel}
+  <NameFilterPanel
+    value={nameFilterValue}
+    anchorRect={namePanelAnchorRect}
+    on:change={(e) => handleNameFilterChange(e.detail)}
+    on:close={() => (openNamePanel = false)}
   />
 {/if}
 
 <style>
   .TableRow {
+    --header-bg: var(--theme-color-Sub-light);
+    --header-fg: var(--theme-color-Main-light);
+    --header-border: color-mix(in srgb, var(--theme-color-Sub-dark) 42%, transparent);
+    --header-hover: color-mix(in srgb, var(--theme-color-Accent-dark) 78%, transparent);
+    --header-active: var(--theme-color-Accent-main);
+    --header-button-border: color-mix(in srgb, var(--theme-color-Main-light) 24%, transparent);
+    --header-icon-size: 2rem;
+    --header-action-icon-size: 1.5rem;
+
     position: sticky;
     top: 0;
     display: flex;
@@ -351,11 +582,10 @@
     min-width: 4rem;
     display: flex;
     flex-direction: column;
-    border-right: 1px solid;
-    border-left: 1px solid;
-    border-bottom: 1px solid;
-    background-color: var(--theme-color-Sub-light);
-    color: var(--theme-color-Main-light);
+    border-right: 1px solid var(--header-border);
+    border-bottom: 1px solid var(--header-border);
+    background-color: var(--header-bg);
+    color: var(--header-fg);
     align-items: center;
     justify-content: center;
     font-weight: bold;
@@ -365,7 +595,7 @@
     padding-right: 2rem;
   }
   .TableHeader:first-of-type {
-    border-left: 0px;
+    border-left: 0;
   }
   .TextOverFlow {
     text-overflow: ellipsis;
@@ -375,135 +605,184 @@
 
   .HeaderLabelRow {
     display: flex;
-    flex: 1;
+    flex: 0 0 2rem;
     width: 100%;
-    height: 100%;
-    justify-content: center;
+    height: 2rem;
     align-items: center;
-    gap: 0.2rem;
-    padding: 0 0.3rem;
+    justify-content: center;
+    gap: 0.1rem;
+    padding: 0 0.2rem;
     overflow: hidden;
     box-sizing: border-box;
-  }
-  .HeaderLabelRow.sortable {
-    cursor: pointer;
-    user-select: none;
-  }
-  .HeaderLabelRow.sortable:hover {
-    background-color: var(--theme-color-Accent-dark);
+    transition:
+      background-color 0.12s ease,
+      color 0.12s ease;
   }
   .HeaderLabelRow.sortActive {
-    color: var(--theme-color-Accent-main);
+    color: var(--header-active);
   }
-  .SortIndicator {
-    font-size: 0.7rem;
+  .HeaderLabelText {
+    flex: 1 1 auto;
+    min-width: 0;
+    text-align: center;
+  }
+  .HeaderUtilityButtons {
+    display: flex;
+    align-items: center;
+    gap: 0.1rem;
     flex-shrink: 0;
-    color: var(--theme-color-Accent-main);
   }
 
-  .DateFilterBtn {
-    width: 1.4rem;
-    height: 1.4rem;
+  .SortButton,
+  .ExpandCollapseBtn,
+  .ColumnSettingsBtn {
     display: flex;
     align-items: center;
     justify-content: center;
+    color: var(--header-fg);
     background: transparent;
-    border: none;
-    cursor: pointer;
+    border: 1px solid transparent;
     border-radius: 0.25rem;
-    padding: 0.2rem;
-    opacity: 0.5;
+    cursor: pointer;
+    opacity: 0.68;
+    padding: 0;
+    box-sizing: border-box;
     flex-shrink: 0;
-  }
-  .DateFilterBtn:hover,
-  .DateFilterBtn.active,
-  .DateFilterBtn[aria-expanded="true"] {
-    background-color: var(--theme-color-Accent-dark);
-    opacity: 1;
-  }
-  .DateFilterBtn svg {
-    width: 100%;
-    height: 100%;
-    stroke: var(--theme-color-Main-light);
+    transition:
+      background-color 0.12s ease,
+      border-color 0.12s ease,
+      opacity 0.12s ease;
   }
 
-  .ExpandCollapseButtons {
+  .SortButton:hover,
+  .ExpandCollapseBtn:hover,
+  .ColumnSettingsBtn:hover,
+  .ColumnSettingsBtn[aria-expanded="true"] {
+    background-color: var(--header-hover);
+    border-color: var(--header-button-border);
+    opacity: 1;
+  }
+
+  .SortButton.active {
+    color: var(--header-active);
+    opacity: 1;
+  }
+
+  .SortButton svg,
+  .ExpandCollapseBtn svg,
+  .ColumnSettingsBtn svg {
+    width: var(--header-action-icon-size);
+    height: var(--header-action-icon-size);
+    stroke: currentColor;
+  }
+
+  .SortButton {
+    width: var(--header-icon-size);
+    height: var(--header-icon-size);
+  }
+
+  .HeaderControlRow {
     display: flex;
-    gap: 0.15rem;
+    flex: 0 0 2rem;
+    width: 100%;
+    height: 2rem;
     align-items: center;
+    justify-content: center;
+    gap: 0.2rem;
     padding: 0 0.3rem;
+    box-sizing: border-box;
+    overflow: hidden;
   }
   .ExpandCollapseBtn {
-    width: 1.4rem;
-    height: 1.4rem;
+    width: var(--header-icon-size);
+    height: var(--header-icon-size);
+  }
+
+  .HeaderFilterGroup {
     display: flex;
     align-items: center;
-    justify-content: center;
-    background: transparent;
-    border: none;
-    cursor: pointer;
-    border-radius: 0.25rem;
-    padding: 0.2rem;
-    opacity: 0.5;
-    flex-shrink: 0;
-  }
-  .ExpandCollapseBtn:hover {
-    background-color: var(--theme-color-Accent-dark);
-    opacity: 1;
-  }
-  .ExpandCollapseBtn svg {
     width: 100%;
-    height: 100%;
-    stroke: var(--theme-color-Main-light);
+    min-width: 0;
+    height: 2rem;
   }
 
   .ColumnSettingsBtn {
     position: absolute;
-    top: 0;
-    bottom: 0;
+    top: 50%;
     right: 0;
-    width: 2rem;
-    flex-shrink: 0;
+    width: var(--header-icon-size);
+    height: var(--header-icon-size);
+    z-index: 1;
+    transform: translateY(-50%);
+  }
+
+  .HeaderFilterControl {
     display: flex;
     align-items: center;
-    justify-content: center;
-    background-color: var(--theme-color-Sub-light);
-    border: none;
-    border-left: 1px solid var(--theme-color-Sub-dark);
-    border-bottom: 1px solid;
-    cursor: pointer;
-    z-index: 1;
-    opacity: 0.6;
-    padding: 0.4rem;
+    width: 100%;
+    min-width: 0;
+    height: 2rem;
+    margin: 0;
+    padding: 0;
     box-sizing: border-box;
+    border: none;
+    border-radius: 0;
+    background-color: transparent;
+    color: var(--theme-color-Main-light);
+    cursor: pointer;
+    flex: 1 1 auto;
+    font-weight: 1;
+    overflow: hidden;
+    white-space: nowrap;
   }
-  .ColumnSettingsBtn:hover,
-  .ColumnSettingsBtn[aria-expanded="true"] {
-    opacity: 1;
-    background-color: var(--theme-color-Accent-dark);
+  .HeaderFilterControl:focus-visible {
+    outline: auto;
   }
-  .ColumnSettingsBtn svg {
+  .HeaderFilterSummary {
+    cursor: default;
+  }
+  .FilterIcon {
+    width: 1.5rem;
+    height: 1.5rem;
+    margin: 0;
+    padding: 0.25rem;
+    box-sizing: content-box;
+    flex-shrink: 0;
+  }
+  .FilterIcon svg {
     width: 100%;
     height: 100%;
-    stroke: var(--theme-color-Main-light);
+    fill: var(--theme-color-Main-light);
+    stroke: none;
+  }
+  .HeaderFilterControl.active .FilterIcon svg {
+    fill: var(--theme-color-Accent-main);
+  }
+  .FilterSelection {
+    min-width: 0;
+    padding: 0 0.25rem;
+    box-sizing: border-box;
+    overflow: hidden;
+    text-overflow: ellipsis;
   }
 
   .ColumnSettingsPanel {
     position: fixed;
     z-index: 99999999;
     background: var(--theme-color-Main-main);
-    border: 1px solid var(--theme-color-Sub-dark);
-    border-radius: 0.5rem;
+    border: 1px solid var(--theme-color-Shadow-main);
+    border-radius: 0.4rem;
     box-shadow: 0 0.25rem 0.75rem rgba(0, 0, 0, 0.25);
     padding: 0.5rem 0;
     min-width: 13rem;
+    color: var(--theme-color-Sub-main);
   }
   .PanelTitle {
     font-size: 0.75rem;
     font-weight: bold;
-    color: var(--theme-color-Sub-dark);
+    color: var(--theme-color-Sub-main);
     padding: 0.25rem 0.75rem 0.5rem;
-    border-bottom: 1px solid var(--theme-color-Sub-dark);
+    border-bottom: 1px solid var(--theme-color-Shadow-main);
     margin-bottom: 0.25rem;
   }
   .SettingsRow {
@@ -511,11 +790,11 @@
     align-items: center;
     padding: 0.3rem 0.75rem;
     gap: 0.5rem;
-    color: var(--theme-color-Sub-light);
+    color: var(--theme-color-Sub-main);
     font-size: 0.875rem;
   }
   .SettingsRow:hover {
-    background-color: var(--theme-color-Main-dark);
+    background-color: color-mix(in srgb, var(--theme-color-Accent-main) 10%, transparent);
   }
   .LockIcon {
     width: 0.9rem;
@@ -558,11 +837,11 @@
     cursor: pointer;
     border-radius: 0.2rem;
     padding: 0.1rem;
-    color: var(--theme-color-Sub-light);
+    color: var(--theme-color-Sub-main);
     opacity: 0.6;
   }
   .MoveBtn:hover {
-    background-color: var(--theme-color-Accent-dark);
+    background-color: color-mix(in srgb, var(--theme-color-Accent-main) 14%, transparent);
     opacity: 1;
   }
   .MoveBtn svg {

--- a/src/stores/search.ts
+++ b/src/stores/search.ts
@@ -68,7 +68,9 @@ function createFilter(initialValue: FilterState): FilterStore {
   );
 
   const hasActiveFilters = (current: FilterState) =>
-    Object.keys(current || {}).some((key) => current[key] && current[key].length > 0);
+    Object.keys(current || {}).some(
+      (key) => key !== "search_memo" && current[key] && current[key].length > 0
+    );
 
   return {
     subscribe,

--- a/src/stores/sort.ts
+++ b/src/stores/sort.ts
@@ -20,8 +20,8 @@ function createSort(): SortStore {
     cycle: (column: string) => {
       if (!SORTABLE_COLUMNS.has(column)) return;
       update((current) => {
-        if (!current || current.column !== column) return { column, direction: "asc" };
-        if (current.direction === "asc") return { column, direction: "desc" };
+        if (!current || current.column !== column) return { column, direction: "desc" };
+        if (current.direction === "desc") return { column, direction: "asc" };
         return null;
       });
     },

--- a/tests/component/SearchBox.test.js
+++ b/tests/component/SearchBox.test.js
@@ -9,19 +9,19 @@ describe("SearchBox", () => {
     filter.set({});
   });
 
-  test("updates the name filter as the user types", async () => {
+  test("updates the full-text filter as the user types", async () => {
     render(SearchBox);
 
     const input = screen.getByPlaceholderText("filter tasks...");
     await fireEvent.input(input, { target: { value: "release" } });
 
     expect(get(filter)).toEqual({
-      name: ["release"],
+      full_text: ["release"],
     });
   });
 
   test("clears the filter on Escape and keeps focus in the input", async () => {
-    filter.set({ name: ["release"] });
+    filter.set({ full_text: ["release"] });
     render(SearchBox);
 
     const input = screen.getByPlaceholderText("filter tasks...");
@@ -30,7 +30,7 @@ describe("SearchBox", () => {
     await fireEvent.keyDown(input, { key: "Escape" });
 
     expect(get(filter)).toEqual({
-      name: null,
+      full_text: null,
     });
     expect(input).toHaveValue("");
     expect(input).toHaveFocus();
@@ -39,7 +39,7 @@ describe("SearchBox", () => {
   test("reflects store updates when the input is not focused", async () => {
     render(SearchBox);
 
-    filter.set({ name: ["backlog"] });
+    filter.set({ full_text: ["backlog"] });
     await tick();
 
     expect(screen.getByPlaceholderText("filter tasks...")).toHaveValue("backlog");

--- a/tests/unit/tree_control.test.js
+++ b/tests/unit/tree_control.test.js
@@ -84,6 +84,35 @@ describe("tree_control", () => {
     expect(filtered.children[0].data.status).toBe("Pending");
   });
 
+  test("filterTree keeps name filter scoped to the name column", () => {
+    const tree = createTree();
+    tree.children[0].data.memo = [{ id: "m1", title: "Note", content: "ship", tags: [] }];
+
+    const filtered = filterTree(tree, { name: ["ship"] });
+
+    expect(filtered.children).toHaveLength(1);
+    expect(filtered.children[0].id).toBe("task-2");
+  });
+
+  test("filterTree supports full-text search separately from column filters", () => {
+    const filtered = filterTree(createTree(), { full_text: ["progress"] });
+
+    expect(filtered.children).toHaveLength(1);
+    expect(filtered.children[0].id).toBe("task-1");
+  });
+
+  test("filterTree can include memo content in full-text search", () => {
+    const tree = createTree();
+    tree.children[0].data.memo = [{ id: "m1", title: "Note", content: "launch notes", tags: [] }];
+
+    expect(filterTree(tree, { full_text: ["launch"] })).toBeNull();
+
+    const filtered = filterTree(tree, { full_text: ["launch"], search_memo: ["1"] });
+
+    expect(filtered.children).toHaveLength(1);
+    expect(filtered.children[0].id).toBe("task-1");
+  });
+
   test("filterTree with tags filter keeps only tasks whose memos contain the tag", () => {
     const tree = {
       id: "root",


### PR DESCRIPTION
## Summary

- TreeTableHeaderを上段「ラベル＋ソート」、下段「カラムフィルタ」に統一
- name / date / status のフィルタ表示、状態表示、クリア操作を整理
- status以外のフィルタにも、statusと同じ実装方針のクリアボタンを追加
- 枠外検索は全文検索、ヘッダ内フィルタはカラム単位のフィルタとして分離
- ソート状態が分かるようにアイコン表示とアクティブ色を調整

## Why

ヘッダ内で1行表示と2行表示が混在しており、status以外のフィルタではフィルタ適用後も状態表示やクリア操作が分かりづらい状態でした。また、外部検索とカラムフィルタの役割が混ざっていたため、全文検索とカラム検索を明確に分けました。

## Impact

- 各カラムのフィルタ状態がヘッダ上で確認しやすくなります
- フィルタ適用中のカラムは、ヘッダ内の×ボタンから直接クリアできます
- 外部検索は全文検索として残り、name列のフィルタはカラム内フィルタとして動作します
- status / name / date のフィルタ操作感と見た目が近づきます

## Validation

- `svelte-check --tsconfig ./tsconfig.json`
- `prettier --check src\components\TreeTableHeader.svelte`
- `git diff --check`
- `vite build`
