### PR TITLE
fix: improve tree table visual separators and header UI

### DIFF
--- a/src/components/DateRangePanel.svelte
+++ b/src/components/DateRangePanel.svelte
@@ -123,7 +123,7 @@
     border-radius: 0.25rem;
     padding: 0.2rem 0.3rem;
     font-size: 0.8rem;
-    color-scheme: dark;
+    color-scheme: var(--color-scheme, dark);
     box-sizing: border-box;
     min-width: 0;
   }

--- a/src/components/TreeTable.svelte
+++ b/src/components/TreeTable.svelte
@@ -773,9 +773,16 @@
     user-select: none;
     z-index: 10000;
   }
-  .TableRoot :global(.HandlingResizer),
-  .TableRoot :global(.Resizer:hover) {
-    background-color: var(--theme-color-Accent-light);
+  .TableRoot :global(.HandlingResizer::before),
+  .TableRoot :global(.Resizer:hover::before) {
+    content: "";
+    position: absolute;
+    top: 0;
+    left: 2px;
+    width: 2px;
+    height: 100%;
+    background-color: var(--theme-color-Accent-main);
+    opacity: 0.9;
   }
   .EmptyState {
     display: flex;

--- a/src/components/TreeTableHeader.svelte
+++ b/src/components/TreeTableHeader.svelte
@@ -3,6 +3,7 @@
   import { column_settings } from "../stores/column_settings.ts";
   import { closed_node_ids } from "../stores/ui.ts";
   import { sort_state, SORTABLE_COLUMNS } from "../stores/sort.ts";
+  import { ripple } from "../common/common.js";
   import IconButton from "./IconButton.svelte";
   import MultiSelect from "./MultiSelect.svelte";
   import DateRangePanel from "./DateRangePanel.svelte";
@@ -322,6 +323,7 @@
               aria-label="{header.name} フィルター"
               aria-expanded={openNamePanel}
               title="Name フィルター"
+              use:ripple
             >
               <span class="FilterIcon" aria-hidden="true">
                 <svg viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg">
@@ -360,6 +362,7 @@
               aria-label="{header.name} 日付フィルター"
               aria-expanded={openDatePanel === header.name}
               title="日付フィルター"
+              use:ripple
             >
               <span class="FilterIcon" aria-hidden="true">
                 <svg viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg">
@@ -558,12 +561,12 @@
   .TableRow {
     --header-bg: var(--theme-color-Sub-light);
     --header-fg: var(--theme-color-Main-light);
-    --header-border: color-mix(in srgb, var(--theme-color-Sub-dark) 42%, transparent);
+    --header-border: var(--theme-color-Main-dark);
     --header-hover: color-mix(in srgb, var(--theme-color-Accent-dark) 78%, transparent);
     --header-active: var(--theme-color-Accent-main);
     --header-button-border: color-mix(in srgb, var(--theme-color-Main-light) 24%, transparent);
-    --header-icon-size: 2rem;
-    --header-action-icon-size: 1.5rem;
+    --header-icon-size: 1.5rem;
+    --header-action-icon-size: 1.1rem;
 
     position: sticky;
     top: 0;
@@ -582,8 +585,8 @@
     min-width: 4rem;
     display: flex;
     flex-direction: column;
-    border-right: 1px solid var(--header-border);
-    border-bottom: 1px solid var(--header-border);
+    border-right: 2px solid var(--header-border);
+    border-bottom: 2px solid var(--header-border);
     background-color: var(--header-bg);
     color: var(--header-fg);
     align-items: center;
@@ -737,6 +740,9 @@
   }
   .HeaderFilterControl:focus-visible {
     outline: auto;
+  }
+  .HeaderFilterControl:active {
+    background-color: transparent;
   }
   .HeaderFilterSummary {
     cursor: default;

--- a/src/components/TreeTableRow.svelte
+++ b/src/components/TreeTableRow.svelte
@@ -401,6 +401,10 @@
     padding: 0 0.5rem;
     align-items: center;
     color: var(--theme-color-Sub-light);
+    border-right: 2px solid var(--theme-color-Main-dark);
+  }
+  .TableData:last-child {
+    border-right: none;
   }
   .TableData span {
     flex: 1;
@@ -415,7 +419,7 @@
     height: 100%;
     width: 0.6rem;
     margin-left: 0.3rem;
-    border-left: 1px solid gray;
+    border-left: 1px solid color-mix(in srgb, var(--theme-color-Sub-light) 30%, transparent);
   }
   .ExpandButton:focus-visible {
     outline: auto;

--- a/src/stores/theme.ts
+++ b/src/stores/theme.ts
@@ -46,9 +46,11 @@ function createTheme(initialValue: ThemeName | undefined): ThemeStore {
 
         if (current === "dark") {
           traverse(THEME_DARK as ThemePalette, "--theme");
+          document.documentElement.style.setProperty("--color-scheme", "dark");
           platform.setMetaData("theme", current);
         } else if (current === "light") {
           traverse(THEME_LIGHT as ThemePalette, "--theme");
+          document.documentElement.style.setProperty("--color-scheme", "light");
           platform.setMetaData("theme", current);
         }
       });


### PR DESCRIPTION
## Summary
- Add column divider lines to TreeTableRow (2px solid, last column excluded)
- Fix TreeLine color: replace hardcoded gray with theme variable
- Resizer: hover-only, matching SplitPane design (::before accent line)
- Unify header/row border to 2px
- Downsize header buttons (2rem→1.5rem) and improve vertical centering
- Add ripple to name/date filter buttons to match status filter behavior
- Fix gray flash on filter button active state (override global style)
- Date picker color-scheme now follows theme via CSS variable (light/dark)
## Changes
| File | Change |
|------|--------|
| TreeTableRow.svelte | Column dividers, TreeLine color fix, exclude last column border |
| TreeTable.svelte | Resizer hover-only, SplitPane-style design |
| TreeTableHeader.svelte | 2px borders, smaller buttons, ripple, active fix |
| DateRangePanel.svelte | color-scheme uses CSS variable |
| stores/theme.ts | Set --color-scheme on theme change |
## Reviewer Notes
Resizer appearance is intentionally matched to SplitPane. The `--color-scheme` variable falls back to `dark` so it works even before theme is initialized.