### PR TITLE
[codex] Use release app token for version tagging

### DIFF
--- a/.github/workflows/tag-release.yml
+++ b/.github/workflows/tag-release.yml
@@ -10,16 +10,28 @@ on:
         type: string
 
 permissions:
-  contents: write
+  contents: read
 
 jobs:
   tag:
     runs-on: ubuntu-latest
+    environment: release
+    concurrency:
+      group: release-tag
+      cancel-in-progress: false
     steps:
+      - id: release-token
+        name: Create release app token
+        uses: actions/create-github-app-token@v1
+        with:
+          app-id: ${{ secrets.RELEASE_APP_ID }}
+          private-key: ${{ secrets.RELEASE_APP_PRIVATE_KEY }}
+
       - uses: actions/checkout@v4
         with:
           ref: main
           fetch-depth: 0
+          token: ${{ steps.release-token.outputs.token }}
 
       - uses: actions/setup-node@v4
         with:
@@ -76,8 +88,8 @@ jobs:
 
       - name: Commit and tag version
         run: |
-          git config user.name "github-actions[bot]"
-          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git config user.name "task-manage-release[bot]"
+          git config user.email "task-manage-release[bot]@users.noreply.github.com"
 
           if ! git diff --quiet -- package.json package-lock.json; then
             git add package.json package-lock.json


### PR DESCRIPTION
## Summary
- Change `Create Release Tag` to use a release GitHub App token instead of the default `GITHUB_TOKEN` for checkout and push.
- Scope the workflow job to the `release` environment so the App credentials can live in environment secrets.
- Reduce the default workflow token permission from `contents: write` to `contents: read`.
- Add release-tag concurrency to avoid two version/tag runs racing against the same latest tag.

## Security Model
The intended repository ruleset bypass actor is only the release GitHub App. Humans, Codex/Claude, and the standard `github-actions[bot]` token should remain subject to the PR-required main ruleset.

## Follow-up Setup Required
- Create/install a release GitHub App, recommended name: `task-manage-release`.
- Give it repository permission `Contents: Read and write` only.
- Add the App as the main ruleset bypass actor.
- Add `RELEASE_APP_ID` and `RELEASE_APP_PRIVATE_KEY` as secrets on the `release` environment.

I already created the `release` environment and set `copper-mijinko` as the required reviewer.

## Validation
- `prettier --check .github/workflows/tag-release.yml`