### PR TITLE
[codex] fix gantt today line scaling

### DIFF
--- a/src/components/GanttPanel.svelte
+++ b/src/components/GanttPanel.svelte
@@ -136,7 +136,7 @@
   $: totalDays = Math.ceil((timelineEnd.getTime() - timelineStart.getTime()) / DAY_MS);
   $: totalWidthRem = totalDays * remPerDay;
   $: todayTs = startOfDay();
-  $: todayRem = remFromDate(todayTs);
+  $: todayRem = remFromDate(todayTs, remPerDay, timelineStart);
 
   // ── Header cells ─────────────────────────────────────────────────
 

--- a/tests/component/GanttPanel.test.js
+++ b/tests/component/GanttPanel.test.js
@@ -83,6 +83,11 @@ function getTimelineWidthRem(container) {
   return Number.parseFloat(inner.style.width);
 }
 
+function getTodayLineLeftRem(container) {
+  const line = container.querySelector(".TodayLineFull");
+  return Number.parseFloat(line.style.left);
+}
+
 describe("GanttPanel", () => {
   beforeEach(() => {
     const projectData = createProjectData();
@@ -155,6 +160,24 @@ describe("GanttPanel", () => {
     expect(monthWidth).toBeCloseTo((7 * 7.667) / 30, 3);
     expect(dayWidth).toBeGreaterThan(weekWidth);
     expect(weekWidth).toBeGreaterThan(monthWidth);
+  });
+
+  test("rescales today line position when switching from day to month view", async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date(2030, 0, 1, 9));
+
+    const { container } = render(GanttPanel);
+    await tick();
+
+    const dayLeft = getTodayLineLeftRem(container);
+
+    ganttScale.set("month");
+    await tick();
+    const monthLeft = getTodayLineLeftRem(container);
+
+    expect(dayLeft).toBeCloseTo(30 * 1.667, 3);
+    expect(monthLeft).toBeCloseTo(7.667, 3);
+    expect(dayLeft).toBeGreaterThan(monthLeft);
   });
 
   test("builds timeline range from today and visible task start and due dates", async () => {


### PR DESCRIPTION
## Summary
- Fix the Gantt Today line keeping its day-view rem offset after switching to month view.
- Make `todayRem` explicitly depend on the current scale and timeline start.
- Add a regression test for day-to-month Today line positioning.

## Root Cause
`todayRem` was computed through `remFromDate(todayTs)` without exposing `remPerDay` or `timelineStart` to Svelte's reactive dependency tracking. After changing scale, the header/grid could update while the Today line stayed at the old day-scale position, which made it appear around October in month view.

## Validation
- `prettier --check src/components/GanttPanel.svelte tests/component/GanttPanel.test.js`
- `svelte-check --tsconfig ./tsconfig.json`
- `vitest run tests/component/GanttPanel.test.js`