### PR TITLE
[codex] refine gantt layout and collapsible detail pane

### DIFF
--- a/src/components/GanttPanel.svelte
+++ b/src/components/GanttPanel.svelte
@@ -1,10 +1,12 @@
 <script>
   import { onDestroy, onMount } from "svelte";
+  import Button from "./Button.svelte";
   import {
     filtered_data,
     closed_node_ids,
     ganttScrollTop,
     ganttScale,
+    theme,
     tree_data,
   } from "../stores.ts";
   import {
@@ -738,18 +740,52 @@
   });
 </script>
 
-<div class="GanttRoot" class:DraggingTimeline={!!dragState}>
+<div class="GanttRoot" class:DraggingTimeline={!!dragState} class:DarkTheme={$theme === "dark"}>
   <!-- Scale toggle + header -->
   <div class="GanttHeader">
-    <div class="ScaleButtons">
-      <button class:active={$ganttScale === "day"} on:click={() => ($ganttScale = "day")}>日</button
-      >
-      <button class:active={$ganttScale === "week"} on:click={() => ($ganttScale = "week")}
-        >週</button
-      >
-      <button class:active={$ganttScale === "month"} on:click={() => ($ganttScale = "month")}
-        >月</button
-      >
+    <div class="GanttTitleRow">
+      <span class="GanttTitle">gantt</span>
+      <div class="ScaleButtons">
+        <Button
+          content="日"
+          variant="text"
+          normalColor={$ganttScale === "day"
+            ? "var(--gantt-header-active)"
+            : "var(--gantt-header-fg)"}
+          activeColor="var(--gantt-header-active)"
+          rippleColor="var(--gantt-header-fg)"
+          ariaLabel="日表示"
+          tooltipContent="日表示"
+          style="margin: 0; width: 1.6rem; min-width: 1.6rem; height: 1.5rem; min-height: 1.5rem; padding: 0; box-shadow: none;"
+          on:click={() => ($ganttScale = "day")}
+        />
+        <Button
+          content="週"
+          variant="text"
+          normalColor={$ganttScale === "week"
+            ? "var(--gantt-header-active)"
+            : "var(--gantt-header-fg)"}
+          activeColor="var(--gantt-header-active)"
+          rippleColor="var(--gantt-header-fg)"
+          ariaLabel="週表示"
+          tooltipContent="週表示"
+          style="margin: 0; width: 1.6rem; min-width: 1.6rem; height: 1.5rem; min-height: 1.5rem; padding: 0; box-shadow: none;"
+          on:click={() => ($ganttScale = "week")}
+        />
+        <Button
+          content="月"
+          variant="text"
+          normalColor={$ganttScale === "month"
+            ? "var(--gantt-header-active)"
+            : "var(--gantt-header-fg)"}
+          activeColor="var(--gantt-header-active)"
+          rippleColor="var(--gantt-header-fg)"
+          ariaLabel="月表示"
+          tooltipContent="月表示"
+          style="margin: 0; width: 1.6rem; min-width: 1.6rem; height: 1.5rem; min-height: 1.5rem; padding: 0; box-shadow: none;"
+          on:click={() => ($ganttScale = "month")}
+        />
+      </div>
     </div>
     <div class="TimelineHeaderViewport">
       <div
@@ -867,6 +903,10 @@
 
 <style>
   .GanttRoot {
+    --gantt-header-bg: var(--theme-color-Primary-dark);
+    --gantt-header-fg: var(--theme-color-Main-light);
+    --gantt-header-border: color-mix(in srgb, var(--theme-color-Primary-dark) 82%, black);
+    --gantt-header-active: var(--theme-color-Accent-main);
     --gantt-grid-line: color-mix(in srgb, var(--theme-color-Sub-dark) 16%, transparent);
     --gantt-grid-line-strong: color-mix(in srgb, var(--theme-color-Sub-dark) 26%, transparent);
     --gantt-row-hover: color-mix(in srgb, var(--theme-color-Accent-main) 8%, transparent);
@@ -881,6 +921,11 @@
     min-width: 120px;
   }
 
+  .GanttRoot.DarkTheme {
+    --gantt-header-bg: var(--theme-color-Primary-light);
+    --gantt-header-border: color-mix(in srgb, var(--theme-color-Primary-light) 82%, black);
+  }
+
   .GanttRoot.DraggingTimeline,
   .GanttRoot.DraggingTimeline :global(*) {
     user-select: none;
@@ -891,41 +936,54 @@
     flex-direction: column;
     flex-shrink: 0;
     height: 4rem;
-    border-bottom: 1px solid var(--gantt-grid-line-strong);
-    background: var(--theme-color-Main-main);
+    border-bottom: 2px solid var(--gantt-header-border);
+    background: var(--gantt-header-bg);
+    color: var(--gantt-header-fg);
     position: sticky;
     top: 0;
     z-index: 10;
     overflow: hidden;
   }
 
+  .GanttTitleRow {
+    display: flex;
+    flex: 0 0 2rem;
+    height: 2rem;
+    align-items: center;
+    justify-content: space-between;
+    gap: 0.5rem;
+    padding: 0 0.35rem;
+    box-sizing: border-box;
+    border-bottom: 2px solid var(--gantt-header-border);
+    background: var(--gantt-header-bg);
+    color: var(--gantt-header-fg);
+  }
+
+  .GanttTitle {
+    flex: 1 1 auto;
+    min-width: 0;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+    font-size: 0.9rem;
+    font-weight: bold;
+    text-align: left;
+  }
+
   .ScaleButtons {
     display: flex;
-    gap: 2px;
-    padding: 2px 4px;
+    align-items: center;
+    justify-content: flex-end;
+    gap: 0.2rem;
     flex-shrink: 0;
   }
 
-  .ScaleButtons button {
-    font-size: 0.7rem;
-    padding: 1px 6px;
-    border: 1px solid var(--gantt-grid-line-strong);
-    border-radius: 3px;
-    background: transparent;
-    color: var(--theme-color-Sub-main);
-    cursor: pointer;
-  }
-
-  .ScaleButtons button.active {
-    background: var(--theme-color-Accent-main);
-    color: var(--theme-color-Main-main);
-    border-color: var(--theme-color-Accent-main);
-  }
-
   .TimelineHeaderViewport {
-    flex: 1;
+    flex: 0 0 2rem;
+    height: 2rem;
     overflow: hidden;
     position: relative;
+    background: var(--gantt-header-bg);
   }
 
   .TimelineHeader {
@@ -945,9 +1003,11 @@
     gap: 1px;
     padding: 0 1px;
     font-size: 0.65rem;
+    font-weight: normal;
     line-height: 1.05;
-    color: var(--theme-color-Sub-main);
-    border-right: 1px solid var(--gantt-grid-line-strong);
+    color: var(--gantt-header-fg);
+    border-right: 2px solid var(--gantt-header-border);
+    background: var(--gantt-header-bg);
     white-space: nowrap;
     overflow: hidden;
     box-sizing: border-box;
@@ -961,19 +1021,27 @@
     overflow: hidden;
     text-overflow: clip;
   }
-  .HeaderCell.PastCell,
+  .HeaderCell.PastCell {
+    background-color: color-mix(in srgb, var(--gantt-header-fg) 12%, var(--gantt-header-bg));
+  }
   .GridCell.PastCell {
     background-color: color-mix(in srgb, var(--theme-color-Sub-main) 7%, transparent);
   }
-  .HeaderCell.FutureCell,
+  .HeaderCell.FutureCell {
+    background-color: var(--gantt-header-bg);
+  }
   .GridCell.FutureCell {
     background-color: color-mix(in srgb, var(--theme-color-Main-main) 80%, transparent);
   }
-  .HeaderCell.WeekendCell,
+  .HeaderCell.WeekendCell {
+    background-color: color-mix(in srgb, var(--gantt-header-border) 18%, var(--gantt-header-bg));
+  }
   .GridCell.WeekendCell {
     background-color: color-mix(in srgb, var(--theme-color-Sub-main) 12%, transparent);
   }
-  .HeaderCell.TodayCell,
+  .HeaderCell.TodayCell {
+    background-color: color-mix(in srgb, var(--gantt-header-active) 32%, var(--gantt-header-bg));
+  }
   .GridCell.TodayCell {
     background-color: color-mix(in srgb, var(--theme-color-Accent-main) 18%, transparent);
   }

--- a/src/components/ProjectPage.svelte
+++ b/src/components/ProjectPage.svelte
@@ -31,6 +31,8 @@
     show_alert = !show_alert;
   };
 
+  let detailPaneVisible = true;
+
   // Add
   export async function handleAdd(e, action) {
     e.stopPropagation();
@@ -96,7 +98,7 @@
 
 {#if $tree_data}
   <div class:Content={true}>
-    <SplitPanes defaultRatio={[3, 2]}>
+    <SplitPanes defaultRatio={detailPaneVisible ? [3, 2] : [1]}>
       <Pane style={"padding: 1rem; min-width: 10rem;"}>
         <Card style={"height: 100%; width: 100%; padding: 1rem;"}>
           <div class="TaskListToolbar">
@@ -178,6 +180,47 @@
                 <rect x="3" y="17" width="5" height="3" rx="0.5" fill="currentColor" />
               </svg>
             </IconButton>
+            <IconButton
+              tooltipContent={detailPaneVisible ? "Hide detail pane" : "Show detail pane"}
+              ariaLabel={detailPaneVisible ? "Hide detail pane" : "Show detail pane"}
+              variant="text"
+              normalColor={detailPaneVisible
+                ? "var(--theme-color-Sub-main)"
+                : "var(--theme-color-Accent-main)"}
+              activeColor={"var(--theme-color-Accent-main)"}
+              style="--backgroundColor: var(--theme-color-Shadow-sub);"
+              on:click={() => (detailPaneVisible = !detailPaneVisible)}
+            >
+              <svg viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
+                <rect
+                  x="3"
+                  y="4"
+                  width="18"
+                  height="16"
+                  rx="2"
+                  stroke="currentColor"
+                  stroke-width="1.8"
+                />
+                <path d="M15 4V20" stroke="currentColor" stroke-width="1.8" />
+                {#if detailPaneVisible}
+                  <path
+                    d="M18.5 9L16 12L18.5 15"
+                    stroke="currentColor"
+                    stroke-width="1.8"
+                    stroke-linecap="round"
+                    stroke-linejoin="round"
+                  />
+                {:else}
+                  <path
+                    d="M16.5 9L19 12L16.5 15"
+                    stroke="currentColor"
+                    stroke-width="1.8"
+                    stroke-linecap="round"
+                    stroke-linejoin="round"
+                  />
+                {/if}
+              </svg>
+            </IconButton>
           </div>
           <Card style={"flex: 1; overflow: hidden; padding: 0;"}>
             <div class="TreeAndGantt">
@@ -201,13 +244,15 @@
           </Card>
         </Card>
       </Pane>
-      <Pane style={"padding: 1rem; min-width: 10rem;"}>
-        <Card style={"height: 100%; width: 100%;"}>
-          <div class:TaskDetail={true}>
-            <TaskDetail />
-          </div>
-        </Card>
-      </Pane>
+      {#if detailPaneVisible}
+        <Pane style={"padding: 1rem; min-width: 10rem;"}>
+          <Card style={"height: 100%; width: 100%;"}>
+            <div class:TaskDetail={true}>
+              <TaskDetail />
+            </div>
+          </Card>
+        </Pane>
+      {/if}
     </SplitPanes>
   </div>
   <Dialog

--- a/src/components/SplitPanes.svelte
+++ b/src/components/SplitPanes.svelte
@@ -1,92 +1,125 @@
 <script>
-  import { onMount } from "svelte";
+  import { onDestroy, onMount } from "svelte";
 
   export let defaultRatio = [];
 
   let split_pane_root; // Bind
 
   // Resize
-  let resizers, handlers, resize_observer;
+  let resizers = [];
+  let handlers = [];
+  let resize_observer;
+  let mutation_observer;
+  let paneCount = 0;
 
   // Min width
   let minWidth;
 
   onMount(() => {
-    let panes;
-    // Create resizres
-    [resizers, panes, resize_observer] = createResizers();
+    refreshLayout();
 
-    // Event listners
-    handlers = setResizersEvents(resizers, panes);
-
-    // Min width
-    minWidth = `${4 * panes.length}rem`; // magic number 4rem.
-
-    // Observe slot change
-    let mutation_observer = new MutationObserver(() => {
-      let panes;
-      // Create resizres
-      [resizers, panes] = createResizers(resizers, false, resize_observer);
-      // Event listners
-      unsetResizerEvents(resizers, handlers);
-      handlers = setResizersEvents(resizers, panes);
+    mutation_observer = new MutationObserver((mutations) => {
+      const paneChanged = mutations.some((mutation) =>
+        [...mutation.addedNodes, ...mutation.removedNodes].some(
+          (node) => node.nodeType === Node.ELEMENT_NODE && node.classList?.contains("Pane")
+        )
+      );
+      if (paneChanged) {
+        refreshLayout(true);
+      }
     });
     mutation_observer.observe(split_pane_root, {
-      subtree: true,
       childList: true,
     });
   });
 
-  const createResizers = (resizers = [], is_default = true, resize_observer = null) => {
-    // Get elms
-    let panes = split_pane_root.querySelectorAll(":scope > .Pane");
-    // Default
-    if (is_default) {
-      // Set width
-      if (panes.length > defaultRatio.length) {
-        defaultRatio = defaultRatio.concat(new Array(panes.length - defaultRatio.length).fill(1));
-      } else if (panes.length < defaultRatio.length) {
-        defaultRatio = defaultRatio.slice(0, panes.length);
+  onDestroy(() => {
+    mutation_observer?.disconnect();
+    resize_observer?.disconnect();
+    unsetResizerEvents(resizers, handlers);
+  });
+
+  const refreshLayout = (preserveWidths = false) => {
+    unsetResizerEvents(resizers, handlers);
+    handlers = [];
+    resizers.forEach((resizer) => resizer.remove());
+    resizers = [];
+
+    const panes = [...split_pane_root.querySelectorAll(":scope > .Pane")];
+    const canPreserveWidths = preserveWidths && panes.length === paneCount;
+    paneCount = panes.length;
+    minWidth = `${4 * panes.length}rem`; // magic number 4rem.
+
+    if (!panes.length) {
+      resize_observer?.disconnect();
+      resize_observer = undefined;
+      return;
+    }
+
+    const rootWidth = split_pane_root.getBoundingClientRect().width;
+    const widths = getPaneWidths(panes, rootWidth, canPreserveWidths);
+
+    panes.forEach((pane, index) => {
+      pane.style.width = `${widths[index]}px`;
+    });
+
+    resizers = createResizers(panes, widths);
+    handlers = setResizersEvents(resizers, panes);
+    observeRootResize(panes);
+  };
+
+  const getPaneWidths = (panes, rootWidth, preserveWidths) => {
+    if (preserveWidths) {
+      const currentWidths = panes.map((pane) => pane.getBoundingClientRect().width);
+      const currentTotal = currentWidths.reduce((partialSum, width) => partialSum + width, 0);
+      if (currentTotal > 0) {
+        return currentWidths.map((width) => (width * rootWidth) / currentTotal);
       }
-      const defaultRatio_sum = defaultRatio.reduce((partialSum, a) => partialSum + a, 0);
-      const default_root_width = split_pane_root.getBoundingClientRect().width;
-      const default_pane_widths = defaultRatio.map(
-        (ratio) => (default_root_width * ratio) / defaultRatio_sum
-      );
-      panes.forEach((pane, index) => {
-        pane.style.width = `calc(${default_pane_widths[index]}px)`;
-      });
-      // Create resizer
-      let left = 0;
-      panes.forEach((pane, index) => {
-        if (index == 0) {
-          return;
-        }
-        // Create resizer
-        const resizer = document.createElement("div");
-        resizer.classList.add("Resizer");
-        // Postions of resizer
-        resizer.style.left = `${left + default_pane_widths[index - 1] - 3}px`;
-        left += default_pane_widths[index - 1];
-        // Add resizer into Dom
-        pane.parentNode.insertBefore(resizer, pane);
-        // Keep resizer
-        resizers.push(resizer);
-      });
     }
-    // For split_pane_root resizing
-    if (resize_observer) {
-      resize_observer.disconnect(split_pane_root);
+
+    let ratios = defaultRatio;
+    if (panes.length > ratios.length) {
+      ratios = ratios.concat(new Array(panes.length - ratios.length).fill(1));
+    } else if (panes.length < ratios.length) {
+      ratios = ratios.slice(0, panes.length);
     }
+    const ratioSum = ratios.reduce((partialSum, ratio) => partialSum + ratio, 0) || panes.length;
+    return ratios.map((ratio) => (rootWidth * ratio) / ratioSum);
+  };
+
+  const createResizers = (panes, paneWidths) => {
+    const nextResizers = [];
+    let left = 0;
+
+    panes.forEach((pane, index) => {
+      if (index == 0) {
+        return;
+      }
+      const resizer = document.createElement("div");
+      resizer.classList.add("Resizer");
+      resizer.style.left = `${left + paneWidths[index - 1] - 3}px`;
+      left += paneWidths[index - 1];
+      pane.parentNode.insertBefore(resizer, pane);
+      nextResizers.push(resizer);
+    });
+
+    return nextResizers;
+  };
+
+  const observeRootResize = (panes) => {
+    resize_observer?.disconnect();
     resize_observer = new ResizeObserver((entries) => {
       // Width setting
       let root_width = 0;
-      panes.forEach((pane, index) => {
+      panes.forEach((pane) => {
         root_width += pane.getBoundingClientRect().width;
       });
+      if (root_width === 0) {
+        return;
+      }
       let new_root_width = entries[0].contentRect.width;
       let new_pane_widths = [];
-      panes.forEach((pane, index) => {
+      panes.forEach((pane) => {
         new_pane_widths.push((pane.getBoundingClientRect().width * new_root_width) / root_width);
       });
       panes.forEach((pane, index) => {
@@ -99,8 +132,6 @@
       });
     });
     resize_observer.observe(split_pane_root);
-    // Return
-    return [resizers, panes, resize_observer];
   };
 
   const setResizersEvents = (resizers, panes) => {

--- a/src/components/SplitPanes.svelte
+++ b/src/components/SplitPanes.svelte
@@ -65,7 +65,6 @@
         // Create resizer
         const resizer = document.createElement("div");
         resizer.classList.add("Resizer");
-        resizer.style.height = `${split_pane_root.offsetHeight}px`;
         // Postions of resizer
         resizer.style.left = `${left + default_pane_widths[index - 1] - 3}px`;
         left += default_pane_widths[index - 1];
@@ -80,10 +79,6 @@
       resize_observer.disconnect(split_pane_root);
     }
     resize_observer = new ResizeObserver((entries) => {
-      // Height setting
-      for (let resizer of resizers) {
-        resizer.style.height = `${entries[0].contentRect.height}px`;
-      }
       // Width setting
       let root_width = 0;
       panes.forEach((pane, index) => {
@@ -222,6 +217,8 @@
   .SplitPaneRoot > :global(.Resizer) {
     position: absolute;
     top: 0;
+    bottom: 0;
+    height: 100%;
     width: 5px;
     cursor: col-resize;
     user-select: none;

--- a/tests/component/GanttPanel.test.js
+++ b/tests/component/GanttPanel.test.js
@@ -1,4 +1,4 @@
-import { render } from "@testing-library/svelte";
+import { fireEvent, render } from "@testing-library/svelte";
 import { get } from "svelte/store";
 import { tick } from "svelte";
 
@@ -8,6 +8,7 @@ import {
   filtered_data,
   ganttScale,
   ganttScrollTop,
+  theme,
   tree_data,
 } from "../../src/stores.ts";
 
@@ -92,6 +93,7 @@ describe("GanttPanel", () => {
     closed_node_ids.set(new Set());
     ganttScale.set("day");
     ganttScrollTop.set(0);
+    theme.set("light");
   });
 
   afterEach(() => {
@@ -127,6 +129,30 @@ describe("GanttPanel", () => {
 
     expect(headerCell.children[0]).toHaveClass("HeaderCellDate");
     expect(headerCell.children[1]).toHaveClass("HeaderCellWeekday");
+  });
+
+  test("renders a left aligned gantt title row with scale buttons", async () => {
+    const { container, getByRole } = render(GanttPanel);
+    await tick();
+
+    const title = container.querySelector(".GanttTitle");
+
+    expect(title).toHaveTextContent("gantt");
+    expect(title).toHaveClass("GanttTitle");
+    expect(container.querySelector(".GanttTitleRow .ScaleButtons")).toBeInTheDocument();
+    expect(container.querySelector(".TimelineHeaderViewport .HeaderCell")).toBeInTheDocument();
+
+    await fireEvent.click(getByRole("button", { name: "月表示" }));
+    expect(get(ganttScale)).toBe("month");
+  });
+
+  test("uses the dark theme header color variant when the app is dark", async () => {
+    theme.set("dark");
+
+    const { container } = render(GanttPanel);
+    await tick();
+
+    expect(container.querySelector(".GanttRoot")).toHaveClass("DarkTheme");
   });
 
   test("rescales task bar width when switching between day week and month views", async () => {

--- a/tests/component/ProjectPage.test.js
+++ b/tests/component/ProjectPage.test.js
@@ -18,8 +18,19 @@ vi.mock("../../src/components/TaskDetail.svelte", async () => {
   return { default: mod.default };
 });
 
+vi.mock("../../src/components/GanttPanel.svelte", async () => {
+  const mod = await import("../mocks/GanttPanelStub.svelte");
+  return { default: mod.default };
+});
+
 import ProjectPage from "../../src/components/ProjectPage.svelte";
-import { closed_node_ids, selected_id, table_selected_id, tree_data } from "../../src/stores.ts";
+import {
+  closed_node_ids,
+  ganttVisible,
+  selected_id,
+  table_selected_id,
+  tree_data,
+} from "../../src/stores.ts";
 
 function createProjectData() {
   return {
@@ -66,6 +77,7 @@ describe("ProjectPage", () => {
     selected_id.set("project-1");
     table_selected_id.set("task-1");
     closed_node_ids.set(new Set());
+    ganttVisible.set(false);
   });
 
   afterEach(() => {
@@ -163,5 +175,32 @@ describe("ProjectPage", () => {
 
     expect(get(tree_data).data.children).toHaveLength(0);
     expect(get(table_selected_id)).toBeUndefined();
+  });
+
+  test("toggles the right detail pane", async () => {
+    render(ProjectPage);
+
+    expect(screen.getByTestId("task-detail-stub")).toBeInTheDocument();
+
+    await fireEvent.click(screen.getByRole("button", { name: "Hide detail pane" }));
+
+    expect(screen.queryByTestId("task-detail-stub")).not.toBeInTheDocument();
+
+    await fireEvent.click(screen.getByRole("button", { name: "Show detail pane" }));
+
+    expect(screen.getByTestId("task-detail-stub")).toBeInTheDocument();
+  });
+
+  test("closes the right detail pane while the gantt panel remains visible", async () => {
+    ganttVisible.set(true);
+
+    render(ProjectPage);
+
+    expect(screen.getByTestId("gantt-panel-stub")).toBeInTheDocument();
+
+    await fireEvent.click(screen.getByRole("button", { name: "Hide detail pane" }));
+
+    expect(screen.queryByTestId("task-detail-stub")).not.toBeInTheDocument();
+    expect(screen.getByTestId("gantt-panel-stub")).toBeInTheDocument();
   });
 });

--- a/tests/component/SplitPanes.test.js
+++ b/tests/component/SplitPanes.test.js
@@ -1,0 +1,38 @@
+import { render } from "@testing-library/svelte";
+import { tick } from "svelte";
+
+import SplitPanesHarness from "../mocks/SplitPanesHarness.svelte";
+
+class ResizeObserverMock {
+  constructor(callback) {
+    this.callback = callback;
+  }
+
+  observe(target) {
+    this.callback([{ contentRect: { width: 400, height: 300 }, target }]);
+  }
+
+  disconnect() {}
+}
+
+describe("SplitPanes", () => {
+  const OriginalResizeObserver = globalThis.ResizeObserver;
+
+  beforeEach(() => {
+    globalThis.ResizeObserver = ResizeObserverMock;
+  });
+
+  afterEach(() => {
+    globalThis.ResizeObserver = OriginalResizeObserver;
+  });
+
+  test("lets resizer height follow the split pane root", async () => {
+    const { container } = render(SplitPanesHarness);
+    await tick();
+
+    const resizer = container.querySelector(".Resizer");
+
+    expect(resizer).toBeInTheDocument();
+    expect(resizer.style.height).toBe("");
+  });
+});

--- a/tests/mocks/GanttPanelStub.svelte
+++ b/tests/mocks/GanttPanelStub.svelte
@@ -1,0 +1,1 @@
+<div data-testid="gantt-panel-stub">gantt panel stub</div>

--- a/tests/mocks/SplitPanesHarness.svelte
+++ b/tests/mocks/SplitPanesHarness.svelte
@@ -1,0 +1,13 @@
+<script>
+  import Pane from "../../src/components/Pane.svelte";
+  import SplitPanes from "../../src/components/SplitPanes.svelte";
+
+  export let defaultRatio = [1, 1];
+</script>
+
+<div style="width: 400px; height: 300px;">
+  <SplitPanes {defaultRatio}>
+    <Pane style="height: 100%; min-width: 4rem;">left</Pane>
+    <Pane style="height: 100%; min-width: 4rem;">right</Pane>
+  </SplitPanes>
+</div>


### PR DESCRIPTION
## Summary
- Restyle the Gantt header as a two-row header aligned with the task tree header rhythm.
- Add a toolbar toggle that hides and restores the right-side task detail pane.
- Expand the table/Gantt workspace when the detail pane is hidden, which is especially useful while viewing the Gantt chart.
- Rework `SplitPanes` cleanup and refresh logic so resizers are rebuilt cleanly when panes are added or removed.
- Add component coverage for detail-pane toggling, including the Gantt-visible case.

## Impact
- Users can reclaim horizontal space for the table and Gantt chart without changing the selected task.
- Split pane resizing continues to work after the right pane is closed and reopened.

## Validation
- `vitest run tests/component/ProjectPage.test.js tests/component/SplitPanes.test.js`
- `svelte-check --tsconfig ./tsconfig.json`
- `vite build`