### PR TITLE
[codex] refine gantt header and visible range

### DIFF
--- a/src/components/GanttPanel.svelte
+++ b/src/components/GanttPanel.svelte
@@ -29,6 +29,9 @@
   // ── Timeline range ──────────────────────────────────────────────
 
   const DAY_MS = 24 * 60 * 60 * 1000;
+  const TIMELINE_START_PADDING_DAYS = 30;
+  const TIMELINE_TODAY_FUTURE_DAYS = 180;
+  const TIMELINE_END_PADDING_DAYS = 30;
 
   function parseDate(s) {
     if (!s) return null;
@@ -64,8 +67,6 @@
 
   let timelineStart = new Date();
   let timelineEnd = new Date();
-  let timelineRangeProjectId;
-  let timelineRangeReady = false;
 
   $: {
     let minTs = null;
@@ -73,32 +74,25 @@
     for (const row of rows) {
       const sd = parseDate(row.node.data["start date"]);
       const dd = parseDate(row.node.data["due date"]) || parseDate(inheritedMap.get(row.id));
-      if (sd && (minTs === null || sd < minTs)) minTs = sd;
-      if (dd && (maxTs === null || dd > maxTs)) maxTs = dd;
+      for (const ts of [sd, dd]) {
+        if (!ts) continue;
+        if (minTs === null || ts < minTs) minTs = ts;
+        if (maxTs === null || ts > maxTs) maxTs = ts;
+      }
     }
     const today = startOfDay();
-    const pad = 14 * DAY_MS;
-    const nextStart = new Date(startOfDay((minTs ?? today) - pad));
-    const nextEnd = new Date(startOfDay((maxTs ?? today) + pad * 4) + DAY_MS);
-    const projectId = $tree_data?.data?.id;
+    const startBaseTs = minTs === null ? today : Math.min(today, minTs);
+    const endBaseTs = maxTs === null ? today : maxTs;
+    const nextStart = new Date(startOfDay(startBaseTs - TIMELINE_START_PADDING_DAYS * DAY_MS));
+    const nextEndTs = Math.max(
+      today + TIMELINE_TODAY_FUTURE_DAYS * DAY_MS,
+      endBaseTs + TIMELINE_END_PADDING_DAYS * DAY_MS
+    );
+    const nextEnd = new Date(startOfDay(nextEndTs) + DAY_MS);
 
     if (!dragState) {
-      if (!timelineRangeReady || projectId !== timelineRangeProjectId) {
-        timelineStart = nextStart;
-        timelineEnd = nextEnd;
-        timelineRangeProjectId = projectId;
-        timelineRangeReady = true;
-      } else {
-        const dataStartTs = minTs ?? today;
-        const dataEndTs = (maxTs ?? today) + DAY_MS;
-
-        if (dataStartTs < timelineStart.getTime()) {
-          timelineStart = nextStart;
-        }
-        if (dataEndTs > timelineEnd.getTime()) {
-          timelineEnd = nextEnd;
-        }
-      }
+      timelineStart = nextStart;
+      timelineEnd = nextEnd;
     }
   }
 
@@ -152,13 +146,14 @@
     while (cur < end) {
       const cellStart = new Date(cur);
       let label = "";
+      let weekdayLabel = "";
       let next;
       if (scale === "day") {
         label = formatLocalDate(cur, {
           month: "numeric",
           day: "numeric",
-          weekday: "short",
         });
+        weekdayLabel = formatLocalDate(cur, { weekday: "short" });
         next = new Date(cur.getTime() + DAY_MS);
       } else if (scale === "week") {
         const d = cur.getDay();
@@ -166,8 +161,8 @@
         label = formatLocalDate(monday, {
           month: "numeric",
           day: "numeric",
-          weekday: "short",
         });
+        weekdayLabel = formatLocalDate(monday, { weekday: "short" });
         next = new Date(monday.getTime() + 7 * DAY_MS);
         cur.setTime(monday.getTime());
       } else {
@@ -180,6 +175,7 @@
       const endTs = next.getTime();
       cells.push({
         label,
+        weekdayLabel,
         leftRem,
         widthRem,
         tone: getPeriodTone(startTs, endTs),
@@ -769,7 +765,10 @@
             class:WeekendCell={cell.weekend}
             style="left:{cell.leftRem}rem; width:{cell.widthRem}rem;"
           >
-            {cell.label}
+            <span class="HeaderCellDate">{cell.label}</span>
+            {#if cell.weekdayLabel}
+              <span class="HeaderCellWeekday">{cell.weekdayLabel}</span>
+            {/if}
           </div>
         {/each}
         <!-- Today line in header -->
@@ -940,14 +939,27 @@
     top: 0;
     bottom: 0;
     display: flex;
+    flex-direction: column;
     align-items: center;
-    padding: 0 2px;
+    justify-content: center;
+    gap: 1px;
+    padding: 0 1px;
     font-size: 0.65rem;
+    line-height: 1.05;
     color: var(--theme-color-Sub-main);
     border-right: 1px solid var(--gantt-grid-line-strong);
     white-space: nowrap;
     overflow: hidden;
     box-sizing: border-box;
+    text-align: center;
+  }
+
+  .HeaderCellDate,
+  .HeaderCellWeekday {
+    display: block;
+    max-width: 100%;
+    overflow: hidden;
+    text-overflow: clip;
   }
   .HeaderCell.PastCell,
   .GridCell.PastCell {

--- a/tests/component/GanttPanel.test.js
+++ b/tests/component/GanttPanel.test.js
@@ -11,6 +11,8 @@ import {
   tree_data,
 } from "../../src/stores.ts";
 
+const DAY_MS = 24 * 60 * 60 * 1000;
+
 function createProjectData(taskData = {}) {
   return {
     headers: [
@@ -76,6 +78,11 @@ function getBarWidthRem(container) {
   return Number.parseFloat(bar.style.width);
 }
 
+function getTimelineWidthRem(container) {
+  const inner = container.querySelector(".GanttBodyInner");
+  return Number.parseFloat(inner.style.width);
+}
+
 describe("GanttPanel", () => {
   beforeEach(() => {
     const projectData = createProjectData();
@@ -85,6 +92,10 @@ describe("GanttPanel", () => {
     closed_node_ids.set(new Set());
     ganttScale.set("day");
     ganttScrollTop.set(0);
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
   });
 
   test("shows a translucent create preview while dragging a new range", async () => {
@@ -106,6 +117,16 @@ describe("GanttPanel", () => {
     expect(container.querySelector(".CreatePreview")).not.toBeInTheDocument();
     expect(get(tree_data).data.children[0].data["start date"]).toBeDefined();
     expect(get(tree_data).data.children[0].data["due date"]).toBeDefined();
+  });
+
+  test("renders day header date and weekday on separate lines", async () => {
+    const { container } = render(GanttPanel);
+    await tick();
+
+    const headerCell = container.querySelector(".HeaderCell");
+
+    expect(headerCell.children[0]).toHaveClass("HeaderCellDate");
+    expect(headerCell.children[1]).toHaveClass("HeaderCellWeekday");
   });
 
   test("rescales task bar width when switching between day week and month views", async () => {
@@ -134,5 +155,26 @@ describe("GanttPanel", () => {
     expect(monthWidth).toBeCloseTo((7 * 7.667) / 30, 3);
     expect(dayWidth).toBeGreaterThan(weekWidth);
     expect(weekWidth).toBeGreaterThan(monthWidth);
+  });
+
+  test("builds timeline range from today and visible task start and due dates", async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date(2030, 0, 1, 9));
+
+    const projectData = createProjectData({
+      startDate: "2029-12-20",
+      dueDate: "2030-08-01",
+    });
+    tree_data.set(projectData);
+    filtered_data.set(projectData.data);
+
+    const { container } = render(GanttPanel);
+    await tick();
+
+    const expectedStart = new Date(2029, 10, 20).getTime();
+    const expectedEnd = new Date(2030, 8, 1).getTime();
+    const expectedDays = (expectedEnd - expectedStart) / DAY_MS;
+
+    expect(getTimelineWidthRem(container)).toBeCloseTo(expectedDays * 1.667, 3);
   });
 });


### PR DESCRIPTION
## Summary
- Split day and week Gantt header labels into separate date and weekday lines to avoid clipped weekday text in narrow cells.
- Recalculate the Gantt timeline range from Today plus the visible tasks' minimum and maximum start/due dates.
- Use a default range from Today - 30 days through Today + 180 days, extending the end to max visible task date + 30 days when needed.

## Behavior Notes
- The timeline range now shrinks or expands from currently visible rows when not dragging.
- Effective inherited due dates are still included because those dates can render bars on child rows.

## Validation
- `prettier --check src/components/GanttPanel.svelte tests/component/GanttPanel.test.js`
- `svelte-check --tsconfig ./tsconfig.json`
- `vitest run tests/component/GanttPanel.test.js`