### PR TITLE
[codex] Improve memo tags and task detail layout

### DIFF
--- a/src/components/Card.svelte
+++ b/src/components/Card.svelte
@@ -2,7 +2,7 @@
   export let style = "";
 </script>
 
-<div class="container" {style}>
+<div class="container Card" {style}>
   <slot />
 </div>
 

--- a/src/components/DateInput.svelte
+++ b/src/components/DateInput.svelte
@@ -29,7 +29,9 @@
 
 <div
   class="Container"
-  style="--dark:{is_dark ? 'dark' : ''}; --borderColor: {borderColor}; --color-datetime: {color};"
+  style="--dark:{is_dark
+    ? 'dark'
+    : ''}; --backgroundColor: {backgroundColor}; --borderColor: {borderColor}; --color-datetime: {color};"
 >
   <input
     {style}

--- a/src/components/IconButton.svelte
+++ b/src/components/IconButton.svelte
@@ -24,15 +24,17 @@
     abgcolor = disabled
       ? "color-mix(in srgb, var(--theme-color-Main-dark) 72%, var(--theme-color-Main-light))"
       : activeColor;
-    abdcolor = disabled ? "color-mix(in srgb, var(--theme-color-Sub-main) 28%, transparent)" : "none";
+    abdcolor = disabled
+      ? "color-mix(in srgb, var(--theme-color-Sub-main) 28%, transparent)"
+      : "none";
     fcolor = disabled ? "var(--theme-color-Sub-main)" : "var(--theme-color-Main-light)";
     bgcolor = disabled
       ? "color-mix(in srgb, var(--theme-color-Main-dark) 72%, var(--theme-color-Main-light))"
       : normalColor;
-    bdcolor = disabled ? "color-mix(in srgb, var(--theme-color-Sub-main) 28%, transparent)" : "none";
-    shadow = disabled
-      ? "none"
-      : "0 .2rem .5rem rgba(0,0,0,0.25), 0 .1em .25rem rgba(0,0,0,0);";
+    bdcolor = disabled
+      ? "color-mix(in srgb, var(--theme-color-Sub-main) 28%, transparent)"
+      : "none";
+    shadow = disabled ? "none" : "0 .2rem .5rem rgba(0,0,0,0.25), 0 .1em .25rem rgba(0,0,0,0);";
 
     if (!disabled) {
       switch (variant) {

--- a/src/components/IconButton.svelte
+++ b/src/components/IconButton.svelte
@@ -20,13 +20,19 @@
   let shadow = "0 .2rem .5rem rgba(0,0,0,0.25), 0 .1em .25rem rgba(0,0,0,0);";
 
   $: {
-    afcolor = disabled ? "gray" : "var(--theme-color-Main-light)";
-    abgcolor = disabled ? "gray" : activeColor;
-    abdcolor = disabled ? "gray" : "none";
-    fcolor = disabled ? "gray" : "var(--theme-color-Main-light)";
-    bgcolor = disabled ? "gray" : normalColor;
-    bdcolor = disabled ? "gray" : "none";
-    shadow = "0 .2rem .5rem rgba(0,0,0,0.25), 0 .1em .25rem rgba(0,0,0,0);";
+    afcolor = disabled ? "var(--theme-color-Sub-main)" : "var(--theme-color-Main-light)";
+    abgcolor = disabled
+      ? "color-mix(in srgb, var(--theme-color-Main-dark) 72%, var(--theme-color-Main-light))"
+      : activeColor;
+    abdcolor = disabled ? "color-mix(in srgb, var(--theme-color-Sub-main) 28%, transparent)" : "none";
+    fcolor = disabled ? "var(--theme-color-Sub-main)" : "var(--theme-color-Main-light)";
+    bgcolor = disabled
+      ? "color-mix(in srgb, var(--theme-color-Main-dark) 72%, var(--theme-color-Main-light))"
+      : normalColor;
+    bdcolor = disabled ? "color-mix(in srgb, var(--theme-color-Sub-main) 28%, transparent)" : "none";
+    shadow = disabled
+      ? "none"
+      : "0 .2rem .5rem rgba(0,0,0,0.25), 0 .1em .25rem rgba(0,0,0,0);";
 
     if (!disabled) {
       switch (variant) {
@@ -59,7 +65,7 @@
   aria-label={ariaLabel}
   use:ripple={{
     duration: 350,
-    color: disabled ? "gray" : rippleColor,
+    color: disabled ? "var(--theme-color-Sub-dark)" : rippleColor,
     disable: !use_ripple,
   }}
   use:tooltip={{
@@ -105,6 +111,9 @@
     background-color: var(--activeBackgroundColor);
     color: var(--activeFontColor);
     box-shadow: var(--shadow);
+  }
+  button:disabled {
+    cursor: not-allowed;
   }
   .IconButton :global(svg) {
     width: 100%;

--- a/src/components/MarkdownMemo.svelte
+++ b/src/components/MarkdownMemo.svelte
@@ -32,6 +32,12 @@
   let renderSequence = 0;
   let previewEl: HTMLElement | null = null;
   let livePreviewEl: HTMLElement | null = null;
+  let editBody: HTMLElement | null = null;
+  let markdownSplitPercent = 55;
+
+  const SPLIT_MIN_PERCENT = 30;
+  const SPLIT_MAX_PERCENT = 72;
+  const SPLIT_KEY_STEP = 5;
 
   const EXTERNAL_LINK_PATTERN = /^(https?:\/\/|mailto:|file:\/\/)/i;
   const toolbarIcons = {
@@ -381,6 +387,65 @@
     }
   }
 
+  function clampSplitPercent(value: number): number {
+    return Math.min(SPLIT_MAX_PERCENT, Math.max(SPLIT_MIN_PERCENT, value));
+  }
+
+  function applyMarkdownSplitPercent(value: number) {
+    markdownSplitPercent = clampSplitPercent(value);
+    view?.requestMeasure();
+  }
+
+  function resizeMarkdownSplitFromClientX(clientX: number) {
+    if (!editBody) return;
+    const rect = editBody.getBoundingClientRect();
+    if (rect.width <= 0) return;
+    applyMarkdownSplitPercent(((clientX - rect.left) / rect.width) * 100);
+  }
+
+  function handleSplitPointerMove(event: PointerEvent) {
+    resizeMarkdownSplitFromClientX(event.clientX);
+  }
+
+  function stopSplitResize() {
+    window.removeEventListener("pointermove", handleSplitPointerMove);
+    window.removeEventListener("pointerup", stopSplitResize);
+    document.body.style.removeProperty("cursor");
+    document.body.style.removeProperty("user-select");
+  }
+
+  function startSplitResize(event: PointerEvent) {
+    if (!editBody) return;
+    event.preventDefault();
+    (event.currentTarget as HTMLElement).setPointerCapture?.(event.pointerId);
+    document.body.style.cursor = "col-resize";
+    document.body.style.userSelect = "none";
+    resizeMarkdownSplitFromClientX(event.clientX);
+    window.addEventListener("pointermove", handleSplitPointerMove);
+    window.addEventListener("pointerup", stopSplitResize);
+  }
+
+  function handleSplitKeydown(event: KeyboardEvent) {
+    switch (event.key) {
+      case "ArrowLeft":
+        event.preventDefault();
+        applyMarkdownSplitPercent(markdownSplitPercent - SPLIT_KEY_STEP);
+        break;
+      case "ArrowRight":
+        event.preventDefault();
+        applyMarkdownSplitPercent(markdownSplitPercent + SPLIT_KEY_STEP);
+        break;
+      case "Home":
+        event.preventDefault();
+        applyMarkdownSplitPercent(SPLIT_MIN_PERCENT);
+        break;
+      case "End":
+        event.preventDefault();
+        applyMarkdownSplitPercent(SPLIT_MAX_PERCENT);
+        break;
+    }
+  }
+
   const editorTheme = EditorView.theme({
     "&": {
       height: "100%",
@@ -548,6 +613,7 @@
   }
 
   onDestroy(() => {
+    stopSplitResize();
     clearTimeout(savedTimer);
     if (view) {
       clearTimeout(saveTimer);
@@ -720,8 +786,28 @@
           </div>
         </div>
       </div>
-      <div class="edit-body">
-        <div class="editor" bind:this={container}></div>
+      <div
+        class="edit-body"
+        bind:this={editBody}
+        style={`--editor-pane-width: ${markdownSplitPercent}%`}
+      >
+        <div class="editor-pane">
+          <div class="editor" bind:this={container}></div>
+        </div>
+        <!-- svelte-ignore a11y_no_noninteractive_tabindex -->
+        <!-- svelte-ignore a11y_no_noninteractive_element_interactions -->
+        <div
+          class="markdown-split-resizer"
+          role="separator"
+          aria-label="Resize editor and preview"
+          aria-orientation="vertical"
+          aria-valuemin={SPLIT_MIN_PERCENT}
+          aria-valuemax={SPLIT_MAX_PERCENT}
+          aria-valuenow={Math.round(markdownSplitPercent)}
+          tabindex="0"
+          on:pointerdown={startSplitResize}
+          on:keydown={handleSplitKeydown}
+        ></div>
         <div class="live-preview" aria-label="Markdown preview">
           {#if currentContent.trim()}
             <!-- eslint-disable-next-line svelte/no-at-html-tags -->
@@ -960,23 +1046,73 @@
     cursor: default;
   }
 
+  .edit-body {
+    --editor-pane-width: 55%;
+    display: flex;
+    min-height: 0;
+    flex: 1;
+  }
+
+  .editor-pane {
+    display: flex;
+    flex: 0 0 var(--editor-pane-width);
+    min-width: 0;
+    overflow: hidden;
+  }
+
   .editor {
     flex: 1;
     overflow: hidden;
     min-width: 0;
   }
 
-  .edit-body {
-    display: grid;
-    grid-template-columns: minmax(0, 1fr) minmax(16rem, 0.9fr);
-    min-height: 0;
-    flex: 1;
+  .markdown-split-resizer {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    flex: 0 0 0.65rem;
+    min-width: 0.65rem;
+    padding: 0;
+    cursor: col-resize;
+    border-left: 1px solid color-mix(in srgb, var(--theme-color-Sub-dark) 50%, transparent);
+    border-right: 1px solid color-mix(in srgb, var(--theme-color-Sub-dark) 50%, transparent);
+    border-top: 0;
+    border-bottom: 0;
+    background-color: color-mix(in srgb, var(--theme-color-Main-dark) 78%, transparent);
+    touch-action: none;
+  }
+
+  .markdown-split-resizer::before {
+    content: "";
+    width: 0.16rem;
+    height: 3rem;
+    border-radius: 999px;
+    background-color: color-mix(in srgb, var(--theme-color-Sub-main) 55%, transparent);
+    box-shadow:
+      -0.22rem 0 0 color-mix(in srgb, var(--theme-color-Sub-main) 22%, transparent),
+      0.22rem 0 0 color-mix(in srgb, var(--theme-color-Sub-main) 22%, transparent);
+    transition:
+      background-color 0.12s ease,
+      box-shadow 0.12s ease;
+  }
+
+  .markdown-split-resizer:hover::before,
+  .markdown-split-resizer:focus-visible::before {
+    background-color: var(--theme-color-Accent-main);
+    box-shadow:
+      -0.22rem 0 0 color-mix(in srgb, var(--theme-color-Accent-main) 32%, transparent),
+      0.22rem 0 0 color-mix(in srgb, var(--theme-color-Accent-main) 32%, transparent);
+  }
+
+  .markdown-split-resizer:focus-visible {
+    outline: 2px solid var(--theme-color-Accent-main);
+    outline-offset: -2px;
   }
 
   .live-preview {
+    flex: 1 1 0;
     min-width: 0;
     overflow: auto;
-    border-left: 1px solid var(--theme-color-Sub-dark);
     background-color: color-mix(in srgb, var(--theme-color-Main-light) 92%, black);
   }
 
@@ -1005,10 +1141,11 @@
   }
 
   @media (max-width: 900px) {
-    .edit-body {
-      grid-template-columns: 1fr;
+    .editor-pane {
+      flex-basis: 100%;
     }
 
+    .markdown-split-resizer,
     .live-preview {
       display: none;
     }

--- a/src/components/MarkdownMemo.svelte
+++ b/src/components/MarkdownMemo.svelte
@@ -8,6 +8,7 @@
   import { history, defaultKeymap, historyKeymap } from "@codemirror/commands";
   import { highlightSelectionMatches, searchKeymap } from "@codemirror/search";
   import { marked } from "marked";
+  import quillIcons from "quill/ui/icons.js";
   import { toMarkdown } from "../common/memo_utils";
   import * as platform from "../lib/platform";
 
@@ -33,6 +34,19 @@
   let livePreviewEl: HTMLElement | null = null;
 
   const EXTERNAL_LINK_PATTERN = /^(https?:\/\/|mailto:|file:\/\/)/i;
+  const toolbarIcons = {
+    bold: quillIcons.bold,
+    italic: quillIcons.italic,
+    inlineCode: quillIcons.code,
+    heading1: quillIcons.header["1"],
+    heading2: quillIcons.header["2"],
+    heading3: quillIcons.header["3"],
+    link: quillIcons.link,
+    bulletList: quillIcons.list.bullet,
+    checklist: quillIcons.list.check,
+    quote: quillIcons.blockquote,
+    codeBlock: quillIcons["code-block"],
+  };
 
   function normalizeMemoTitle(title: string): string {
     return title.trim().toLocaleLowerCase();
@@ -579,71 +593,120 @@
     <div class="edit-mode">
       <div class="edit-bar">
         <div class="toolbar">
+          <!-- eslint-disable svelte/no-at-html-tags -->
           <button
+            type="button"
             class="tool-btn tool-bold"
+            aria-label="Bold"
             title="Bold (Ctrl+B)"
             on:mousedown|preventDefault
-            on:click={formatBold}>B</button
+            on:click={formatBold}
           >
+            <span class="tool-icon" aria-hidden="true">{@html toolbarIcons.bold}</span>
+          </button>
           <button
+            type="button"
             class="tool-btn tool-italic"
+            aria-label="Italic"
             title="Italic (Ctrl+I)"
             on:mousedown|preventDefault
-            on:click={formatItalic}>I</button
+            on:click={formatItalic}
           >
+            <span class="tool-icon" aria-hidden="true">{@html toolbarIcons.italic}</span>
+          </button>
           <button
-            class="tool-btn tool-mono tool-code-inline"
+            type="button"
+            class="tool-btn tool-code-inline"
+            aria-label="Inline code"
             title="Inline code"
             on:mousedown|preventDefault
-            on:click={formatInlineCode}>`…`</button
+            on:click={formatInlineCode}
           >
+            <span class="tool-icon" aria-hidden="true">{@html toolbarIcons.inlineCode}</span>
+          </button>
           <span class="tool-sep"></span>
           <button
+            type="button"
             class="tool-btn"
+            aria-label="Heading 1"
             title="Heading 1"
             on:mousedown|preventDefault
-            on:click={() => formatHeading(1)}>H1</button
+            on:click={() => formatHeading(1)}
           >
+            <span class="tool-icon" aria-hidden="true">{@html toolbarIcons.heading1}</span>
+          </button>
           <button
+            type="button"
             class="tool-btn"
+            aria-label="Heading 2"
             title="Heading 2"
             on:mousedown|preventDefault
-            on:click={() => formatHeading(2)}>H2</button
+            on:click={() => formatHeading(2)}
           >
+            <span class="tool-icon" aria-hidden="true">{@html toolbarIcons.heading2}</span>
+          </button>
           <button
+            type="button"
             class="tool-btn"
+            aria-label="Heading 3"
             title="Heading 3"
             on:mousedown|preventDefault
-            on:click={() => formatHeading(3)}>H3</button
+            on:click={() => formatHeading(3)}
           >
+            <span class="tool-icon" aria-hidden="true">{@html toolbarIcons.heading3}</span>
+          </button>
           <span class="tool-sep"></span>
           <button
+            type="button"
             class="tool-btn"
+            aria-label="Link"
             title="Link (Ctrl+K)"
             on:mousedown|preventDefault
-            on:click={formatLink}>[]</button
+            on:click={formatLink}
           >
+            <span class="tool-icon" aria-hidden="true">{@html toolbarIcons.link}</span>
+          </button>
           <button
+            type="button"
             class="tool-btn"
+            aria-label="Bullet list"
             title="Bullet list"
             on:mousedown|preventDefault
-            on:click={formatBulletList}>-</button
+            on:click={formatBulletList}
           >
+            <span class="tool-icon" aria-hidden="true">{@html toolbarIcons.bulletList}</span>
+          </button>
           <button
+            type="button"
             class="tool-btn"
+            aria-label="Checklist"
             title="Checklist"
             on:mousedown|preventDefault
-            on:click={formatCheckbox}>[ ]</button
+            on:click={formatCheckbox}
           >
-          <button class="tool-btn" title="Quote" on:mousedown|preventDefault on:click={formatQuote}
-            >&gt;</button
-          >
+            <span class="tool-icon" aria-hidden="true">{@html toolbarIcons.checklist}</span>
+          </button>
           <button
-            class="tool-btn tool-mono tool-code-block"
+            type="button"
+            class="tool-btn"
+            aria-label="Quote"
+            title="Quote"
+            on:mousedown|preventDefault
+            on:click={formatQuote}
+          >
+            <span class="tool-icon" aria-hidden="true">{@html toolbarIcons.quote}</span>
+          </button>
+          <button
+            type="button"
+            class="tool-btn tool-code-block"
+            aria-label="Code block"
             title="Code block"
             on:mousedown|preventDefault
-            on:click={formatCodeBlock}>```</button
+            on:click={formatCodeBlock}
           >
+            <span class="tool-icon" aria-hidden="true">{@html toolbarIcons.codeBlock}</span>
+          </button>
+          <!-- eslint-enable svelte/no-at-html-tags -->
         </div>
         <div class="edit-bar-end">
           <span class="save-status" aria-live="polite">
@@ -697,6 +760,11 @@
 
 <style>
   .wrapper {
+    --memo-quill-button-color: var(--theme-color-Sub-light);
+    --memo-quill-button-active-color: #06c;
+    --memo-quill-button-height: 24px;
+    --memo-quill-button-width: 28px;
+
     display: flex;
     flex-direction: column;
     flex: 1;
@@ -716,7 +784,7 @@
     display: flex;
     justify-content: space-between;
     align-items: center;
-    padding: 0.3rem 0.5rem;
+    padding: 8px;
     background-color: var(--theme-color-Main-dark);
     flex-shrink: 0;
     gap: 0.5rem;
@@ -726,7 +794,7 @@
   .toolbar {
     display: flex;
     align-items: center;
-    gap: 0.15rem;
+    gap: 0;
     flex-wrap: nowrap;
     flex: 1 1 auto;
     min-width: 0;
@@ -744,29 +812,78 @@
     align-items: center;
     justify-content: center;
     flex: 0 0 auto;
-    height: 1.65rem;
-    padding: 0 0.35rem;
+    height: var(--memo-quill-button-height);
+    width: auto;
+    padding: 3px 5px;
     margin: 0;
-    font-size: 0.75rem;
-    background-color: color-mix(in srgb, var(--theme-color-Sub-dark) 10%, transparent);
-    border: 1px solid color-mix(in srgb, var(--theme-color-Sub-dark) 35%, transparent);
-    border-radius: 4px;
-    color: var(--theme-color-Sub-light);
+    font-size: 0.8rem;
+    background: none;
+    border: none;
+    border-radius: 0;
+    color: var(--memo-quill-button-color);
     cursor: pointer;
     line-height: 1;
-    min-width: 1.65rem;
+    min-width: var(--memo-quill-button-width);
     text-align: center;
+    transition: color 0.1s ease;
   }
 
-  .tool-btn:hover {
-    background-color: color-mix(in srgb, var(--theme-color-Sub-dark) 25%, transparent);
-    border-color: var(--theme-color-Sub-light);
-    color: var(--theme-color-Sub-light);
+  .tool-btn:hover,
+  .tool-btn:focus-visible {
+    background: none;
+    color: var(--memo-quill-button-active-color);
   }
 
   .tool-btn:active {
-    background-color: color-mix(in srgb, var(--theme-color-Sub-dark) 40%, transparent);
-    transform: translateY(1px);
+    background: none;
+  }
+
+  .tool-icon {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    width: 18px;
+    height: 18px;
+    pointer-events: none;
+  }
+
+  .tool-icon :global(svg) {
+    display: block;
+    width: 18px;
+    height: 18px;
+  }
+
+  .tool-icon :global(.ql-stroke) {
+    fill: none;
+    stroke: currentColor;
+    stroke-linecap: round;
+    stroke-linejoin: round;
+    stroke-width: 2;
+  }
+
+  .tool-icon :global(.ql-stroke-miter) {
+    fill: none;
+    stroke: currentColor;
+    stroke-miterlimit: 10;
+    stroke-width: 2;
+  }
+
+  .tool-icon :global(.ql-fill),
+  .tool-icon :global(.ql-stroke.ql-fill) {
+    fill: currentColor;
+  }
+
+  .tool-icon :global(.ql-even) {
+    fill-rule: evenodd;
+  }
+
+  .tool-icon :global(.ql-thin),
+  .tool-icon :global(.ql-stroke.ql-thin) {
+    stroke-width: 1;
+  }
+
+  .tool-icon :global(.ql-transparent) {
+    opacity: 0.4;
   }
 
   .tool-bold {
@@ -777,22 +894,16 @@
     font-style: italic;
   }
 
-  .tool-mono {
-    font-family: ui-monospace, "Cascadia Code", "Fira Code", monospace;
-    font-size: 0.72rem;
-    letter-spacing: -0.03em;
-  }
-
   .tool-code-inline,
   .tool-code-block {
-    border-left: 2px solid color-mix(in srgb, var(--theme-color-Accent-main) 55%, transparent);
+    min-width: var(--memo-quill-button-width);
   }
 
   .tool-sep {
-    width: 1px;
-    height: 1rem;
-    background-color: var(--theme-color-Sub-dark);
-    margin: 0 0.15rem;
+    width: 0;
+    height: var(--memo-quill-button-height);
+    background-color: transparent;
+    margin: 0 0.55rem 0 0.35rem;
     flex-shrink: 0;
   }
 

--- a/src/components/MemoTab.svelte
+++ b/src/components/MemoTab.svelte
@@ -91,10 +91,14 @@
   $: selectedMemo = memo[selectedMemoIndex];
   $: currentTags = selectedMemo?.tags ?? [];
   $: suggestedTags = allTags.filter((tag) => !currentTags.includes(tag));
-  $: visibleSuggestedTags = suggestedTags.slice(0, 8);
+  $: normalizedTagQuery = normalizeTagInput(tagInput);
+  $: visibleSuggestedTags = suggestedTags
+    .filter((tag) => !normalizedTagQuery || tag.includes(normalizedTagQuery))
+    .slice(0, 8);
   $: tagScopeLabel = isWorkspaceProject ? "Markdown" : "Quill";
 
   let tagInput = "";
+  let tagInputElement;
 
   function normalizeTagInput(value) {
     return String(value || "")
@@ -115,12 +119,17 @@
   }
 
   function handleTagInput(e) {
-    if (e.key === "Enter" && tagInput.trim()) {
+    if ((e.key === "Enter" || e.key === ",") && tagInput.trim()) {
       e.preventDefault();
       addTagFromInput();
     } else if (e.key === "Backspace" && tagInput === "" && currentTags.length > 0 && saveMemoTags) {
       saveMemoTags(selectedMemoIndex, currentTags.slice(0, -1));
     }
+  }
+
+  function focusTagInput(e) {
+    if (e.target?.closest?.("button")) return;
+    tagInputElement?.focus();
   }
 
   function removeTag(tag) {
@@ -289,16 +298,18 @@
 
   {#if selectedMemo}
     <div class="tag-panel" aria-label="Memo tags">
-      <div class="tag-panel-header">
+      <div class="tag-editor">
         <div class="tag-title" aria-hidden="true">
           <span class="tag-mark">#</span>
-          <span>Tags</span>
+          <span class="tag-title-copy">
+            <span>Tags</span>
+            <span class="tag-scope">{tagScopeLabel}</span>
+          </span>
         </div>
-        <span class="tag-scope">{tagScopeLabel}</span>
-      </div>
 
-      <div class="tag-editor-row">
-        <div class="tag-field" class:is-empty={currentTags.length === 0}>
+        <!-- svelte-ignore a11y_click_events_have_key_events -->
+        <!-- svelte-ignore a11y_no_static_element_interactions -->
+        <div class="tag-field" class:is-empty={currentTags.length === 0} on:click={focusTagInput}>
           {#each currentTags as tag (tag)}
             <span class="tag-chip">
               <span>{tag}</span>
@@ -317,11 +328,13 @@
           <input
             class="tag-input"
             type="text"
-            list="memo-tag-suggestions"
+            bind:this={tagInputElement}
             bind:value={tagInput}
             on:keydown={handleTagInput}
             placeholder="Add tag"
             aria-label="Memo tag"
+            autocomplete="off"
+            spellcheck="false"
           />
         </div>
         <button
@@ -334,6 +347,7 @@
           <svg viewBox="0 0 24 24" aria-hidden="true">
             <path d="M12 5V19M5 12H19" />
           </svg>
+          <span>Add</span>
         </button>
       </div>
 
@@ -351,10 +365,6 @@
           {/each}
         </div>
       {/if}
-
-      <datalist id="memo-tag-suggestions">
-        {#each suggestedTags as t}<option value={t}></option>{/each}
-      </datalist>
     </div>
   {/if}
 
@@ -500,37 +510,28 @@
   .tag-panel {
     display: flex;
     flex-direction: column;
-    gap: 0.45rem;
-    padding: 0.55rem 0.75rem 0.65rem;
-    border-top: 1px solid color-mix(in srgb, var(--theme-color-Sub-dark) 35%, transparent);
+    gap: 0.5rem;
+    padding: 0.75rem;
     border-bottom: 1px solid color-mix(in srgb, var(--theme-color-Sub-dark) 65%, transparent);
-    background-color: var(--theme-color-Main-dark);
+    background-color: color-mix(in srgb, var(--theme-color-Main-dark) 90%, transparent);
     flex-shrink: 0;
   }
 
-  .tag-panel-header,
-  .tag-editor-row {
-    display: flex;
+  .tag-editor {
+    display: grid;
+    grid-template-columns: auto minmax(0, 1fr) auto;
     align-items: center;
-    width: 100%;
-    min-width: 0;
-  }
-
-  .tag-panel-header {
-    justify-content: space-between;
     gap: 0.75rem;
-  }
-
-  .tag-editor-row {
-    gap: 0.5rem;
+    min-width: 0;
   }
 
   .tag-title {
     display: inline-flex;
     align-items: center;
-    gap: 0.45rem;
+    gap: 0.5rem;
     flex: 0 0 auto;
-    color: var(--theme-color-Sub-light);
+    min-width: 5.5rem;
+    color: var(--theme-color-Sub-main);
     font-size: 0.82rem;
     font-weight: 700;
   }
@@ -546,18 +547,25 @@
     background-color: color-mix(in srgb, var(--theme-color-Accent-main) 13%, transparent);
   }
 
+  .tag-title-copy {
+    display: flex;
+    flex-direction: column;
+    gap: 0.08rem;
+    line-height: 1.1;
+  }
+
   .tag-scope {
-    display: inline-flex;
-    align-items: center;
-    min-height: 1.45rem;
-    padding: 0 0.55rem;
-    border-radius: 999px;
+    display: block;
+    min-height: 0;
+    padding: 0;
+    border-radius: 0;
     color: var(--theme-color-Sub-main);
-    background-color: color-mix(in srgb, var(--theme-color-Sub-dark) 22%, transparent);
-    font-size: 0.7rem;
+    background-color: transparent;
+    font-size: 0.66rem;
     font-weight: 600;
     letter-spacing: 0;
     white-space: nowrap;
+    opacity: 0.78;
   }
 
   .tag-field {
@@ -567,12 +575,13 @@
     align-items: center;
     gap: 0.25rem;
     min-width: 0;
-    min-height: 2.25rem;
-    padding: 0.25rem 0.45rem;
+    min-height: 2.75rem;
+    padding: 0.35rem 0.55rem;
     border: 1px solid color-mix(in srgb, var(--theme-color-Sub-main) 40%, transparent);
     border-radius: 8px;
-    background-color: color-mix(in srgb, var(--theme-color-Main-light) 90%, transparent);
+    background-color: var(--theme-color-Main-light);
     box-shadow: inset 0 0 0 1px transparent;
+    cursor: text;
     transition:
       border-color 0.12s ease,
       box-shadow 0.12s ease,
@@ -592,15 +601,19 @@
   .tag-chip {
     display: inline-flex;
     align-items: center;
-    gap: 0.3rem;
-    min-height: 1.55rem;
-    max-width: 13rem;
-    padding: 0 0.2rem 0 0.6rem;
-    border-radius: 999px;
-    border: 1px solid color-mix(in srgb, var(--theme-color-Accent-main) 35%, transparent);
-    background-color: color-mix(in srgb, var(--theme-color-Accent-main) 15%, transparent);
+    gap: 0.35rem;
+    min-height: 2rem;
+    max-width: 14rem;
+    padding: 0 0.35rem 0 0.75rem;
+    border-radius: 8px;
+    border: none;
+    background-color: color-mix(
+      in srgb,
+      var(--theme-color-Accent-main) 24%,
+      var(--theme-color-Main-light)
+    );
     color: var(--theme-color-Sub-light);
-    font-size: 0.76rem;
+    font-size: 0.84rem;
     font-weight: 600;
     white-space: nowrap;
   }
@@ -618,8 +631,8 @@
     display: inline-flex;
     align-items: center;
     justify-content: center;
-    width: 1.25rem;
-    height: 1.25rem;
+    width: 1.35rem;
+    height: 1.35rem;
     padding: 0;
     border-radius: 50%;
   }
@@ -642,15 +655,24 @@
   }
 
   .tag-input {
+    appearance: none;
     background: transparent;
     border: none;
     color: var(--theme-color-Sub-light);
-    font-size: 0.82rem;
-    min-width: 4.5rem;
-    flex: 1 1 6rem;
-    outline: none;
+    font-size: 0.84rem;
+    min-width: 5rem;
+    flex: 1 1 7rem;
+    outline: 0;
     padding: 0;
     text-align: left;
+    width: auto;
+    cursor: text;
+  }
+
+  input.tag-input:focus,
+  input.tag-input:hover {
+    outline: 0;
+    cursor: text;
   }
 
   .tag-input::placeholder {
@@ -661,9 +683,10 @@
     display: inline-flex;
     align-items: center;
     justify-content: center;
+    gap: 0.5rem;
     flex: 0 0 auto;
-    width: 2.35rem;
-    height: 2.35rem;
+    min-height: 2.5rem;
+    padding: 0 1rem;
     border: 1px solid color-mix(in srgb, var(--theme-color-Accent-main) 35%, transparent);
     border-radius: 8px;
     color: var(--theme-color-Main-main);
@@ -697,6 +720,12 @@
     height: 1rem;
   }
 
+  .tag-add span {
+    font-size: 0.82rem;
+    font-weight: 700;
+    line-height: 1;
+  }
+
   .tag-add path {
     fill: none;
     stroke: currentColor;
@@ -711,16 +740,18 @@
     gap: 0.35rem;
     width: 100%;
     min-width: 0;
+    padding-left: 6.25rem;
+    box-sizing: border-box;
   }
 
   .tag-suggestion {
     display: inline-flex;
     align-items: center;
     max-width: 12rem;
-    min-height: 1.55rem;
-    padding: 0 0.6rem;
+    min-height: 2rem;
+    padding: 0 0.65rem;
     border: 1px solid color-mix(in srgb, var(--theme-color-Sub-main) 24%, transparent);
-    border-radius: 999px;
+    border-radius: 8px;
     color: var(--theme-color-Sub-main);
     background-color: color-mix(in srgb, var(--theme-color-Main-light) 70%, transparent);
     font-size: 0.72rem;
@@ -745,11 +776,21 @@
 
   @media (max-width: 760px) {
     .tag-panel {
-      padding: 0.5rem;
+      padding: 0.6rem;
     }
 
-    .tag-panel-header {
-      align-items: flex-start;
+    .tag-editor {
+      grid-template-columns: 1fr;
+      align-items: stretch;
+      gap: 0.55rem;
+    }
+
+    .tag-title {
+      min-width: 0;
+    }
+
+    .tag-suggestions {
+      padding-left: 0;
     }
   }
 

--- a/src/components/MemoTab.svelte
+++ b/src/components/MemoTab.svelte
@@ -242,6 +242,7 @@
         {/each}
       {/if}
     </div>
+    <span class="memo-type-label">{tagScopeLabel}</span>
     <div class="memotab-control">
       <IconButton
         tooltipContent="Add a memo."
@@ -303,7 +304,6 @@
           <span class="tag-mark">#</span>
           <span class="tag-title-copy">
             <span>Tags</span>
-            <span class="tag-scope">{tagScopeLabel}</span>
           </span>
         </div>
 
@@ -313,16 +313,18 @@
           {#each currentTags as tag (tag)}
             <span class="tag-chip">
               <span>{tag}</span>
-              <button
-                class="tag-remove"
-                type="button"
+              <IconButton
+                variant="text"
+                normalColor={"var(--theme-color-Sub-main)"}
+                activeColor={"var(--theme-color-Sub-light)"}
+                style="margin: 0; width: 1.35rem; height: 1.35rem; border: none;"
+                ariaLabel="Remove tag {tag}"
                 on:click={() => removeTag(tag)}
-                aria-label="Remove tag {tag}"
               >
                 <svg viewBox="0 0 24 24" aria-hidden="true">
                   <path d="M7 7L17 17M17 7L7 17" />
                 </svg>
-              </button>
+              </IconButton>
             </span>
           {/each}
           <input
@@ -337,31 +339,33 @@
             spellcheck="false"
           />
         </div>
-        <button
-          class="tag-add"
-          type="button"
-          aria-label="Add tag"
+        <IconButton
+          tooltipContent="Add tag"
+          ariaLabel="Add tag"
+          normalColor={"var(--theme-color-Primary-main)"}
+          activeColor={"var(--theme-color-Primary-dark)"}
+          style="margin: 0; width: 2rem; height: 2rem;"
           disabled={!tagInput.trim() || !saveMemoTags}
           on:click={addTagFromInput}
         >
           <svg viewBox="0 0 24 24" aria-hidden="true">
             <path d="M12 5V19M5 12H19" />
           </svg>
-          <span>Add</span>
-        </button>
+        </IconButton>
       </div>
 
       {#if visibleSuggestedTags.length > 0}
         <div class="tag-suggestions" aria-label="Suggested tags">
           {#each visibleSuggestedTags as tag (tag)}
-            <button
-              type="button"
-              class="tag-suggestion"
+            <Button
+              content={`#${tag}`}
+              variant="outlined"
+              normalColor={"var(--theme-color-Sub-main)"}
+              activeColor={"var(--theme-color-Accent-main)"}
+              style="margin: 0; min-height: 2rem; height: 2rem; max-width: 12rem; padding: 0 0.65rem; font-size: 0.72rem;"
               disabled={!saveMemoTags}
               on:click={() => addTag(tag)}
-            >
-              #{tag}
-            </button>
+            />
           {/each}
         </div>
       {/if}
@@ -430,6 +434,21 @@
     padding: 0.5rem;
     overflow-x: auto;
     flex: 1;
+  }
+
+  .memo-type-label {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    min-width: 5.5rem;
+    height: 2rem;
+    margin: 0.5rem 0.25rem;
+    padding: 0 0.5rem;
+    color: var(--theme-color-Sub-main);
+    font-size: 0.82rem;
+    font-weight: 700;
+    white-space: nowrap;
+    flex: 0 0 auto;
   }
 
   .memotab-control {
@@ -511,28 +530,32 @@
     display: flex;
     flex-direction: column;
     gap: 0.5rem;
+    box-sizing: border-box;
+    min-width: 0;
     padding: 0.75rem;
     border-bottom: 1px solid color-mix(in srgb, var(--theme-color-Sub-dark) 65%, transparent);
-    background-color: color-mix(in srgb, var(--theme-color-Main-dark) 90%, transparent);
+    background-color: transparent;
+    container-type: inline-size;
     flex-shrink: 0;
   }
 
   .tag-editor {
-    display: grid;
-    grid-template-columns: auto minmax(0, 1fr) auto;
+    display: flex;
+    flex-direction: row;
     align-items: center;
-    gap: 0.75rem;
+    gap: 0.5rem;
+    width: 100%;
     min-width: 0;
   }
 
   .tag-title {
     display: inline-flex;
     align-items: center;
-    gap: 0.5rem;
+    gap: 0.35rem;
     flex: 0 0 auto;
     min-width: 5.5rem;
     color: var(--theme-color-Sub-main);
-    font-size: 0.82rem;
+    font-size: 1rem;
     font-weight: 700;
   }
 
@@ -540,11 +563,7 @@
     display: inline-flex;
     align-items: center;
     justify-content: center;
-    width: 1.5rem;
-    height: 1.5rem;
-    border-radius: 8px;
-    color: var(--theme-color-Accent-main);
-    background-color: color-mix(in srgb, var(--theme-color-Accent-main) 13%, transparent);
+    color: var(--theme-color-Sub-main);
   }
 
   .tag-title-copy {
@@ -554,26 +573,14 @@
     line-height: 1.1;
   }
 
-  .tag-scope {
-    display: block;
-    min-height: 0;
-    padding: 0;
-    border-radius: 0;
-    color: var(--theme-color-Sub-main);
-    background-color: transparent;
-    font-size: 0.66rem;
-    font-weight: 600;
-    letter-spacing: 0;
-    white-space: nowrap;
-    opacity: 0.78;
-  }
-
   .tag-field {
     display: flex;
     flex: 1 1 auto;
     flex-wrap: wrap;
     align-items: center;
     gap: 0.25rem;
+    box-sizing: border-box;
+    width: 100%;
     min-width: 0;
     min-height: 2.75rem;
     padding: 0.35rem 0.55rem;
@@ -602,8 +609,9 @@
     display: inline-flex;
     align-items: center;
     gap: 0.35rem;
+    min-width: 0;
     min-height: 2rem;
-    max-width: 14rem;
+    max-width: min(14rem, 100%);
     padding: 0 0.35rem 0 0.75rem;
     border-radius: 8px;
     border: none;
@@ -619,39 +627,28 @@
   }
 
   .tag-chip span {
+    flex: 1 1 auto;
+    min-width: 0;
     overflow: hidden;
     text-overflow: ellipsis;
   }
 
-  .tag-remove {
-    background: none;
-    border: none;
-    color: var(--theme-color-Sub-main);
-    cursor: pointer;
-    display: inline-flex;
-    align-items: center;
-    justify-content: center;
-    width: 1.35rem;
-    height: 1.35rem;
-    padding: 0;
-    border-radius: 50%;
+  .tag-chip :global(.IconButton) {
+    flex: 0 0 auto;
   }
 
-  .tag-remove:hover {
-    color: var(--theme-color-Sub-light);
-    background-color: color-mix(in srgb, var(--theme-color-Sub-main) 18%, transparent);
-  }
-
-  .tag-remove svg {
+  .tag-chip :global(.IconButton svg) {
     width: 0.85rem;
     height: 0.85rem;
   }
 
-  .tag-remove path {
+  .tag-chip :global(.IconButton path),
+  .tag-editor :global(.IconButton path) {
     fill: none;
     stroke: currentColor;
     stroke-width: 2;
     stroke-linecap: round;
+    stroke-linejoin: round;
   }
 
   .tag-input {
@@ -660,8 +657,9 @@
     border: none;
     color: var(--theme-color-Sub-light);
     font-size: 0.84rem;
-    min-width: 5rem;
-    flex: 1 1 7rem;
+    min-width: 0;
+    max-width: 100%;
+    flex: 1 1 4.5rem;
     outline: 0;
     padding: 0;
     text-align: left;
@@ -679,59 +677,9 @@
     color: var(--theme-color-Sub-dark);
   }
 
-  .tag-add {
-    display: inline-flex;
-    align-items: center;
-    justify-content: center;
-    gap: 0.5rem;
-    flex: 0 0 auto;
-    min-height: 2.5rem;
-    padding: 0 1rem;
-    border: 1px solid color-mix(in srgb, var(--theme-color-Accent-main) 35%, transparent);
-    border-radius: 8px;
-    color: var(--theme-color-Main-main);
-    background-color: var(--theme-color-Accent-dark);
-    cursor: pointer;
-    box-shadow: 0 0.15rem 0.35rem rgba(0, 0, 0, 0.18);
-    transition:
-      background-color 0.12s ease,
-      box-shadow 0.12s ease,
-      opacity 0.12s ease;
-  }
-
-  .tag-add:hover:not(:disabled),
-  .tag-add:focus-visible {
-    color: var(--theme-color-Main-main);
-    background-color: var(--theme-color-Accent-main);
-    box-shadow: 0 0.25rem 0.55rem rgba(0, 0, 0, 0.24);
-  }
-
-  .tag-add:disabled {
-    cursor: default;
-    color: var(--theme-color-Sub-dark);
-    background-color: color-mix(in srgb, var(--theme-color-Sub-dark) 18%, transparent);
-    border-color: color-mix(in srgb, var(--theme-color-Sub-dark) 26%, transparent);
-    box-shadow: none;
-    opacity: 1;
-  }
-
-  .tag-add svg {
+  .tag-editor :global(.IconButton svg) {
     width: 1rem;
     height: 1rem;
-  }
-
-  .tag-add span {
-    font-size: 0.82rem;
-    font-weight: 700;
-    line-height: 1;
-  }
-
-  .tag-add path {
-    fill: none;
-    stroke: currentColor;
-    stroke-width: 2;
-    stroke-linecap: round;
-    stroke-linejoin: round;
   }
 
   .tag-suggestions {
@@ -744,34 +692,10 @@
     box-sizing: border-box;
   }
 
-  .tag-suggestion {
-    display: inline-flex;
-    align-items: center;
-    max-width: 12rem;
-    min-height: 2rem;
-    padding: 0 0.65rem;
-    border: 1px solid color-mix(in srgb, var(--theme-color-Sub-main) 24%, transparent);
-    border-radius: 8px;
-    color: var(--theme-color-Sub-main);
-    background-color: color-mix(in srgb, var(--theme-color-Main-light) 70%, transparent);
-    font-size: 0.72rem;
-    font-weight: 600;
-    overflow: hidden;
-    text-overflow: ellipsis;
-    white-space: nowrap;
-    cursor: pointer;
-  }
-
-  .tag-suggestion:hover:not(:disabled),
-  .tag-suggestion:focus-visible {
-    color: var(--theme-color-Sub-light);
-    border-color: var(--theme-color-Accent-main);
-    background-color: color-mix(in srgb, var(--theme-color-Accent-main) 12%, transparent);
-  }
-
-  .tag-suggestion:disabled {
-    cursor: default;
-    opacity: 0.5;
+  @container (max-width: 34rem) {
+    .tag-suggestions {
+      padding-left: 0;
+    }
   }
 
   @media (max-width: 760px) {
@@ -780,9 +704,7 @@
     }
 
     .tag-editor {
-      grid-template-columns: 1fr;
-      align-items: stretch;
-      gap: 0.55rem;
+      gap: 0.45rem;
     }
 
     .tag-title {

--- a/src/components/MemoTab.svelte
+++ b/src/components/MemoTab.svelte
@@ -91,6 +91,8 @@
   $: selectedMemo = memo[selectedMemoIndex];
   $: currentTags = selectedMemo?.tags ?? [];
   $: suggestedTags = allTags.filter((tag) => !currentTags.includes(tag));
+  $: visibleSuggestedTags = suggestedTags.slice(0, 8);
+  $: tagScopeLabel = isWorkspaceProject ? "Markdown" : "Quill";
 
   let tagInput = "";
 
@@ -100,12 +102,16 @@
       .toLowerCase();
   }
 
-  function addTagFromInput() {
-    const newTag = normalizeTagInput(tagInput);
+  function addTag(value) {
+    const newTag = normalizeTagInput(value);
     if (newTag && !currentTags.includes(newTag) && saveMemoTags) {
       saveMemoTags(selectedMemoIndex, [...currentTags, newTag]);
     }
     tagInput = "";
+  }
+
+  function addTagFromInput() {
+    addTag(tagInput);
   }
 
   function handleTagInput(e) {
@@ -282,46 +288,70 @@
   </div>
 
   {#if selectedMemo}
-    <div class="tag-bar" aria-label="Memo tags">
-      <div class="tag-label" aria-hidden="true">
-        <span class="tag-mark">#</span>
-        <span>Tags</span>
+    <div class="tag-panel" aria-label="Memo tags">
+      <div class="tag-panel-header">
+        <div class="tag-title" aria-hidden="true">
+          <span class="tag-mark">#</span>
+          <span>Tags</span>
+        </div>
+        <span class="tag-scope">{tagScopeLabel}</span>
       </div>
-      <div class="tag-field">
-        {#each currentTags as tag (tag)}
-          <span class="tag-chip">
-            {tag}
+
+      <div class="tag-editor-row">
+        <div class="tag-field" class:is-empty={currentTags.length === 0}>
+          {#each currentTags as tag (tag)}
+            <span class="tag-chip">
+              <span>{tag}</span>
+              <button
+                class="tag-remove"
+                type="button"
+                on:click={() => removeTag(tag)}
+                aria-label="Remove tag {tag}"
+              >
+                <svg viewBox="0 0 24 24" aria-hidden="true">
+                  <path d="M7 7L17 17M17 7L7 17" />
+                </svg>
+              </button>
+            </span>
+          {/each}
+          <input
+            class="tag-input"
+            type="text"
+            list="memo-tag-suggestions"
+            bind:value={tagInput}
+            on:keydown={handleTagInput}
+            placeholder="Add tag"
+            aria-label="Memo tag"
+          />
+        </div>
+        <button
+          class="tag-add"
+          type="button"
+          aria-label="Add tag"
+          disabled={!tagInput.trim() || !saveMemoTags}
+          on:click={addTagFromInput}
+        >
+          <svg viewBox="0 0 24 24" aria-hidden="true">
+            <path d="M12 5V19M5 12H19" />
+          </svg>
+        </button>
+      </div>
+
+      {#if visibleSuggestedTags.length > 0}
+        <div class="tag-suggestions" aria-label="Suggested tags">
+          {#each visibleSuggestedTags as tag (tag)}
             <button
-              class="tag-remove"
               type="button"
-              on:click={() => removeTag(tag)}
-              aria-label="Remove tag {tag}"
+              class="tag-suggestion"
+              disabled={!saveMemoTags}
+              on:click={() => addTag(tag)}
             >
-              x
+              #{tag}
             </button>
-          </span>
-        {/each}
-        <input
-          class="tag-input"
-          type="text"
-          list="memo-tag-suggestions"
-          bind:value={tagInput}
-          on:keydown={handleTagInput}
-          placeholder="Tag"
-          aria-label="Memo tag"
-        />
-      </div>
-      <button
-        class="tag-add"
-        type="button"
-        aria-label="Add tag"
-        disabled={!tagInput.trim() || !saveMemoTags}
-        on:click={addTagFromInput}
-      >
-        <svg viewBox="0 0 24 24" aria-hidden="true">
-          <path d="M12 5V19M5 12H19" />
-        </svg>
-      </button>
+          {/each}
+        </div>
+      {/if}
+
       <datalist id="memo-tag-suggestions">
         {#each suggestedTags as t}<option value={t}></option>{/each}
       </datalist>
@@ -467,36 +497,67 @@
     border-right: 0.15rem solid var(--theme-color-Accent-main);
   }
 
-  .tag-bar {
+  .tag-panel {
     display: flex;
-    align-items: center;
-    gap: 0.5rem;
-    padding: 0.35rem 0.6rem;
-    min-height: 2.5rem;
-    border-bottom: 1px solid var(--theme-color-Sub-dark);
+    flex-direction: column;
+    gap: 0.45rem;
+    padding: 0.55rem 0.75rem 0.65rem;
+    border-top: 1px solid color-mix(in srgb, var(--theme-color-Sub-dark) 35%, transparent);
+    border-bottom: 1px solid color-mix(in srgb, var(--theme-color-Sub-dark) 65%, transparent);
     background-color: var(--theme-color-Main-dark);
     flex-shrink: 0;
   }
 
-  .tag-label {
+  .tag-panel-header,
+  .tag-editor-row {
+    display: flex;
+    align-items: center;
+    width: 100%;
+    min-width: 0;
+  }
+
+  .tag-panel-header {
+    justify-content: space-between;
+    gap: 0.75rem;
+  }
+
+  .tag-editor-row {
+    gap: 0.5rem;
+  }
+
+  .tag-title {
     display: inline-flex;
     align-items: center;
-    gap: 0.25rem;
+    gap: 0.45rem;
     flex: 0 0 auto;
-    color: var(--theme-color-Sub-main);
-    font-size: 0.78rem;
-    font-weight: 600;
+    color: var(--theme-color-Sub-light);
+    font-size: 0.82rem;
+    font-weight: 700;
   }
 
   .tag-mark {
     display: inline-flex;
     align-items: center;
     justify-content: center;
-    width: 1.25rem;
-    height: 1.25rem;
-    border-radius: 4px;
-    color: var(--theme-color-Main-main);
-    background-color: var(--theme-color-Accent-dark);
+    width: 1.5rem;
+    height: 1.5rem;
+    border-radius: 8px;
+    color: var(--theme-color-Accent-main);
+    background-color: color-mix(in srgb, var(--theme-color-Accent-main) 13%, transparent);
+  }
+
+  .tag-scope {
+    display: inline-flex;
+    align-items: center;
+    min-height: 1.45rem;
+    padding: 0 0.55rem;
+    border-radius: 999px;
+    color: var(--theme-color-Sub-main);
+    background-color: color-mix(in srgb, var(--theme-color-Sub-dark) 22%, transparent);
+    font-size: 0.7rem;
+    font-weight: 600;
+    letter-spacing: 0;
+    white-space: nowrap;
   }
 
   .tag-field {
@@ -506,57 +567,85 @@
     align-items: center;
     gap: 0.25rem;
     min-width: 0;
-    min-height: 1.85rem;
-    padding: 0.2rem 0.35rem;
-    border: 1px solid color-mix(in srgb, var(--theme-color-Sub-dark) 65%, transparent);
-    border-radius: 4px;
-    background-color: color-mix(in srgb, var(--theme-color-Main-light) 88%, transparent);
+    min-height: 2.25rem;
+    padding: 0.25rem 0.45rem;
+    border: 1px solid color-mix(in srgb, var(--theme-color-Sub-main) 40%, transparent);
+    border-radius: 8px;
+    background-color: color-mix(in srgb, var(--theme-color-Main-light) 90%, transparent);
+    box-shadow: inset 0 0 0 1px transparent;
+    transition:
+      border-color 0.12s ease,
+      box-shadow 0.12s ease,
+      background-color 0.12s ease;
   }
 
   .tag-field:focus-within {
     border-color: var(--theme-color-Accent-main);
+    box-shadow: inset 0 0 0 1px var(--theme-color-Accent-main);
+    background-color: var(--theme-color-Main-light);
+  }
+
+  .tag-field.is-empty {
+    padding-left: 0.7rem;
   }
 
   .tag-chip {
     display: inline-flex;
     align-items: center;
-    gap: 0.25rem;
-    min-height: 1.35rem;
-    padding: 0 0.25rem 0 0.45rem;
+    gap: 0.3rem;
+    min-height: 1.55rem;
+    max-width: 13rem;
+    padding: 0 0.2rem 0 0.6rem;
     border-radius: 999px;
-    background-color: var(--theme-color-Accent-dark);
-    color: var(--theme-color-Main-main);
-    font-size: 0.75rem;
+    border: 1px solid color-mix(in srgb, var(--theme-color-Accent-main) 35%, transparent);
+    background-color: color-mix(in srgb, var(--theme-color-Accent-main) 15%, transparent);
+    color: var(--theme-color-Sub-light);
+    font-size: 0.76rem;
+    font-weight: 600;
     white-space: nowrap;
+  }
+
+  .tag-chip span {
+    overflow: hidden;
+    text-overflow: ellipsis;
   }
 
   .tag-remove {
     background: none;
     border: none;
-    color: var(--theme-color-Main-main);
+    color: var(--theme-color-Sub-main);
     cursor: pointer;
     display: inline-flex;
     align-items: center;
     justify-content: center;
-    width: 1rem;
-    height: 1rem;
+    width: 1.25rem;
+    height: 1.25rem;
     padding: 0;
-    font-size: 0.75rem;
-    line-height: 1;
-    opacity: 0.7;
     border-radius: 50%;
   }
 
   .tag-remove:hover {
-    opacity: 1;
-    background-color: color-mix(in srgb, var(--theme-color-Main-main) 18%, transparent);
+    color: var(--theme-color-Sub-light);
+    background-color: color-mix(in srgb, var(--theme-color-Sub-main) 18%, transparent);
+  }
+
+  .tag-remove svg {
+    width: 0.85rem;
+    height: 0.85rem;
+  }
+
+  .tag-remove path {
+    fill: none;
+    stroke: currentColor;
+    stroke-width: 2;
+    stroke-linecap: round;
   }
 
   .tag-input {
     background: transparent;
     border: none;
     color: var(--theme-color-Sub-light);
-    font-size: 0.8rem;
+    font-size: 0.82rem;
     min-width: 4.5rem;
     flex: 1 1 6rem;
     outline: none;
@@ -573,25 +662,34 @@
     align-items: center;
     justify-content: center;
     flex: 0 0 auto;
-    width: 2rem;
-    height: 2rem;
-    border: 1px solid color-mix(in srgb, var(--theme-color-Sub-dark) 65%, transparent);
-    border-radius: 4px;
-    color: var(--theme-color-Sub-main);
-    background-color: color-mix(in srgb, var(--theme-color-Main-light) 88%, transparent);
+    width: 2.35rem;
+    height: 2.35rem;
+    border: 1px solid color-mix(in srgb, var(--theme-color-Accent-main) 35%, transparent);
+    border-radius: 8px;
+    color: var(--theme-color-Main-main);
+    background-color: var(--theme-color-Accent-dark);
     cursor: pointer;
+    box-shadow: 0 0.15rem 0.35rem rgba(0, 0, 0, 0.18);
+    transition:
+      background-color 0.12s ease,
+      box-shadow 0.12s ease,
+      opacity 0.12s ease;
   }
 
   .tag-add:hover:not(:disabled),
   .tag-add:focus-visible {
     color: var(--theme-color-Main-main);
-    border-color: var(--theme-color-Accent-main);
-    background-color: var(--theme-color-Accent-dark);
+    background-color: var(--theme-color-Accent-main);
+    box-shadow: 0 0.25rem 0.55rem rgba(0, 0, 0, 0.24);
   }
 
   .tag-add:disabled {
     cursor: default;
-    opacity: 0.45;
+    color: var(--theme-color-Sub-dark);
+    background-color: color-mix(in srgb, var(--theme-color-Sub-dark) 18%, transparent);
+    border-color: color-mix(in srgb, var(--theme-color-Sub-dark) 26%, transparent);
+    box-shadow: none;
+    opacity: 1;
   }
 
   .tag-add svg {
@@ -605,6 +703,54 @@
     stroke-width: 2;
     stroke-linecap: round;
     stroke-linejoin: round;
+  }
+
+  .tag-suggestions {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 0.35rem;
+    width: 100%;
+    min-width: 0;
+  }
+
+  .tag-suggestion {
+    display: inline-flex;
+    align-items: center;
+    max-width: 12rem;
+    min-height: 1.55rem;
+    padding: 0 0.6rem;
+    border: 1px solid color-mix(in srgb, var(--theme-color-Sub-main) 24%, transparent);
+    border-radius: 999px;
+    color: var(--theme-color-Sub-main);
+    background-color: color-mix(in srgb, var(--theme-color-Main-light) 70%, transparent);
+    font-size: 0.72rem;
+    font-weight: 600;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+    cursor: pointer;
+  }
+
+  .tag-suggestion:hover:not(:disabled),
+  .tag-suggestion:focus-visible {
+    color: var(--theme-color-Sub-light);
+    border-color: var(--theme-color-Accent-main);
+    background-color: color-mix(in srgb, var(--theme-color-Accent-main) 12%, transparent);
+  }
+
+  .tag-suggestion:disabled {
+    cursor: default;
+    opacity: 0.5;
+  }
+
+  @media (max-width: 760px) {
+    .tag-panel {
+      padding: 0.5rem;
+    }
+
+    .tag-panel-header {
+      align-items: flex-start;
+    }
   }
 
   .memotab-content {

--- a/src/components/MemoTab.svelte
+++ b/src/components/MemoTab.svelte
@@ -90,17 +90,28 @@
   $: editedContent = memo.length > selectedMemoIndex ? memo[selectedMemoIndex].content : "";
   $: selectedMemo = memo[selectedMemoIndex];
   $: currentTags = selectedMemo?.tags ?? [];
+  $: suggestedTags = allTags.filter((tag) => !currentTags.includes(tag));
 
   let tagInput = "";
+
+  function normalizeTagInput(value) {
+    return String(value || "")
+      .trim()
+      .toLowerCase();
+  }
+
+  function addTagFromInput() {
+    const newTag = normalizeTagInput(tagInput);
+    if (newTag && !currentTags.includes(newTag) && saveMemoTags) {
+      saveMemoTags(selectedMemoIndex, [...currentTags, newTag]);
+    }
+    tagInput = "";
+  }
 
   function handleTagInput(e) {
     if (e.key === "Enter" && tagInput.trim()) {
       e.preventDefault();
-      const newTag = tagInput.trim().toLowerCase();
-      if (!currentTags.includes(newTag) && saveMemoTags) {
-        saveMemoTags(selectedMemoIndex, [...currentTags, newTag]);
-      }
-      tagInput = "";
+      addTagFromInput();
     } else if (e.key === "Backspace" && tagInput === "" && currentTags.length > 0 && saveMemoTags) {
       saveMemoTags(selectedMemoIndex, currentTags.slice(0, -1));
     }
@@ -271,25 +282,48 @@
   </div>
 
   {#if selectedMemo}
-    <div class="tag-bar">
-      {#each currentTags as tag (tag)}
-        <span class="tag-chip">
-          {tag}
-          <button class="tag-remove" on:click={() => removeTag(tag)} aria-label="Remove tag {tag}"
-            >×</button
-          >
-        </span>
-      {/each}
-      <input
-        class="tag-input"
-        type="text"
-        list="memo-tag-suggestions"
-        bind:value={tagInput}
-        on:keydown={handleTagInput}
-        placeholder={currentTags.length === 0 ? "タグを追加..." : ""}
-      />
+    <div class="tag-bar" aria-label="Memo tags">
+      <div class="tag-label" aria-hidden="true">
+        <span class="tag-mark">#</span>
+        <span>Tags</span>
+      </div>
+      <div class="tag-field">
+        {#each currentTags as tag (tag)}
+          <span class="tag-chip">
+            {tag}
+            <button
+              class="tag-remove"
+              type="button"
+              on:click={() => removeTag(tag)}
+              aria-label="Remove tag {tag}"
+            >
+              x
+            </button>
+          </span>
+        {/each}
+        <input
+          class="tag-input"
+          type="text"
+          list="memo-tag-suggestions"
+          bind:value={tagInput}
+          on:keydown={handleTagInput}
+          placeholder="Tag"
+          aria-label="Memo tag"
+        />
+      </div>
+      <button
+        class="tag-add"
+        type="button"
+        aria-label="Add tag"
+        disabled={!tagInput.trim() || !saveMemoTags}
+        on:click={addTagFromInput}
+      >
+        <svg viewBox="0 0 24 24" aria-hidden="true">
+          <path d="M12 5V19M5 12H19" />
+        </svg>
+      </button>
       <datalist id="memo-tag-suggestions">
-        {#each allTags as t}<option value={t}></option>{/each}
+        {#each suggestedTags as t}<option value={t}></option>{/each}
       </datalist>
     </div>
   {/if}
@@ -435,21 +469,61 @@
 
   .tag-bar {
     display: flex;
+    align-items: center;
+    gap: 0.5rem;
+    padding: 0.35rem 0.6rem;
+    min-height: 2.5rem;
+    border-bottom: 1px solid var(--theme-color-Sub-dark);
+    background-color: var(--theme-color-Main-dark);
+    flex-shrink: 0;
+  }
+
+  .tag-label {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.25rem;
+    flex: 0 0 auto;
+    color: var(--theme-color-Sub-main);
+    font-size: 0.78rem;
+    font-weight: 600;
+  }
+
+  .tag-mark {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    width: 1.25rem;
+    height: 1.25rem;
+    border-radius: 4px;
+    color: var(--theme-color-Main-main);
+    background-color: var(--theme-color-Accent-dark);
+  }
+
+  .tag-field {
+    display: flex;
+    flex: 1 1 auto;
     flex-wrap: wrap;
     align-items: center;
     gap: 0.25rem;
-    padding: 0.25rem 0.5rem;
-    min-height: 2rem;
-    border-bottom: 1px solid var(--theme-color-Sub-dark);
-    flex-shrink: 0;
+    min-width: 0;
+    min-height: 1.85rem;
+    padding: 0.2rem 0.35rem;
+    border: 1px solid color-mix(in srgb, var(--theme-color-Sub-dark) 65%, transparent);
+    border-radius: 4px;
+    background-color: color-mix(in srgb, var(--theme-color-Main-light) 88%, transparent);
+  }
+
+  .tag-field:focus-within {
+    border-color: var(--theme-color-Accent-main);
   }
 
   .tag-chip {
     display: inline-flex;
     align-items: center;
-    gap: 0.2rem;
-    padding: 0.1rem 0.4rem;
-    border-radius: 0.75rem;
+    gap: 0.25rem;
+    min-height: 1.35rem;
+    padding: 0 0.25rem 0 0.45rem;
+    border-radius: 999px;
     background-color: var(--theme-color-Accent-dark);
     color: var(--theme-color-Main-main);
     font-size: 0.75rem;
@@ -461,29 +535,76 @@
     border: none;
     color: var(--theme-color-Main-main);
     cursor: pointer;
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    width: 1rem;
+    height: 1rem;
     padding: 0;
     font-size: 0.75rem;
     line-height: 1;
     opacity: 0.7;
+    border-radius: 50%;
   }
 
   .tag-remove:hover {
     opacity: 1;
+    background-color: color-mix(in srgb, var(--theme-color-Main-main) 18%, transparent);
   }
 
   .tag-input {
     background: transparent;
     border: none;
-    color: var(--theme-color-Sub-main);
+    color: var(--theme-color-Sub-light);
     font-size: 0.8rem;
-    min-width: 6rem;
-    flex: 1;
+    min-width: 4.5rem;
+    flex: 1 1 6rem;
     outline: none;
     padding: 0;
+    text-align: left;
   }
 
   .tag-input::placeholder {
     color: var(--theme-color-Sub-dark);
+  }
+
+  .tag-add {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    flex: 0 0 auto;
+    width: 2rem;
+    height: 2rem;
+    border: 1px solid color-mix(in srgb, var(--theme-color-Sub-dark) 65%, transparent);
+    border-radius: 4px;
+    color: var(--theme-color-Sub-main);
+    background-color: color-mix(in srgb, var(--theme-color-Main-light) 88%, transparent);
+    cursor: pointer;
+  }
+
+  .tag-add:hover:not(:disabled),
+  .tag-add:focus-visible {
+    color: var(--theme-color-Main-main);
+    border-color: var(--theme-color-Accent-main);
+    background-color: var(--theme-color-Accent-dark);
+  }
+
+  .tag-add:disabled {
+    cursor: default;
+    opacity: 0.45;
+  }
+
+  .tag-add svg {
+    width: 1rem;
+    height: 1rem;
+  }
+
+  .tag-add path {
+    fill: none;
+    stroke: currentColor;
+    stroke-width: 2;
+    stroke-linecap: round;
+    stroke-linejoin: round;
   }
 
   .memotab-content {

--- a/src/components/MenuList.svelte
+++ b/src/components/MenuList.svelte
@@ -44,6 +44,7 @@
   let show_confirm = false;
   let project_id_confirm;
   let project_name_confirm;
+  let tagQuery = "";
   const toggle_confirm = () => {
     show_confirm = !show_confirm;
   };
@@ -66,6 +67,17 @@
       children: $info_ids,
     },
   ];
+  $: tagEntries = [...$tag_index.entries()].sort(([a], [b]) => a.localeCompare(b));
+  $: normalizedTagQuery = tagQuery.trim().toLocaleLowerCase();
+  $: visibleTagEntries = normalizedTagQuery
+    ? tagEntries.filter(([tag]) => tag.toLocaleLowerCase().includes(normalizedTagQuery))
+    : tagEntries;
+  $: tagScopeLabel =
+    $selected_type === "WorkspaceProject"
+      ? "Markdown"
+      : $selected_type === "Projects"
+        ? "Quill"
+        : "Memo";
 
   // Add
   const handleAdd = (e) => {
@@ -449,64 +461,74 @@
   {/if}
 
   <!-- Tag browser -->
-  <br />
-  <div class="Section">
-    <span class="TagLogo">#</span>
-    <span class="TextOverFlow">Tags</span>
-    <div class="AddButtonContainer">
-      <IconButton
-        ariaLabel="Toggle tags section"
-        normalColor="rgba(255,255,255,0.1)"
-        activeColor="rgba(255,255,255,0.2)"
+  <div class="TagBrowser">
+    <div class="TagHeader">
+      <div class="TagTitle">
+        <span class="TagLogo">#</span>
+        <div class="TagTitleText">
+          <span class="TextOverFlow">Tags</span>
+          <span class="TagScope">{tagScopeLabel}</span>
+        </div>
+      </div>
+      <button
+        class="TagToggle"
+        type="button"
+        aria-label="Toggle tags section"
+        aria-expanded={tagsExpanded}
         on:click={() => (tagsExpanded = !tagsExpanded)}
       >
         {#if tagsExpanded}
-          <svg viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
-            <path
-              d="M18 15L12 9L6 15"
-              stroke="white"
-              stroke-width="2"
-              stroke-linecap="round"
-              stroke-linejoin="round"
-            />
+          <svg viewBox="0 0 24 24" aria-hidden="true">
+            <path d="M18 15L12 9L6 15" />
           </svg>
         {:else}
-          <svg viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
-            <path
-              d="M6 9L12 15L18 9"
-              stroke="white"
-              stroke-width="2"
-              stroke-linecap="round"
-              stroke-linejoin="round"
-            />
+          <svg viewBox="0 0 24 24" aria-hidden="true">
+            <path d="M6 9L12 15L18 9" />
           </svg>
         {/if}
-      </IconButton>
+      </button>
     </div>
+    {#if tagsExpanded}
+      <div class="TagContents" transition:slide={{ duration: 100 }}>
+        <label class="TagSearch">
+          <svg viewBox="0 0 24 24" aria-hidden="true">
+            <path d="M21 21L16.7 16.7M18 11A7 7 0 1 1 4 11A7 7 0 0 1 18 11Z" />
+          </svg>
+          <input
+            bind:value={tagQuery}
+            type="text"
+            placeholder="Filter tags"
+            aria-label="Filter tags"
+          />
+        </label>
+
+        {#if visibleTagEntries.length > 0}
+          {#each visibleTagEntries as [tag, nodes] (tag)}
+            <button
+              class="MenuRow TagRow"
+              class:Selected={$active_tag === tag}
+              use:ripple
+              on:click={() => ($active_tag = $active_tag === tag ? null : tag)}
+            >
+              <span class="TagRowMark">#</span>
+              <span class="TextOverFlow">{tag}</span>
+              <span class="TagBadge">{nodes.size}</span>
+            </button>
+          {/each}
+        {:else if $tag_index.size > 0}
+          <div class="MenuRow EmptyTagRow">
+            <span class="TagRowMark">#</span>
+            <span class="TextOverFlow">No matches</span>
+          </div>
+        {:else}
+          <div class="MenuRow EmptyTagRow">
+            <span class="TagRowMark">#</span>
+            <span class="TextOverFlow">No tags</span>
+          </div>
+        {/if}
+      </div>
+    {/if}
   </div>
-  {#if tagsExpanded}
-    <div class="TagContents" transition:slide={{ duration: 100 }}>
-      {#if $tag_index.size > 0}
-        {#each [...$tag_index.entries()].sort( ([a], [b]) => a.localeCompare(b) ) as [tag, nodes] (tag)}
-          <button
-            class="MenuRow"
-            class:Selected={$active_tag === tag}
-            use:ripple
-            on:click={() => ($active_tag = $active_tag === tag ? null : tag)}
-          >
-            <div class="TreeLine" style="flex-shrink: 0"></div>
-            <span class="TextOverFlow">{tag}</span>
-            <span class="TagBadge">{nodes.size}</span>
-          </button>
-        {/each}
-      {:else}
-        <div class="MenuRow EmptyTagRow">
-          <div class="TreeLine" style="flex-shrink: 0"></div>
-          <span class="TextOverFlow">No tags</span>
-        </div>
-      {/if}
-    </div>
-  {/if}
 </div>
 <Dialog
   show={show_confirm}
@@ -680,26 +702,144 @@
   .NoWorkspace:hover {
     text-decoration: underline;
   }
-  .TagLogo {
+  .TagBrowser {
+    display: flex;
+    flex-direction: column;
+    gap: 0.45rem;
+    margin: 0.75rem 0.5rem 0.5rem;
+    padding: 0.55rem;
+    border: 1px solid rgba(255, 255, 255, 0.08);
+    border-radius: 8px;
+    background-color: rgba(255, 255, 255, 0.045);
+  }
+  .TagHeader {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 0.5rem;
+    min-width: 0;
+  }
+  .TagTitle {
+    display: flex;
+    align-items: center;
+    gap: 0.6rem;
+    min-width: 0;
+    color: white;
+  }
+  .TagLogo,
+  .TagRowMark {
     display: inline-flex;
     align-items: center;
     justify-content: center;
-    width: 1.5rem;
-    height: 1.5rem;
-    margin-right: 1rem;
-    color: white;
-    font-weight: bold;
-    font-size: 1.1rem;
     flex-shrink: 0;
+    font-weight: 700;
+  }
+  .TagLogo {
+    width: 1.7rem;
+    height: 1.7rem;
+    border-radius: 8px;
+    color: var(--theme-color-Accent-main);
+    background-color: rgba(255, 255, 255, 0.08);
+    font-size: 1rem;
+  }
+  .TagTitleText {
+    display: flex;
+    flex-direction: column;
+    gap: 0.15rem;
+    min-width: 0;
+    font-size: 0.86rem;
+    font-weight: 700;
+  }
+  .TagScope {
+    color: rgba(255, 255, 255, 0.58);
+    font-size: 0.68rem;
+    font-weight: 600;
+    line-height: 1;
+  }
+  .TagToggle {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    width: 1.9rem;
+    height: 1.9rem;
+    border: none;
+    border-radius: 999px;
+    color: rgba(255, 255, 255, 0.76);
+    background-color: rgba(255, 255, 255, 0.08);
+    cursor: pointer;
+    flex-shrink: 0;
+  }
+  .TagToggle:hover,
+  .TagToggle:focus-visible {
+    color: white;
+    background-color: rgba(255, 255, 255, 0.16);
+  }
+  .TagToggle svg,
+  .TagSearch svg {
+    width: 1rem;
+    height: 1rem;
+  }
+  .TagToggle path,
+  .TagSearch path {
+    fill: none;
+    stroke: currentColor;
+    stroke-width: 2;
+    stroke-linecap: round;
+    stroke-linejoin: round;
   }
   .TagContents {
     display: flex;
     flex-direction: column;
+    gap: 0.25rem;
     width: 100%;
-    max-height: 30%;
+    max-height: 32%;
     overflow-y: auto;
   }
+  .TagSearch {
+    display: flex;
+    align-items: center;
+    gap: 0.45rem;
+    min-height: 2rem;
+    margin-bottom: 0.25rem;
+    padding: 0 0.55rem;
+    border: 1px solid rgba(255, 255, 255, 0.13);
+    border-radius: 8px;
+    color: rgba(255, 255, 255, 0.58);
+    background-color: rgba(0, 0, 0, 0.14);
+  }
+  .TagSearch:focus-within {
+    border-color: var(--theme-color-Accent-main);
+    color: white;
+    box-shadow: inset 0 0 0 1px var(--theme-color-Accent-main);
+  }
+  .TagSearch input {
+    min-width: 0;
+    width: 100%;
+    border: none;
+    outline: none;
+    color: white;
+    background: transparent;
+    font-size: 0.78rem;
+  }
+  .TagSearch input::placeholder {
+    color: rgba(255, 255, 255, 0.44);
+  }
+  .TagRow {
+    gap: 0.55rem;
+    min-height: 2rem;
+    padding: 0 0.45rem;
+    border-radius: 8px;
+  }
+  .TagRowMark {
+    width: 1.35rem;
+    height: 1.35rem;
+    border-radius: 999px;
+    color: var(--theme-color-Accent-main);
+    background-color: rgba(255, 255, 255, 0.07);
+    font-size: 0.74rem;
+  }
   .EmptyTagRow {
+    gap: 0.55rem;
     color: rgba(255, 255, 255, 0.55);
     cursor: default;
   }
@@ -710,10 +850,18 @@
     display: none;
   }
   .TagBadge {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    min-width: 1.45rem;
+    height: 1.25rem;
     margin-left: auto;
-    margin-right: 0.5rem;
-    font-size: 0.7rem;
-    color: rgba(255, 255, 255, 0.6);
+    padding: 0 0.35rem;
+    border-radius: 999px;
+    font-size: 0.68rem;
+    font-weight: 700;
+    color: rgba(255, 255, 255, 0.7);
+    background-color: rgba(255, 255, 255, 0.08);
     flex-shrink: 0;
   }
 </style>

--- a/src/components/MenuList.svelte
+++ b/src/components/MenuList.svelte
@@ -449,44 +449,44 @@
   {/if}
 
   <!-- Tag browser -->
-  {#if $tag_index.size > 0}
-    <br />
-    <div class="Section">
-      <span class="TagLogo">#</span>
-      <span class="TextOverFlow">Tags</span>
-      <div class="AddButtonContainer">
-        <IconButton
-          ariaLabel="Toggle tags section"
-          normalColor="rgba(255,255,255,0.1)"
-          activeColor="rgba(255,255,255,0.2)"
-          on:click={() => (tagsExpanded = !tagsExpanded)}
-        >
-          {#if tagsExpanded}
-            <svg viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
-              <path
-                d="M18 15L12 9L6 15"
-                stroke="white"
-                stroke-width="2"
-                stroke-linecap="round"
-                stroke-linejoin="round"
-              />
-            </svg>
-          {:else}
-            <svg viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
-              <path
-                d="M6 9L12 15L18 9"
-                stroke="white"
-                stroke-width="2"
-                stroke-linecap="round"
-                stroke-linejoin="round"
-              />
-            </svg>
-          {/if}
-        </IconButton>
-      </div>
+  <br />
+  <div class="Section">
+    <span class="TagLogo">#</span>
+    <span class="TextOverFlow">Tags</span>
+    <div class="AddButtonContainer">
+      <IconButton
+        ariaLabel="Toggle tags section"
+        normalColor="rgba(255,255,255,0.1)"
+        activeColor="rgba(255,255,255,0.2)"
+        on:click={() => (tagsExpanded = !tagsExpanded)}
+      >
+        {#if tagsExpanded}
+          <svg viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
+            <path
+              d="M18 15L12 9L6 15"
+              stroke="white"
+              stroke-width="2"
+              stroke-linecap="round"
+              stroke-linejoin="round"
+            />
+          </svg>
+        {:else}
+          <svg viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
+            <path
+              d="M6 9L12 15L18 9"
+              stroke="white"
+              stroke-width="2"
+              stroke-linecap="round"
+              stroke-linejoin="round"
+            />
+          </svg>
+        {/if}
+      </IconButton>
     </div>
-    {#if tagsExpanded}
-      <div class="TagContents" transition:slide={{ duration: 100 }}>
+  </div>
+  {#if tagsExpanded}
+    <div class="TagContents" transition:slide={{ duration: 100 }}>
+      {#if $tag_index.size > 0}
         {#each [...$tag_index.entries()].sort( ([a], [b]) => a.localeCompare(b) ) as [tag, nodes] (tag)}
           <button
             class="MenuRow"
@@ -499,8 +499,13 @@
             <span class="TagBadge">{nodes.size}</span>
           </button>
         {/each}
-      </div>
-    {/if}
+      {:else}
+        <div class="MenuRow EmptyTagRow">
+          <div class="TreeLine" style="flex-shrink: 0"></div>
+          <span class="TextOverFlow">No tags</span>
+        </div>
+      {/if}
+    </div>
   {/if}
 </div>
 <Dialog
@@ -693,6 +698,16 @@
     width: 100%;
     max-height: 30%;
     overflow-y: auto;
+  }
+  .EmptyTagRow {
+    color: rgba(255, 255, 255, 0.55);
+    cursor: default;
+  }
+  .EmptyTagRow:hover {
+    background-color: transparent;
+  }
+  .EmptyTagRow:hover::before {
+    display: none;
   }
   .TagBadge {
     margin-left: auto;

--- a/src/components/Pane.svelte
+++ b/src/components/Pane.svelte
@@ -17,5 +17,13 @@
     justify-content: center;
     overflow: auto;
     min-width: 2rem;
+    padding: 0;
+  }
+
+  .Pane:has(> :global(.Card)) {
+    align-items: stretch;
+    justify-content: stretch;
+    overflow: hidden;
+    padding: 1rem;
   }
 </style>

--- a/src/components/ProjectPage.svelte
+++ b/src/components/ProjectPage.svelte
@@ -99,8 +99,9 @@
 {#if $tree_data}
   <div class:Content={true}>
     <SplitPanes defaultRatio={detailPaneVisible ? [3, 2] : [1]}>
-      <Pane style={"padding: 1rem; min-width: 10rem;"}>
+      <Pane style={"min-width: 10rem;"}>
         <Card style={"height: 100%; width: 100%; padding: 1rem;"}>
+          <div class="PaneTitle">Task Tree</div>
           <div class="TaskListToolbar">
             <div class:TableButtons={true}>
               <IconButton
@@ -245,12 +246,10 @@
         </Card>
       </Pane>
       {#if detailPaneVisible}
-        <Pane style={"padding: 1rem; min-width: 10rem;"}>
-          <Card style={"height: 100%; width: 100%;"}>
-            <div class:TaskDetail={true}>
-              <TaskDetail />
-            </div>
-          </Card>
+        <Pane style={"min-width: 10rem;"}>
+          <div class:TaskDetail={true}>
+            <TaskDetail />
+          </div>
         </Pane>
       {/if}
     </SplitPanes>
@@ -320,6 +319,21 @@
     box-sizing: border-box;
     flex-wrap: wrap;
   }
+  .PaneTitle {
+    display: flex;
+    align-items: center;
+    min-height: 2rem;
+    padding: 0 0.75rem;
+    border-left: 0.25rem solid var(--theme-color-Accent-main);
+    border-radius: 6px;
+    color: var(--theme-color-Sub-light);
+    background-color: color-mix(in srgb, var(--theme-color-Sub-dark) 12%, transparent);
+    font-size: 1.15rem;
+    font-weight: 700;
+    line-height: 1;
+    letter-spacing: 0;
+    flex: 0 0 auto;
+  }
   .TreeAndGantt {
     height: 100%;
     width: 100%;
@@ -355,10 +369,12 @@
     background: rgba(128, 128, 128, 0.5);
   }
   div.TaskDetail {
-    height: calc(100% - 2rem);
-    width: calc(100% - 2rem);
+    flex: 1;
+    min-height: 0;
+    height: 100%;
+    width: 100%;
     box-sizing: border-box;
-    margin: 1rem;
+    margin: 0;
   }
 
   @media (max-width: 760px) {

--- a/src/components/SplitPanes.svelte
+++ b/src/components/SplitPanes.svelte
@@ -2,6 +2,7 @@
   import { onDestroy, onMount } from "svelte";
 
   export let defaultRatio = [];
+  export let direction = "horizontal";
 
   let split_pane_root; // Bind
 
@@ -13,7 +14,13 @@
   let paneCount = 0;
 
   // Min width
-  let minWidth;
+  let minWidth = "auto";
+  let minHeight = "auto";
+
+  $: isVertical = direction === "vertical";
+  $: primaryDimension = isVertical ? "height" : "width";
+  $: primaryClient = isVertical ? "clientY" : "clientX";
+  $: primaryCursor = isVertical ? "row-resize" : "col-resize";
 
   onMount(() => {
     refreshLayout();
@@ -48,7 +55,8 @@
     const panes = [...split_pane_root.querySelectorAll(":scope > .Pane")];
     const canPreserveWidths = preserveWidths && panes.length === paneCount;
     paneCount = panes.length;
-    minWidth = `${4 * panes.length}rem`; // magic number 4rem.
+    minWidth = isVertical ? "0" : `${4 * panes.length}rem`; // magic number 4rem.
+    minHeight = isVertical ? `${4 * panes.length}rem` : "0";
 
     if (!panes.length) {
       resize_observer?.disconnect();
@@ -56,24 +64,24 @@
       return;
     }
 
-    const rootWidth = split_pane_root.getBoundingClientRect().width;
-    const widths = getPaneWidths(panes, rootWidth, canPreserveWidths);
+    const rootSize = split_pane_root.getBoundingClientRect()[primaryDimension];
+    const sizes = getPaneSizes(panes, rootSize, canPreserveWidths);
 
     panes.forEach((pane, index) => {
-      pane.style.width = `${widths[index]}px`;
+      pane.style[primaryDimension] = `${sizes[index]}px`;
     });
 
-    resizers = createResizers(panes, widths);
+    resizers = createResizers(panes, sizes);
     handlers = setResizersEvents(resizers, panes);
     observeRootResize(panes);
   };
 
-  const getPaneWidths = (panes, rootWidth, preserveWidths) => {
+  const getPaneSizes = (panes, rootSize, preserveWidths) => {
     if (preserveWidths) {
-      const currentWidths = panes.map((pane) => pane.getBoundingClientRect().width);
-      const currentTotal = currentWidths.reduce((partialSum, width) => partialSum + width, 0);
+      const currentSizes = panes.map((pane) => pane.getBoundingClientRect()[primaryDimension]);
+      const currentTotal = currentSizes.reduce((partialSum, size) => partialSum + size, 0);
       if (currentTotal > 0) {
-        return currentWidths.map((width) => (width * rootWidth) / currentTotal);
+        return currentSizes.map((size) => (size * rootSize) / currentTotal);
       }
     }
 
@@ -84,12 +92,12 @@
       ratios = ratios.slice(0, panes.length);
     }
     const ratioSum = ratios.reduce((partialSum, ratio) => partialSum + ratio, 0) || panes.length;
-    return ratios.map((ratio) => (rootWidth * ratio) / ratioSum);
+    return ratios.map((ratio) => (rootSize * ratio) / ratioSum);
   };
 
-  const createResizers = (panes, paneWidths) => {
+  const createResizers = (panes, paneSizes) => {
     const nextResizers = [];
-    let left = 0;
+    let offset = 0;
 
     panes.forEach((pane, index) => {
       if (index == 0) {
@@ -97,8 +105,8 @@
       }
       const resizer = document.createElement("div");
       resizer.classList.add("Resizer");
-      resizer.style.left = `${left + paneWidths[index - 1] - 3}px`;
-      left += paneWidths[index - 1];
+      resizer.style[isVertical ? "top" : "left"] = `${offset + paneSizes[index - 1] - 3}px`;
+      offset += paneSizes[index - 1];
       pane.parentNode.insertBefore(resizer, pane);
       nextResizers.push(resizer);
     });
@@ -108,27 +116,32 @@
 
   const observeRootResize = (panes) => {
     resize_observer?.disconnect();
+    if (typeof ResizeObserver === "undefined") {
+      return;
+    }
     resize_observer = new ResizeObserver((entries) => {
-      // Width setting
-      let root_width = 0;
+      // Primary-size setting
+      let root_size = 0;
       panes.forEach((pane) => {
-        root_width += pane.getBoundingClientRect().width;
+        root_size += pane.getBoundingClientRect()[primaryDimension];
       });
-      if (root_width === 0) {
+      if (root_size === 0) {
         return;
       }
-      let new_root_width = entries[0].contentRect.width;
-      let new_pane_widths = [];
+      let new_root_size = entries[0].contentRect[primaryDimension];
+      let new_pane_sizes = [];
       panes.forEach((pane) => {
-        new_pane_widths.push((pane.getBoundingClientRect().width * new_root_width) / root_width);
+        new_pane_sizes.push(
+          (pane.getBoundingClientRect()[primaryDimension] * new_root_size) / root_size
+        );
       });
       panes.forEach((pane, index) => {
-        pane.style.width = `${new_pane_widths[index]}px`;
+        pane.style[primaryDimension] = `${new_pane_sizes[index]}px`;
       });
-      let left = 0;
+      let offset = 0;
       resizers.forEach((resizer, index) => {
-        resizer.style.left = `${left + new_pane_widths[index] - 3}px`;
-        left += new_pane_widths[index];
+        resizer.style[isVertical ? "top" : "left"] = `${offset + new_pane_sizes[index] - 3}px`;
+        offset += new_pane_sizes[index];
       });
     });
     resize_observer.observe(split_pane_root);
@@ -142,39 +155,44 @@
       const pane_r = panes[i + 1];
       const resizer = resizers[i];
 
-      const style_min_w = window.getComputedStyle(pane).minWidth;
+      const minProperty = isVertical ? "minHeight" : "minWidth";
+      const style_min_w = window.getComputedStyle(pane)[minProperty];
       const min_w = style_min_w.includes("%")
-        ? (parseFloat(window.getComputedStyle(pane).minWidth, 10) / 100) *
-          split_pane_root.getBoundingClientRect().width
-        : parseFloat(window.getComputedStyle(pane).minWidth, 10) || 10;
-      const style_min_wr = window.getComputedStyle(pane_r).minWidth;
+        ? (parseFloat(style_min_w, 10) / 100) *
+          split_pane_root.getBoundingClientRect()[primaryDimension]
+        : parseFloat(style_min_w, 10) || 10;
+      const style_min_wr = window.getComputedStyle(pane_r)[minProperty];
       const min_wr = style_min_wr.includes("%")
-        ? (parseFloat(window.getComputedStyle(pane_r).minWidth, 10) / 100) *
-          split_pane_root.getBoundingClientRect().width
-        : parseFloat(window.getComputedStyle(pane_r).minWidth, 10) || 10;
+        ? (parseFloat(style_min_wr, 10) / 100) *
+          split_pane_root.getBoundingClientRect()[primaryDimension]
+        : parseFloat(style_min_wr, 10) || 10;
 
       // Track the current position of mouse
-      let x = 0;
-      let w = 0;
-      let wr = 0;
-      let l = 0;
+      let startPointer = 0;
+      let size = 0;
+      let sizeR = 0;
+      let resizerOffset = 0;
 
       const mouseDownHandler = function (e) {
         let cssText = document.body.style.cssText;
-        document.body.style.cssText = cssText + "cursor: col-resize !important;";
+        document.body.style.cssText = cssText + `cursor: ${primaryCursor} !important;`;
 
         // Add HandlingResizer class
         resizer.classList.add("HandlingResizer");
 
         // Get the current mouse position
-        x = e.clientX;
+        startPointer = e[primaryClient];
 
-        // Calculate the current width of column
-        w = pane.getBoundingClientRect().width;
-        wr = pane_r.getBoundingClientRect().width;
+        // Calculate the current size of pane
+        size = pane.getBoundingClientRect()[primaryDimension];
+        sizeR = pane_r.getBoundingClientRect()[primaryDimension];
 
-        // Calculate the curent left of resizer
-        l = resizer.getBoundingClientRect().left - resizer.parentNode.getBoundingClientRect().left;
+        // Calculate the current offset of resizer
+        const resizerRect = resizer.getBoundingClientRect();
+        const parentRect = resizer.parentNode.getBoundingClientRect();
+        resizerOffset = isVertical
+          ? resizerRect.top - parentRect.top
+          : resizerRect.left - parentRect.left;
 
         // Attach listeners for document's events
         document.addEventListener("mousemove", mouseMoveHandler);
@@ -183,27 +201,27 @@
 
       const mouseMoveHandler = function (e) {
         // Determine how far the mouse has been moved
-        let dx = e.clientX - x;
-        let new_width = w + dx;
-        let new_widthr = wr - dx;
+        let delta = e[primaryClient] - startPointer;
+        let newSize = size + delta;
+        let newSizeR = sizeR - delta;
 
-        if (new_width < min_w) {
-          new_widthr = w + wr - min_w;
-          new_width = min_w;
-          dx = new_width - w;
+        if (newSize < min_w) {
+          newSizeR = size + sizeR - min_w;
+          newSize = min_w;
+          delta = newSize - size;
         }
-        if (new_widthr < min_wr) {
-          new_width = w + wr - min_wr;
-          new_widthr = min_wr;
-          dx = new_width - w;
+        if (newSizeR < min_wr) {
+          newSize = size + sizeR - min_wr;
+          newSizeR = min_wr;
+          delta = newSize - size;
         }
 
-        // Update the width of column
-        pane.style.width = `${new_width}px`;
-        pane_r.style.width = `${new_widthr}px`;
+        // Update the size of pane
+        pane.style[primaryDimension] = `${newSize}px`;
+        pane_r.style[primaryDimension] = `${newSizeR}px`;
 
         // Update resizer pos
-        resizer.style.left = `${l + dx}px`;
+        resizer.style[isVertical ? "top" : "left"] = `${resizerOffset + delta}px`;
       };
 
       // When user releases the mouse, remove the existing event listeners
@@ -232,7 +250,12 @@
   };
 </script>
 
-<div bind:this={split_pane_root} class:SplitPaneRoot={true} style="--minWidth: {minWidth}">
+<div
+  bind:this={split_pane_root}
+  class:SplitPaneRoot={true}
+  class:Vertical={isVertical}
+  style="--minWidth: {minWidth}; --minHeight: {minHeight}"
+>
   <slot />
 </div>
 
@@ -243,7 +266,11 @@
     width: 100%;
     height: 100%;
     min-width: var(--minWidth);
+    min-height: var(--minHeight);
     position: relative;
+  }
+  .SplitPaneRoot.Vertical {
+    flex-direction: column;
   }
   .SplitPaneRoot > :global(.Resizer) {
     position: absolute;
@@ -255,6 +282,14 @@
     user-select: none;
     z-index: 999;
   }
+  .SplitPaneRoot.Vertical > :global(.Resizer) {
+    top: auto;
+    left: 0;
+    right: 0;
+    width: 100%;
+    height: 5px;
+    cursor: row-resize;
+  }
   .SplitPaneRoot > :global(.Resizer::before) {
     content: "";
     position: absolute;
@@ -265,6 +300,12 @@
     background-color: color-mix(in srgb, var(--theme-color-Sub-dark) 28%, transparent);
     opacity: 0.7;
   }
+  .SplitPaneRoot.Vertical > :global(.Resizer::before) {
+    top: 2px;
+    left: 0;
+    width: 100%;
+    height: 1px;
+  }
   .SplitPaneRoot > :global(.HandlingResizer),
   .SplitPaneRoot > :global(.Resizer:hover) {
     background-color: transparent;
@@ -274,5 +315,10 @@
     width: 2px;
     background-color: var(--theme-color-Accent-main);
     opacity: 0.9;
+  }
+  .SplitPaneRoot.Vertical > :global(.HandlingResizer::before),
+  .SplitPaneRoot.Vertical > :global(.Resizer:hover::before) {
+    width: 100%;
+    height: 2px;
   }
 </style>

--- a/src/components/StatusSelect.svelte
+++ b/src/components/StatusSelect.svelte
@@ -2,6 +2,7 @@
   import Select from "./Select.svelte";
 
   export let status = "Open";
+  export let style = "height: 1.5rem;";
 
   const color_map = {
     Open: "var(--theme-color-Sub-light)",
@@ -65,7 +66,7 @@
     >
   {/if}
   <Select
-    style="height: 1.5rem;"
+    {style}
     backgroundColor="var(--backgroundColor)"
     color={color_map[status]}
     id="status"

--- a/src/components/TaskDetail.svelte
+++ b/src/components/TaskDetail.svelte
@@ -119,7 +119,7 @@
     const updatedMemo = [...node.data["memo"]];
     updatedMemo[selectedMemoIndex] = { ...updatedMemo[selectedMemoIndex], tags };
     node.data["memo"] = updatedMemo;
-    changeDataDebounce(node, "memo", updatedMemo, editContext);
+    changeData(node, "memo", updatedMemo, editContext);
   };
 </script>
 

--- a/src/components/TaskDetail.svelte
+++ b/src/components/TaskDetail.svelte
@@ -9,10 +9,16 @@
     selected_id,
     workspace_store,
     tag_index,
+    theme,
   } from "../stores.ts";
   import { debounce } from "lodash";
   import { onDestroy } from "svelte";
   import MemoTab from "./MemoTab.svelte";
+  import SplitPanes from "./SplitPanes.svelte";
+  import Pane from "./Pane.svelte";
+  import Card from "./Card.svelte";
+  import StatusSelect from "./StatusSelect.svelte";
+  import DateInput from "./DateInput.svelte";
 
   $: is_selected = $table_selected_id ? true : false;
   $: node =
@@ -21,6 +27,11 @@
   $: memo = node ? node.data["memo"] : [];
   $: isWorkspaceProject = $selected_type === "WorkspaceProject";
   $: workspaceProjectDir = isWorkspaceProject ? $workspace_store.activeProjectDir : null;
+  $: memoType = isWorkspaceProject ? "Markdown" : "Quill";
+  $: isDark = $theme === "dark";
+
+  const detailDateStyle =
+    "border: 0; padding: 0 2rem 0 0.45rem; font-size: 1rem; background-color: transparent;";
 
   const getEditContext = () => ({
     selectedType: $selected_type,
@@ -121,30 +132,151 @@
     node.data["memo"] = updatedMemo;
     changeData(node, "memo", updatedMemo, editContext);
   };
+
+  const changeTaskField = (key, value, debounceChange = false) => {
+    if (!node) {
+      return;
+    }
+
+    const editContext = getEditContext();
+    node.data[key] = value;
+    if (debounceChange) {
+      changeDataDebounce(node, key, value, editContext);
+    } else {
+      changeData(node, key, value, editContext);
+    }
+  };
+
+  const handleNameInput = (event) => {
+    changeTaskField("name", event.target.value, true);
+  };
+
+  const flushNameChange = () => {
+    changeDataDebounce.flush?.();
+  };
 </script>
 
 <div class="container">
-  <div class="memotab-container">
-    {#if is_selected}
-      <MemoTab
-        {memo}
-        {saveMemo}
-        {addMemo}
-        {deleteMemo}
-        {renameMemo}
-        {reorderMemo}
-        {saveMemoTags}
-        {allTags}
-        {isWorkspaceProject}
-        {workspaceProjectDir}
-        taskId={$table_selected_id ?? null}
-      />
-    {:else}
-      <h1 style="color:var(--theme-color-Sub-main); display:flex; justify-content:center">
-        No data.
-      </h1>
-    {/if}
-  </div>
+  {#if is_selected && node}
+    <SplitPanes direction="vertical" defaultRatio={[1, 4]}>
+      <Pane
+        style={"width: 100%; min-height: 9rem; overflow: hidden; align-items: stretch; justify-content: stretch;"}
+      >
+        <Card style={"height: 100%; width: 100%; padding: 0.75rem; gap: 0.5rem; overflow: hidden;"}>
+          <div class="PaneTitle">Task Detail</div>
+          <div class="detail-container">
+            <label class="detail-field">
+              <span>Name</span>
+              <div class="detail-control">
+                <input
+                  class="detail-input"
+                  type="text"
+                  value={name}
+                  aria-label="Task name"
+                  on:input={handleNameInput}
+                  on:blur={flushNameChange}
+                />
+              </div>
+            </label>
+
+            <label class="detail-field">
+              <span>Status</span>
+              <div class="detail-control">
+                <StatusSelect
+                  status={node.data.status ?? "Open"}
+                  style="height: 100%; font-size: 1rem;"
+                  on:change={(event) => changeTaskField("status", event.target.value)}
+                />
+              </div>
+            </label>
+
+            <label class="detail-field">
+              <span>Start Date</span>
+              <div class="detail-control">
+                <DateInput
+                  is_dark={isDark}
+                  id="detail-start-date"
+                  backgroundColor={"var(--theme-color-Main-light)"}
+                  style={detailDateStyle}
+                  value={node.data["start date"] ?? ""}
+                  on:change={(event) =>
+                    changeTaskField("start date", event.target.value || undefined)}
+                />
+              </div>
+            </label>
+
+            <label class="detail-field">
+              <span>Due Date</span>
+              <div class="detail-control">
+                <DateInput
+                  is_dark={isDark}
+                  id="detail-due-date"
+                  backgroundColor={"var(--theme-color-Main-light)"}
+                  style={detailDateStyle}
+                  value={node.data["due date"] ?? ""}
+                  on:change={(event) =>
+                    changeTaskField("due date", event.target.value || undefined)}
+                />
+              </div>
+            </label>
+
+            <label class="detail-field">
+              <span>memo数</span>
+              <div class="detail-control">
+                <input
+                  class="detail-input"
+                  type="number"
+                  value={memo.length}
+                  aria-label="Memo count"
+                  readonly
+                />
+              </div>
+            </label>
+
+            <label class="detail-field">
+              <span>memo type</span>
+              <div class="detail-control">
+                <input
+                  class="detail-input"
+                  type="text"
+                  value={memoType}
+                  aria-label="Memo type"
+                  readonly
+                />
+              </div>
+            </label>
+          </div>
+        </Card>
+      </Pane>
+
+      <Pane
+        style={"width: 100%; min-height: 18rem; overflow: hidden; align-items: stretch; justify-content: stretch;"}
+      >
+        <Card style={"height: 100%; width: 100%; padding: 1rem; gap: 0.75rem; overflow: hidden;"}>
+          <div class="PaneTitle">Memo</div>
+          <div class="memotab-container">
+            <MemoTab
+              {memo}
+              {saveMemo}
+              {addMemo}
+              {deleteMemo}
+              {renameMemo}
+              {reorderMemo}
+              {saveMemoTags}
+              {allTags}
+              {isWorkspaceProject}
+              {workspaceProjectDir}
+              taskId={$table_selected_id ?? null}
+            />
+          </div>
+        </Card>
+      </Pane>
+    </SplitPanes>
+  {:else}
+    <h1 style="color:var(--theme-color-Sub-main); display:flex; justify-content:center">
+      No data.
+    </h1>
+  {/if}
 </div>
 
 <style>
@@ -157,12 +289,106 @@
     display: flex;
     flex-direction: column;
   }
-  .memotab-container {
-    width: 100%;
+  .detail-container {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(13rem, 1fr));
+    align-content: start;
+    gap: 0.4rem 0.6rem;
     flex: 1;
-    height: calc(100% - 3.5rem);
+    width: 100%;
+    min-height: 0;
+    box-sizing: border-box;
+    padding: 0;
+    overflow: auto;
+  }
+  .PaneTitle {
+    display: flex;
+    align-items: center;
+    min-height: 2rem;
+    padding: 0 0.75rem;
+    border-left: 0.25rem solid var(--theme-color-Accent-main);
+    border-radius: 6px;
+    color: var(--theme-color-Sub-light);
+    background-color: color-mix(in srgb, var(--theme-color-Sub-dark) 12%, transparent);
+    font-size: 1.15rem;
+    font-weight: 700;
+    line-height: 1;
+    letter-spacing: 0;
+    flex: 0 0 auto;
+  }
+  .detail-field {
+    display: flex;
+    align-items: center;
+    gap: 0.5rem;
+    min-width: 0;
+    color: var(--theme-color-Sub-main);
+    font-size: 1rem;
+    font-weight: 700;
+  }
+  .detail-field > span {
+    flex: 0 0 5.3rem;
+    min-width: 0;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+    line-height: 1;
+  }
+  .detail-input {
+    width: 100%;
+    height: 100%;
+    box-sizing: border-box;
+    border: 0;
+    padding: 0 0.45rem;
+    color: var(--theme-color-Sub-light);
+    background-color: transparent;
+    font-size: 1rem;
+  }
+  .detail-input[readonly] {
+    color: var(--theme-color-Sub-main);
+  }
+  .detail-input:focus {
+    outline: auto;
+  }
+  .detail-control {
+    display: flex;
+    align-items: center;
+    flex: 1 1 auto;
+    min-width: 0;
+    height: 2rem;
+    box-sizing: border-box;
+    border: 1px solid color-mix(in srgb, var(--theme-color-Sub-main) 35%, transparent);
+    border-radius: 5px;
+    background-color: var(--theme-color-Main-light);
+    overflow: hidden;
+    --backgroundColor: var(--theme-color-Main-light);
+  }
+  .detail-control :global(.StatusContainer) {
+    gap: 0.35rem;
+    padding: 0 0.35rem;
+    box-sizing: border-box;
+  }
+  .detail-control :global(.StatusContainer svg) {
+    flex: 0 0 1.1rem;
+    width: 1.1rem;
+  }
+  .detail-control :global(.select select) {
+    font-size: 1rem;
+  }
+  .detail-control :global(.Date) {
+    font-size: 1rem;
+  }
+  .memotab-container {
+    flex: 1;
+    width: 100%;
+    min-height: 0;
     box-sizing: border-box;
     margin: 0;
     padding: 0;
+    overflow: hidden;
+  }
+  @media (max-width: 760px) {
+    .detail-container {
+      grid-template-columns: 1fr;
+    }
   }
 </style>

--- a/src/stores/tags.ts
+++ b/src/stores/tags.ts
@@ -1,12 +1,21 @@
-import { writable } from "svelte/store";
+import { get, writable } from "svelte/store";
 import { tree_data } from "./tree";
+import { selected_type } from "./ui";
 import type { TreeData } from "../common/tree_control";
+import type { SelectedType } from "../types/app";
 
 /** tag name (lowercase) → set of task node IDs that have a memo with this tag */
 export type TagIndex = Map<string, Set<string>>;
+export type MemoTagScope = "quill" | "markdown" | "none";
 
 export const tag_index = writable<TagIndex>(new Map());
 export const active_tag = writable<string | null>(null);
+
+export function memoTagScopeForSelectedType(selectedType: SelectedType): MemoTagScope {
+  if (selectedType === "WorkspaceProject") return "markdown";
+  if (selectedType === "Projects") return "quill";
+  return "none";
+}
 
 tree_data.subscribe((projectData) => {
   const index = new Map<string, Set<string>>();
@@ -26,4 +35,21 @@ tree_data.subscribe((projectData) => {
 
   walk(projectData?.data ? [projectData.data] : []);
   tag_index.set(index);
+});
+
+let currentTagScope: MemoTagScope | null = null;
+
+selected_type.subscribe((selectedType) => {
+  const nextScope = memoTagScopeForSelectedType(selectedType);
+  if (currentTagScope !== null && nextScope !== currentTagScope) {
+    active_tag.set(null);
+  }
+  currentTagScope = nextScope;
+});
+
+tag_index.subscribe((index) => {
+  const active = get(active_tag);
+  if (active && !index.has(active)) {
+    active_tag.set(null);
+  }
 });

--- a/tests/component/ButtonState.test.js
+++ b/tests/component/ButtonState.test.js
@@ -42,9 +42,11 @@ describe("button color reactivity", () => {
       },
     });
 
-    expect(container.querySelector("button").getAttribute("style")).toContain(
-      "--backgroundColor: gray"
+    const disabledStyle = container.querySelector("button").getAttribute("style");
+    expect(disabledStyle).toContain(
+      "--backgroundColor: color-mix(in srgb, var(--theme-color-Main-dark) 72%, var(--theme-color-Main-light))"
     );
+    expect(disabledStyle).toContain("--fontColor: var(--theme-color-Sub-main)");
 
     await rerender({
       disabled: false,

--- a/tests/component/Memo.test.js
+++ b/tests/component/Memo.test.js
@@ -202,6 +202,25 @@ describe("Markdown Memo - edit mode", () => {
     });
   });
 
+  test("lets the markdown editor and preview split be resized with the keyboard", async () => {
+    renderMarkdownMemo({ saveMemo, content: "hello" });
+    await fireEvent.click(document.querySelector(".edit-mode-btn"));
+    await waitFor(() => {
+      expect(document.querySelector(".markdown-split-resizer")).toBeInTheDocument();
+    });
+
+    const editBody = document.querySelector(".edit-body");
+    const resizer = document.querySelector(".markdown-split-resizer");
+
+    expect(editBody.getAttribute("style")).toContain("--editor-pane-width: 55%");
+
+    await fireEvent.keyDown(resizer, { key: "ArrowLeft" });
+    expect(editBody.getAttribute("style")).toContain("--editor-pane-width: 50%");
+
+    await fireEvent.keyDown(resizer, { key: "End" });
+    expect(editBody.getAttribute("style")).toContain("--editor-pane-width: 72%");
+  });
+
   test("clicking read mode switch returns to view mode", async () => {
     renderMarkdownMemo({ saveMemo, content: "hello" });
     await fireEvent.click(document.querySelector(".edit-mode-btn"));

--- a/tests/component/TaskDetail.test.js
+++ b/tests/component/TaskDetail.test.js
@@ -87,6 +87,36 @@ describe("TaskDetail", () => {
     expect(screen.getByText("Tabs here")).toBeInTheDocument();
     expect(screen.getByPlaceholderText("No page")).toBeInTheDocument();
     expect(screen.getByRole("button", { name: "Add a memo" })).toBeInTheDocument();
+    expect(screen.getByLabelText("Memo type")).toHaveValue("Quill");
+  });
+
+  test("edits task detail fields independent of visible table columns", async () => {
+    table_selected_id.set("task-1");
+    render(TaskDetail);
+
+    await fireEvent.input(screen.getByLabelText("Task name"), {
+      target: { value: "Updated Task" },
+    });
+    await fireEvent.blur(screen.getByLabelText("Task name"));
+    await tick();
+
+    await fireEvent.change(screen.getByLabelText("Status"), {
+      target: { value: "In Progress" },
+    });
+    await fireEvent.change(screen.getByLabelText("Start Date"), {
+      target: { value: "2026-06-01" },
+    });
+    await fireEvent.change(screen.getByLabelText("Due Date"), {
+      target: { value: "2026-06-10" },
+    });
+    await tick();
+
+    const task = get(tree_data).data.children[0].data;
+    expect(task.name).toBe("Updated Task");
+    expect(task.status).toBe("In Progress");
+    expect(task["start date"]).toBe("2026-06-01");
+    expect(task["due date"]).toBe("2026-06-10");
+    expect(screen.getByLabelText("Memo count")).toHaveValue(0);
   });
 
   test("adds a memo tab to the selected task", async () => {

--- a/tests/component/TaskDetail.test.js
+++ b/tests/component/TaskDetail.test.js
@@ -13,6 +13,7 @@ import {
   selected_id,
   selected_type,
   table_selected_id,
+  tag_index,
   tree_data,
   workspace_store,
 } from "../../src/stores.ts";
@@ -133,6 +134,20 @@ describe("TaskDetail", () => {
     expect(get(tree_data).data.children[0].data.memo).toEqual([
       expect.objectContaining({ title: "memo", content: "" }),
     ]);
+  });
+
+  test("saves memo tags immediately and updates the tag index", async () => {
+    table_selected_id.set("task-2");
+    render(TaskDetail);
+
+    const tagInput = document.querySelector(".tag-input");
+    await fireEvent.input(tagInput, { target: { value: "Design " } });
+    await fireEvent.keyDown(tagInput, { key: "Enter" });
+    await tick();
+
+    expect(get(tree_data).data.children[1].data.memo[0].tags).toEqual(["design"]);
+    expect(get(tag_index).get("design")).toEqual(new Set(["task-2"]));
+    expect(screen.getByLabelText("Remove tag design")).toBeInTheDocument();
   });
 
   test("resets the selected memo tab when the selected task changes", async () => {

--- a/tests/e2e/app.smoke.spec.js
+++ b/tests/e2e/app.smoke.spec.js
@@ -65,7 +65,7 @@ async function openTaskDetailWindow(
   }, detailData);
 
   const detailWindow = await detailWindowPromise;
-  await expect(detailWindow.getByText("Task Detail")).toBeVisible();
+  await expect(detailWindow.locator(".eyebrow")).toHaveText("Task Detail");
   await expect(detailWindow.getByRole("heading", { name: detailData.taskName })).toBeVisible();
 
   return detailWindow;

--- a/tests/unit/tags.test.js
+++ b/tests/unit/tags.test.js
@@ -1,0 +1,61 @@
+import { get } from "svelte/store";
+import { describe, expect, test, beforeEach } from "vitest";
+
+import { active_tag, tag_index } from "../../src/stores/tags.ts";
+import { selected_type } from "../../src/stores/ui.ts";
+import { tree_data } from "../../src/stores/tree.ts";
+
+function createProjectData(tags = ["design"]) {
+  return {
+    headers: [{ name: "name", default_ratio: 10 }],
+    data: {
+      id: "project-1",
+      data: {
+        name: "Sample Project",
+        status: "Open",
+        "due date": undefined,
+        memo: [],
+      },
+      children: [
+        {
+          id: "task-1",
+          data: {
+            name: "Task",
+            status: "Open",
+            "due date": undefined,
+            memo: [{ id: "memo-1", title: "Memo", content: "", tags }],
+          },
+          children: [],
+        },
+      ],
+    },
+  };
+}
+
+describe("tag stores", () => {
+  beforeEach(() => {
+    active_tag.set(null);
+    selected_type.set("Projects");
+    tree_data.set(createProjectData());
+  });
+
+  test("indexes memo tags by task id", () => {
+    expect(get(tag_index).get("design")).toEqual(new Set(["task-1"]));
+  });
+
+  test("clears the active tag when switching between Quill and Markdown scopes", () => {
+    active_tag.set("design");
+
+    selected_type.set("WorkspaceProject");
+
+    expect(get(active_tag)).toBeNull();
+  });
+
+  test("clears the active tag when it no longer exists in the current tag index", () => {
+    active_tag.set("design");
+
+    tree_data.set(createProjectData([]));
+
+    expect(get(active_tag)).toBeNull();
+  });
+});


### PR DESCRIPTION
## What changed

- Reworked the memo tag editor so tags wrap inside the field, the `# Tags` label stays compact, and the add action uses the shared icon button styling.
- Kept tag panels visually transparent and removed the special color treatment from the `#` mark.
- Added a dedicated Task Detail card with editable Name, Status, Start Date, Due Date, memo count, and memo type fields independent of visible tree columns.
- Split the right pane into separate Task Detail and Memo cards using vertical `SplitPanes`, while keeping Task Tree, Task Detail, and Memo visually at the same level.
- Extended `SplitPanes` to support vertical resizing and fixed the vertical split drag affordance so it highlights horizontally.
- Made `Pane` add a consistent 1rem inset around direct `Card` children, so Card spacing works generically for both horizontal and vertical splits.
- Normalized Task Detail control sizing, typography, and borders so text inputs, status, dates, and read-only fields look consistent.
- Improved disabled `IconButton` contrast so the Add Tag `+` remains visible even when the button is disabled, and updated the button state test for that behavior.
- Scoped the Task Detail window E2E selector so the new Task Detail pane title does not collide with the window eyebrow text.

## Why

Tags and the tag editor could overflow their container, and the disabled Add Tag button lost its visual meaning because the icon blended into the disabled background. The task detail panel also mixed inconsistent control sizes and borders, making it feel disconnected from the rest of the app.

The right-side layout now treats Task Tree, Task Detail, and Memo as separate cards with consistent spacing. The shared Pane/Card behavior keeps this spacing reusable instead of relying on one-off padding for each split direction.

## Validation

- `svelte-check --tsconfig ./tsconfig.json`
- `vitest run tests/component/Memo.test.js tests/component/TaskDetail.test.js tests/component/ProjectPage.test.js --pool=threads`
- `vitest run tests/component/TaskDetail.test.js tests/component/ProjectPage.test.js tests/component/SplitPanes.test.js --pool=threads`
- `vitest run tests/component/ButtonState.test.js tests/component/Memo.test.js tests/component/TaskDetail.test.js tests/component/ProjectPage.test.js --pool=threads`
- `prettier --check src/components/IconButton.svelte tests/component/ButtonState.test.js`
- `prettier --check tests/e2e/app.smoke.spec.js src/components/IconButton.svelte tests/component/ButtonState.test.js`
- `vite build`