### PR TITLE
[codex] fix gantt bar scaling on view change

### DIFF
--- a/src/components/GanttPanel.svelte
+++ b/src/components/GanttPanel.svelte
@@ -124,12 +124,12 @@
     rootFontSizePx = readRootFontSizePx();
   }
 
-  function dayOffset(date) {
-    return Math.floor((new Date(date).getTime() - timelineStart.getTime()) / DAY_MS);
+  function dayOffset(date, rangeStart = timelineStart) {
+    return Math.floor((new Date(date).getTime() - rangeStart.getTime()) / DAY_MS);
   }
 
-  function remFromDate(date) {
-    return dayOffset(date) * remPerDay;
+  function remFromDate(date, scaleRemPerDay = remPerDay, rangeStart = timelineStart) {
+    return dayOffset(date, rangeStart) * scaleRemPerDay;
   }
 
   $: remPerDay =
@@ -294,7 +294,14 @@
     return { "due date": formatDate(nextDueTs) };
   }
 
-  function getBarStyle(row, activeDragState = dragState) {
+  function getBarStyle(
+    row,
+    activeDragState = dragState,
+    scaleRemPerDay = remPerDay,
+    scaleTodayRem = todayRem,
+    scaleTodayTs = todayTs,
+    rangeStart = timelineStart
+  ) {
     const baseDateState = getRowDateState(row);
     const dateState =
       activeDragState?.id === row.id && activeDragState.mode !== "create"
@@ -311,12 +318,18 @@
     );
 
     if (dateState.startTs && dateState.effectiveDueTs) {
-      const leftRem = remFromDate(dateState.startTs);
+      const leftRem = remFromDate(dateState.startTs, scaleRemPerDay, rangeStart);
       const widthRem = Math.max(
         MIN_BAR_WIDTH_REM,
-        remFromDate(dateState.effectiveDueTs + DAY_MS) - leftRem
+        remFromDate(dateState.effectiveDueTs + DAY_MS, scaleRemPerDay, rangeStart) - leftRem
       );
-      const overdue = getOverdueSegment(status, dateState.effectiveDueTs);
+      const overdue = getOverdueSegment(
+        status,
+        dateState.effectiveDueTs,
+        scaleRemPerDay,
+        scaleTodayTs,
+        rangeStart
+      );
       return {
         ...dateState,
         leftRem,
@@ -327,21 +340,23 @@
         isDue: false,
       };
     } else if (dateState.effectiveDueTs) {
-      const leftRem = remFromDate(dateState.effectiveDueTs) + DUE_MARKER_INSET_REM;
+      const leftRem =
+        remFromDate(dateState.effectiveDueTs, scaleRemPerDay, rangeStart) +
+        DUE_MARKER_INSET_REM;
       return {
         ...dateState,
         leftRem,
-        widthRem: Math.max(MIN_DUE_MARKER_WIDTH_REM, remPerDay - DUE_MARKER_INSET_REM * 2),
+        widthRem: Math.max(MIN_DUE_MARKER_WIDTH_REM, scaleRemPerDay - DUE_MARKER_INSET_REM * 2),
         color: dueColor,
         opacity: dateState.isInherited ? 0.35 : 1,
         isDue: true,
       };
     } else if (dateState.startTs) {
-      const leftRem = remFromDate(dateState.startTs);
-      const widthRem = Math.max(0.167, todayRem - leftRem);
+      const leftRem = remFromDate(dateState.startTs, scaleRemPerDay, rangeStart);
+      const widthRem = Math.max(0.167, scaleTodayRem - leftRem);
       return {
         ...dateState,
-        effectiveDueTs: todayTs,
+        effectiveDueTs: scaleTodayTs,
         leftRem,
         widthRem,
         color,
@@ -375,13 +390,22 @@
     return barColor(status);
   }
 
-  function getOverdueSegment(status, dueTs) {
-    if (!shouldShowDueAlert(status) || !dueTs || dueTs >= todayTs) {
+  function getOverdueSegment(
+    status,
+    dueTs,
+    scaleRemPerDay = remPerDay,
+    scaleTodayTs = todayTs,
+    rangeStart = timelineStart
+  ) {
+    if (!shouldShowDueAlert(status) || !dueTs || dueTs >= scaleTodayTs) {
       return null;
     }
 
-    const leftRem = remFromDate(dueTs + DAY_MS);
-    const widthRem = Math.max(0, remFromDate(todayTs + DAY_MS) - leftRem);
+    const leftRem = remFromDate(dueTs + DAY_MS, scaleRemPerDay, rangeStart);
+    const widthRem = Math.max(
+      0,
+      remFromDate(scaleTodayTs + DAY_MS, scaleRemPerDay, rangeStart) - leftRem
+    );
     if (widthRem <= 0) {
       return null;
     }
@@ -415,19 +439,32 @@
     return dateFromClientX(event.clientX);
   }
 
-  function getRangeGeometry(startTs, endTs) {
+  function getRangeGeometry(startTs, endTs, scaleRemPerDay = remPerDay, rangeStart = timelineStart) {
     const start = Math.min(startTs, endTs);
     const end = Math.max(startTs, endTs);
-    const leftRem = remFromDate(start);
-    const widthRem = Math.max(MIN_BAR_WIDTH_REM, remFromDate(end + DAY_MS) - leftRem);
+    const leftRem = remFromDate(start, scaleRemPerDay, rangeStart);
+    const widthRem = Math.max(
+      MIN_BAR_WIDTH_REM,
+      remFromDate(end + DAY_MS, scaleRemPerDay, rangeStart) - leftRem
+    );
     return { start, end, leftRem, widthRem };
   }
 
-  function getCreatePreview(row, activeDragState = dragState) {
+  function getCreatePreview(
+    row,
+    activeDragState = dragState,
+    scaleRemPerDay = remPerDay,
+    rangeStart = timelineStart
+  ) {
     if (activeDragState?.mode !== "create" || activeDragState.id !== row.id) {
       return null;
     }
-    return getRangeGeometry(activeDragState.anchorTs, activeDragState.currentTs);
+    return getRangeGeometry(
+      activeDragState.anchorTs,
+      activeDragState.currentTs,
+      scaleRemPerDay,
+      rangeStart
+    );
   }
 
   function createRange(event, row, bar) {
@@ -762,8 +799,8 @@
         <div class="TodayLineFull" style="left:{todayRem}rem;"></div>
       {/if}
       {#each rows as row (row.id)}
-        {@const bar = getBarStyle(row, dragState)}
-        {@const preview = getCreatePreview(row, dragState)}
+        {@const bar = getBarStyle(row, dragState, remPerDay, todayRem, todayTs, timelineStart)}
+        {@const preview = getCreatePreview(row, dragState, remPerDay, timelineStart)}
         <div
           class="GanttRow"
           data-row-id={row.id}

--- a/src/components/GanttPanel.svelte
+++ b/src/components/GanttPanel.svelte
@@ -341,8 +341,7 @@
       };
     } else if (dateState.effectiveDueTs) {
       const leftRem =
-        remFromDate(dateState.effectiveDueTs, scaleRemPerDay, rangeStart) +
-        DUE_MARKER_INSET_REM;
+        remFromDate(dateState.effectiveDueTs, scaleRemPerDay, rangeStart) + DUE_MARKER_INSET_REM;
       return {
         ...dateState,
         leftRem,
@@ -439,7 +438,12 @@
     return dateFromClientX(event.clientX);
   }
 
-  function getRangeGeometry(startTs, endTs, scaleRemPerDay = remPerDay, rangeStart = timelineStart) {
+  function getRangeGeometry(
+    startTs,
+    endTs,
+    scaleRemPerDay = remPerDay,
+    rangeStart = timelineStart
+  ) {
     const start = Math.min(startTs, endTs);
     const end = Math.max(startTs, endTs);
     const leftRem = remFromDate(start, scaleRemPerDay, rangeStart);

--- a/tests/component/GanttPanel.test.js
+++ b/tests/component/GanttPanel.test.js
@@ -11,7 +11,7 @@ import {
   tree_data,
 } from "../../src/stores.ts";
 
-function createProjectData() {
+function createProjectData(taskData = {}) {
   return {
     headers: [
       { name: "name", default_ratio: 10 },
@@ -35,8 +35,8 @@ function createProjectData() {
           data: {
             name: "First Task",
             status: "Open",
-            "start date": undefined,
-            "due date": undefined,
+            "start date": taskData.startDate,
+            "due date": taskData.dueDate,
             memo: [],
           },
           children: [],
@@ -71,6 +71,11 @@ function dispatchPointerEvent(target, type, options) {
   target.dispatchEvent(event);
 }
 
+function getBarWidthRem(container) {
+  const bar = container.querySelector('[data-row-id="task-1"] .Bar');
+  return Number.parseFloat(bar.style.width);
+}
+
 describe("GanttPanel", () => {
   beforeEach(() => {
     const projectData = createProjectData();
@@ -101,5 +106,33 @@ describe("GanttPanel", () => {
     expect(container.querySelector(".CreatePreview")).not.toBeInTheDocument();
     expect(get(tree_data).data.children[0].data["start date"]).toBeDefined();
     expect(get(tree_data).data.children[0].data["due date"]).toBeDefined();
+  });
+
+  test("rescales task bar width when switching between day week and month views", async () => {
+    const projectData = createProjectData({
+      startDate: "2030-01-01",
+      dueDate: "2030-01-07",
+    });
+    tree_data.set(projectData);
+    filtered_data.set(projectData.data);
+
+    const { container } = render(GanttPanel);
+    await tick();
+
+    const dayWidth = getBarWidthRem(container);
+
+    ganttScale.set("week");
+    await tick();
+    const weekWidth = getBarWidthRem(container);
+
+    ganttScale.set("month");
+    await tick();
+    const monthWidth = getBarWidthRem(container);
+
+    expect(dayWidth).toBeCloseTo(7 * 1.667, 3);
+    expect(weekWidth).toBeCloseTo(6, 3);
+    expect(monthWidth).toBeCloseTo((7 * 7.667) / 30, 3);
+    expect(dayWidth).toBeGreaterThan(weekWidth);
+    expect(weekWidth).toBeGreaterThan(monthWidth);
   });
 });


### PR DESCRIPTION
## Summary
- Fix Gantt task bars staying visually the same length after switching between day, week, and month views.
- Pass scale-dependent geometry values into bar, overdue segment, and create-preview calculations so Svelte re-evaluates them when the scale changes.
- Add a component regression test covering day -> week -> month bar width changes.

## Root Cause
The header and grid depended directly on the reactive scale-derived values, but bar geometry was computed through helper functions whose scale dependencies were not explicit at the template call site. This could leave task bars rendered with stale rem widths after changing the view scale.

## Validation
- `npm run check`
- `vitest run tests/component/GanttPanel.test.js`