### PR TITLE
[codex] Create versioned release tag workflow

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -61,15 +61,6 @@ jobs:
           node-version: 22
           cache: npm
 
-      - run: npm ci
-
-      - run: |
-          sudo apt update
-          sudo apt install -y wine64
-          sudo dpkg --add-architecture i386
-          sudo apt-get update
-          sudo apt-get install -y wine32:i386
-
       - id: extract_tag
         run: |
           if [[ "${GITHUB_REF}" == refs/tags/v* ]]; then
@@ -78,10 +69,17 @@ jobs:
             echo "version=0.0.0-dev" >> "$GITHUB_OUTPUT"
           fi
 
+      - name: Set package version from tag
+        run: npm version "${{ steps.extract_tag.outputs.version }}" --no-git-tag-version --allow-same-version
+
+      - run: npm ci
+
       - run: |
-          VERSION=${{ steps.extract_tag.outputs.version }}
-          jq --arg v "$VERSION" '.version = $v' package.json > tmp.json
-          mv tmp.json package.json
+          sudo apt update
+          sudo apt install -y wine64
+          sudo dpkg --add-architecture i386
+          sudo apt-get update
+          sudo apt-get install -y wine32:i386
 
       - run: |
           npm run dist

--- a/.github/workflows/tag-release.yml
+++ b/.github/workflows/tag-release.yml
@@ -1,0 +1,67 @@
+name: Create Release Tag
+
+on:
+  workflow_dispatch:
+    inputs:
+      version:
+        description: "Release version, for example 0.1.19 or v0.1.19"
+        required: true
+        type: string
+
+permissions:
+  contents: write
+
+jobs:
+  tag:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: main
+          fetch-depth: 0
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: npm
+
+      - id: version
+        name: Normalize version
+        shell: bash
+        run: |
+          VERSION="${{ inputs.version }}"
+          VERSION="${VERSION#v}"
+
+          if [[ ! "$VERSION" =~ ^[0-9]+\.[0-9]+\.[0-9]+(-[0-9A-Za-z.-]+)?(\+[0-9A-Za-z.-]+)?$ ]]; then
+            echo "Invalid semver version: ${{ inputs.version }}" >&2
+            exit 1
+          fi
+
+          TAG="v$VERSION"
+          if git rev-parse "$TAG" >/dev/null 2>&1; then
+            echo "Tag already exists: $TAG" >&2
+            exit 1
+          fi
+
+          echo "version=$VERSION" >> "$GITHUB_OUTPUT"
+          echo "tag=$TAG" >> "$GITHUB_OUTPUT"
+
+      - name: Update package version
+        run: npm version "${{ steps.version.outputs.version }}" --no-git-tag-version --allow-same-version
+
+      - name: Commit and tag version
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+
+          if ! git diff --quiet -- package.json package-lock.json; then
+            git add package.json package-lock.json
+            git commit -m "chore: release ${{ steps.version.outputs.tag }}"
+          fi
+
+          git tag -a "${{ steps.version.outputs.tag }}" -m "${{ steps.version.outputs.tag }}"
+
+      - name: Push release commit and tag
+        run: |
+          git push origin HEAD:main
+          git push origin "${{ steps.version.outputs.tag }}"

--- a/.prettierignore
+++ b/.prettierignore
@@ -2,3 +2,4 @@ dist/
 renderer/
 node_modules/
 package-lock.json
+.claude/


### PR DESCRIPTION
## Summary
- Add a manual `Create Release Tag` workflow that updates `package.json` and `package-lock.json` from the requested version before creating the release tag.
- Change the existing tag release job to set the package version with `npm version --no-git-tag-version` instead of editing only `package.json` with `jq`.
- Ignore `.claude/` in Prettier checks so local worktree artifacts do not pollute `format:check`.

## Why
The release workflow builds from version tags, but the committed package metadata can remain stale. The new workflow makes the intended release flow explicit: create a version bump commit first, tag that commit, then let the existing tag-triggered release workflow build the release from matching package metadata.

## Validation
- `prettier --check .github/workflows/main.yml .github/workflows/tag-release.yml`
- `npm run lint`
- `npm run check`

Draft PR so the tag/release workflow can be reviewed before enabling it on main.