### PR TITLE
feat(split-panes): mini placeholder Card instead of size-0 collapse

### DIFF
--- a/src/lib/layouts/SplitPanes.svelte
+++ b/src/lib/layouts/SplitPanes.svelte
@@ -131,7 +131,8 @@
       );
       const non_mini_size = panes.reduce(
         (sum, pane) =>
-          sum + (pane.classList.contains("PaneMini")
+          sum +
+          (pane.classList.contains("PaneMini")
             ? 0
             : pane.getBoundingClientRect()[primaryDimension]),
         0

--- a/src/lib/layouts/SplitPanes.svelte
+++ b/src/lib/layouts/SplitPanes.svelte
@@ -114,26 +114,41 @@
     return nextResizers;
   };
 
+  const MINI_PANE_SIZE = 64;
   const observeRootResize = (panes) => {
     resize_observer?.disconnect();
     if (typeof ResizeObserver === "undefined") {
       return;
     }
     resize_observer = new ResizeObserver((entries) => {
-      // Primary-size setting
-      let root_size = 0;
-      panes.forEach((pane) => {
-        root_size += pane.getBoundingClientRect()[primaryDimension];
-      });
-      if (root_size === 0) {
+      // Primary-size setting. Mini panes must keep their fixed MINI_PANE_SIZE
+      // — only non-mini panes share the remaining space proportionally,
+      // otherwise the placeholder Card would visibly shrink/grow with the
+      // container.
+      const mini_total = panes.reduce(
+        (sum, pane) => sum + (pane.classList.contains("PaneMini") ? MINI_PANE_SIZE : 0),
+        0
+      );
+      const non_mini_size = panes.reduce(
+        (sum, pane) =>
+          sum + (pane.classList.contains("PaneMini")
+            ? 0
+            : pane.getBoundingClientRect()[primaryDimension]),
+        0
+      );
+      const new_root_size = entries[0].contentRect[primaryDimension];
+      const non_mini_target = Math.max(0, new_root_size - mini_total);
+      if (non_mini_size === 0 && non_mini_target === 0) {
         return;
       }
-      let new_root_size = entries[0].contentRect[primaryDimension];
-      let new_pane_sizes = [];
-      panes.forEach((pane) => {
-        new_pane_sizes.push(
-          (pane.getBoundingClientRect()[primaryDimension] * new_root_size) / root_size
-        );
+      const new_pane_sizes = panes.map((pane) => {
+        if (pane.classList.contains("PaneMini")) {
+          return MINI_PANE_SIZE;
+        }
+        if (non_mini_size === 0) {
+          return non_mini_target / Math.max(1, panes.length - mini_total / MINI_PANE_SIZE);
+        }
+        return (pane.getBoundingClientRect()[primaryDimension] * non_mini_target) / non_mini_size;
       });
       panes.forEach((pane, index) => {
         pane.style[primaryDimension] = `${new_pane_sizes[index]}px`;
@@ -177,6 +192,11 @@
         let cssText = document.body.style.cssText;
         document.body.style.cssText = cssText + `cursor: ${primaryCursor} !important;`;
 
+        // Cancel any in-flight snap transition so the resizer tracks the cursor
+        // immediately without a lag from the previous mouseup animation.
+        pane.classList.remove("PaneSnapping");
+        pane_r.classList.remove("PaneSnapping");
+
         // Add HandlingResizer class
         resizer.classList.add("HandlingResizer");
 
@@ -199,34 +219,61 @@
         document.addEventListener("mouseup", mouseUpHandler);
       };
 
-      // Snap-to-collapse threshold. Per UX feedback the snap should only
-      // apply when the mouse is RELEASED below the threshold — during drag
-      // the user must be free to move past it without the pane sticking.
-      const closeThreshold = min_w * 0.6;
-      const closeThresholdR = min_wr * 0.6;
+      // Snap-to-mini: fixed pixel thresholds give a consistent feel across
+      // panes with different min sizes. Mini snap is only enabled when the
+      // pane's min size exceeds the threshold — otherwise the pane can
+      // naturally sit below the snap target and the deadzone disappears.
+      // Snap only applies on mouseup; during drag the user is free to
+      // move past the threshold without the pane sticking.
+      const SNAP_THRESHOLD = 80;
+      const enableMini = min_w > SNAP_THRESHOLD;
+      const enableMiniR = min_wr > SNAP_THRESHOLD;
 
-      // Helper: apply a (potentially zero) size to a pane, overriding the
-      // CSS min-width / min-height when the pane is being collapsed so the
-      // visual content actually disappears.
+      // Helper: apply a size to a pane.
+      // When mini=true the pane snaps to MINI_PANE_SIZE: its real content is
+      // hidden via inline style and a blank Card placeholder is injected.
+      // When mini=false (default, used during drag) real content is visible.
       const minPropertyKey = isVertical ? "minHeight" : "minWidth";
-      function applyPaneSize(p, sizeVal) {
+      function applyPaneSize(p, sizeVal, mini = false) {
+        // Safety: in mini mode the size is always MINI_PANE_SIZE — this
+        // protects against any caller (or stale ResizeObserver re-entry)
+        // accidentally passing the raw drag value instead.
+        if (mini) {
+          sizeVal = MINI_PANE_SIZE;
+        }
         p.style[primaryDimension] = `${sizeVal}px`;
-        if (sizeVal === 0) {
-          // Inline `min-*: 0` wins over the stylesheet-level `min-width: 10rem`
-          // declarations that pane consumers set. Without this, dragging to
-          // the edge would snap the resizer but the pane body stayed visible.
+        // Use :scope > to find ONLY the direct-child placeholder. Without
+        // this, nested SplitPanes would interfere: querying the outer pane
+        // would find the inner pane's placeholder and incorrectly skip
+        // creating its own (or wrongly delete the inner one on un-mini).
+        const directPlaceholder = p.querySelector(":scope > .PaneMiniPlaceholder");
+        if (mini) {
+          // Override CSS min-* so the pane can shrink below its declared minimum.
+          // Keep the pane's natural padding so the placeholder Card sits
+          // inside with the same breathing room a real Card would have.
           p.style[minPropertyKey] = "0px";
-          p.classList.add("PaneCollapsed");
+          p.classList.add("PaneMini");
+          if (!directPlaceholder) {
+            const placeholder = document.createElement("div");
+            placeholder.classList.add("PaneMiniPlaceholder");
+            p.appendChild(placeholder);
+          }
+          // Hide real children via inline style (CSS :global selectors can't
+          // reach grandchildren of SplitPaneRoot reliably).
+          for (const child of p.children) {
+            if (!child.classList.contains("PaneMiniPlaceholder")) {
+              child.style.display = "none";
+            }
+          }
         } else {
           p.style[minPropertyKey] = "";
-          p.classList.remove("PaneCollapsed");
+          p.classList.remove("PaneMini");
+          if (directPlaceholder) directPlaceholder.remove();
+          // Restore real children.
+          for (const child of p.children) {
+            child.style.display = "";
+          }
         }
-        // Toggle the wide-hit-area indicator on the resizer whenever either
-        // neighbouring pane is collapsed, so the user sees a clear handle
-        // for re-opening the hidden pane.
-        const eitherCollapsed =
-          pane.classList.contains("PaneCollapsed") || pane_r.classList.contains("PaneCollapsed");
-        resizer.classList.toggle("HasCollapsedNeighbour", eitherCollapsed);
       }
 
       // Track the pointer's raw desired size for each pane during a drag.
@@ -260,9 +307,9 @@
         resizer.style[isVertical ? "top" : "left"] = `${resizerOffset + (rawSize - size)}px`;
       };
 
-      // On mouseup: if the pointer ended below the snap threshold, collapse
-      // that pane to 0; otherwise clamp it to its declared min size so the
-      // configured minimum is still enforced as a resting state.
+      // On mouseup: if the pointer ended below the snap threshold, snap to
+      // MINI_PANE_SIZE and show the placeholder Card; otherwise clamp to the
+      // declared min size so the configured minimum is still enforced.
       const mouseUpHandler = function () {
         document.body.style.cursor = "";
         resizer.classList.remove("HandlingResizer");
@@ -271,25 +318,39 @@
 
         let finalSize = lastDesiredSize;
         let finalSizeR = lastDesiredSizeR;
+        let leftMini = false;
+        let rightMini = false;
 
-        if (finalSize < closeThreshold) {
-          finalSize = 0;
-          finalSizeR = size + sizeR;
+        if (enableMini && finalSize < SNAP_THRESHOLD) {
+          finalSize = MINI_PANE_SIZE;
+          finalSizeR = size + sizeR - MINI_PANE_SIZE;
+          leftMini = true;
         } else if (finalSize < min_w) {
           finalSize = min_w;
           finalSizeR = size + sizeR - min_w;
         }
-        if (finalSizeR < closeThresholdR) {
-          finalSizeR = 0;
-          finalSize = size + sizeR;
+        if (enableMiniR && finalSizeR < SNAP_THRESHOLD) {
+          finalSizeR = MINI_PANE_SIZE;
+          finalSize = size + sizeR - MINI_PANE_SIZE;
+          rightMini = true;
         } else if (finalSizeR < min_wr) {
           finalSizeR = min_wr;
           finalSize = size + sizeR - min_wr;
         }
 
-        applyPaneSize(pane, finalSize);
-        applyPaneSize(pane_r, finalSizeR);
+        // Enable snap transition for this release only, then remove it so
+        // subsequent drag moves are not slowed down.
+        pane.classList.add("PaneSnapping");
+        pane_r.classList.add("PaneSnapping");
+
+        applyPaneSize(pane, finalSize, leftMini);
+        applyPaneSize(pane_r, finalSizeR, rightMini);
         resizer.style[isVertical ? "top" : "left"] = `${resizerOffset + (finalSize - size)}px`;
+
+        setTimeout(() => {
+          pane.classList.remove("PaneSnapping");
+          pane_r.classList.remove("PaneSnapping");
+        }, 180);
       };
 
       resizer.addEventListener("mousedown", mouseDownHandler);
@@ -346,32 +407,6 @@
     width: 100%;
     height: 5px;
     cursor: row-resize;
-  }
-  /* Wider hit area when an adjacent pane has been collapsed: makes it
-     obvious that there's a hidden pane there, and gives the user a much
-     bigger grab target for re-opening it. */
-  .SplitPaneRoot > :global(.Resizer.HasCollapsedNeighbour) {
-    width: 14px;
-  }
-  .SplitPaneRoot.Vertical > :global(.Resizer.HasCollapsedNeighbour) {
-    width: 100%;
-    height: 14px;
-  }
-  .SplitPaneRoot > :global(.Resizer.HasCollapsedNeighbour::before) {
-    width: 6px;
-    background-color: var(--theme-color-Primary-main);
-    opacity: 0.9;
-  }
-  .SplitPaneRoot.Vertical > :global(.Resizer.HasCollapsedNeighbour::before) {
-    width: 100%;
-    height: 6px;
-  }
-  /* Tiny chevron-like hint inside the wide resizer to point toward the
-     hidden pane. We rotate via a CSS variable assigned from JS. */
-  .SplitPaneRoot > :global(.Resizer.HasCollapsedNeighbour::after) {
-    color: var(--theme-color-Main-light);
-    background-image: none;
-    opacity: 1;
   }
   .SplitPaneRoot > :global(.Resizer::before) {
     content: "";
@@ -437,8 +472,39 @@
     top: 0;
     left: 0;
   }
-  /* A collapsed pane has 0 size — kill its overflow so nothing leaks. */
-  .SplitPaneRoot > :global(.Pane.PaneCollapsed) {
+  /* Mini pane: overflow hidden so nothing bleeds out, and force padding so
+     the placeholder Card has breathing room regardless of whether the pane's
+     original child was a Card (which would have applied padding via :has). */
+  .SplitPaneRoot > :global(.Pane.PaneMini) {
     overflow: hidden;
+    padding: var(--sp4);
+  }
+
+  /* Blank Card placeholder injected when a pane enters mini state.
+     Styled as a Card header bar — the entire strip gets the CardHeader
+     blue-tinted background so it reads as "a collapsed card".
+     PaneMiniPlaceholder is a grandchild of SplitPaneRoot, so we use a
+     descendant combinator (space) instead of > to reach it. */
+  .SplitPaneRoot :global(.PaneMiniPlaceholder) {
+    width: 100%;
+    height: 100%;
+    background-color: color-mix(
+      in srgb,
+      var(--theme-color-Primary-main) 12%,
+      var(--theme-color-Main-main)
+    );
+    border: 1px solid color-mix(in srgb, var(--theme-color-Sub-main) 12%, transparent);
+    border-radius: var(--shape-sm);
+    box-shadow: var(--elevation-2);
+    box-sizing: border-box;
+  }
+
+  /* Snap transition — active only for the 180 ms after mouseup so the pane
+     glides to its resting position. Removed before the next drag starts. */
+  .SplitPaneRoot > :global(.Pane.PaneSnapping) {
+    transition: width 0.18s ease;
+  }
+  .SplitPaneRoot.Vertical > :global(.Pane.PaneSnapping) {
+    transition: height 0.18s ease;
   }
 </style>

--- a/tests/component/SplitPanes.test.js
+++ b/tests/component/SplitPanes.test.js
@@ -104,22 +104,25 @@ describe("SplitPanes", () => {
     expect(resizer.style.height).toBe("");
   });
 
-  test("snap-collapses the left pane when released below the threshold", async () => {
+  test("snap-collapses the left pane to mini size when released below the threshold", async () => {
     const { container } = render(SplitPanesHarness);
     await tick();
 
     const resizer = container.querySelector(".Resizer");
     const panes = getPanes(container);
     // Harness root is 400 wide, split 50/50 → both panes start at ~200px.
-    // The min-width is `4rem` (64px). The snap threshold is 64*0.6 = 38.4px.
+    // min-width is 128px, the fixed snap threshold is 80px, MINI_PANE_SIZE is 64px.
     // Drag the resizer hard left to clientX=10 (well below threshold).
     drag(resizer, 200, 10);
     await tick();
 
-    expect(panes[0].classList.contains("PaneCollapsed")).toBe(true);
-    expect(panes[0].style.width).toBe("0px");
-    // Also explicitly overrides CSS min-width so the body doesn't peek out.
+    // Pane snaps to MINI_PANE_SIZE (64px) instead of collapsing to 0.
+    expect(panes[0].classList.contains("PaneMini")).toBe(true);
+    expect(panes[0].style.width).toBe("64px");
+    // Inline min-width override ensures the pane can sit below its CSS min.
     expect(panes[0].style.minWidth).toBe("0px");
+    // Placeholder Card div is injected.
+    expect(panes[0].querySelector(".PaneMiniPlaceholder")).not.toBeNull();
   });
 
   test("clamps to min-width when released between snap-threshold and min", async () => {
@@ -128,51 +131,101 @@ describe("SplitPanes", () => {
 
     const resizer = container.querySelector(".Resizer");
     const panes = getPanes(container);
-    // Drag to ~50px — above the 38px snap threshold but below the 64px min.
-    // Should clamp UP to the configured 4rem (64px) min-width and NOT collapse.
-    drag(resizer, 200, 50);
+    // Drag to 100px — above the 80px snap threshold but below the 128px min.
+    // Should clamp UP to the configured 128px min-width and NOT enter mini state.
+    drag(resizer, 200, 100);
     await tick();
 
-    expect(panes[0].classList.contains("PaneCollapsed")).toBe(false);
-    expect(parseFloat(panes[0].style.width)).toBeGreaterThanOrEqual(63);
+    expect(panes[0].classList.contains("PaneMini")).toBe(false);
+    expect(parseFloat(panes[0].style.width)).toBeGreaterThanOrEqual(127);
   });
 
-  test("re-expands a collapsed pane when the resizer is dragged back", async () => {
+  test("re-expands a mini pane when the resizer is dragged back", async () => {
     const { container } = render(SplitPanesHarness);
     await tick();
 
     const resizer = container.querySelector(".Resizer");
     const panes = getPanes(container);
 
-    // First collapse it.
+    // First collapse to mini.
     drag(resizer, 200, 10);
     await tick();
-    expect(panes[0].classList.contains("PaneCollapsed")).toBe(true);
+    expect(panes[0].classList.contains("PaneMini")).toBe(true);
 
-    // Now drag back well past the snap threshold.
-    drag(resizer, 0, 150);
+    // Drag back well past the snap threshold (pane is now 64px wide).
+    drag(resizer, 0, 200);
     await tick();
 
-    expect(panes[0].classList.contains("PaneCollapsed")).toBe(false);
-    // The PaneCollapsed inline min-width override has been cleared so the
-    // CSS min-width can apply again.
+    expect(panes[0].classList.contains("PaneMini")).toBe(false);
+    // The inline min-width override has been cleared so CSS min-width applies again.
     expect(panes[0].style.minWidth).toBe("");
+    // Placeholder has been removed from the DOM.
+    expect(panes[0].querySelector(".PaneMiniPlaceholder")).toBeNull();
   });
 
-  test("flags the resizer with HasCollapsedNeighbour while a neighbour is collapsed", async () => {
+  test("snap-collapses the right pane to mini size when released below the threshold", async () => {
     const { container } = render(SplitPanesHarness);
     await tick();
 
     const resizer = container.querySelector(".Resizer");
+    const panes = getPanes(container);
+    // Drag the resizer hard right to clientX=390 (right pane shrinks to ~10px).
+    drag(resizer, 200, 390);
+    await tick();
 
+    expect(panes[1].classList.contains("PaneMini")).toBe(true);
+    expect(panes[1].style.width).toBe("64px");
+    expect(panes[1].style.minWidth).toBe("0px");
+    expect(panes[1].querySelector(":scope > .PaneMiniPlaceholder")).not.toBeNull();
+  });
+
+  test("snap-collapses the right pane even when dragged far beyond the viewport edge", async () => {
+    // Repro for: dragging the resizer well past the container edge (off-screen)
+    // must still snap the right pane to MINI_PANE_SIZE, not leave it at 0.
+    const { container } = render(SplitPanesHarness);
+    await tick();
+
+    const resizer = container.querySelector(".Resizer");
+    const panes = getPanes(container);
+    // Container is 400px wide. Drag to clientX=5000 (way off-screen).
+    drag(resizer, 200, 5000);
+    await tick();
+
+    expect(panes[1].classList.contains("PaneMini")).toBe(true);
+    expect(panes[1].style.width).toBe("64px");
+    expect(panes[0].style.width).toBe("336px");
+  });
+
+  test("does not create a stray placeholder when nested SplitPanes are present", async () => {
+    // Verify the :scope > selector fix: a placeholder appended to an inner
+    // pane must not be visible to the outer pane's applyPaneSize.
+    const { container } = render(SplitPanesHarness);
+    await tick();
+
+    const panes = getPanes(container);
+    // Simulate a nested SplitPanes inside the right pane that has its own
+    // mini placeholder (e.g., user collapsed the top pane of an inner
+    // vertical split before collapsing the outer left pane).
+    const nestedRoot = document.createElement("div");
+    nestedRoot.classList.add("SplitPaneRoot");
+    const nestedPane = document.createElement("div");
+    nestedPane.classList.add("Pane", "PaneMini");
+    const nestedPlaceholder = document.createElement("div");
+    nestedPlaceholder.classList.add("PaneMiniPlaceholder");
+    nestedPane.appendChild(nestedPlaceholder);
+    nestedRoot.appendChild(nestedPane);
+    panes[1].appendChild(nestedRoot);
+
+    // Now collapse the LEFT outer pane. The fix should NOT touch the
+    // nested placeholder inside the right pane.
+    const resizer = container.querySelector(".Resizer");
     drag(resizer, 200, 10);
     await tick();
 
-    expect(resizer.classList.contains("HasCollapsedNeighbour")).toBe(true);
-
-    // Expanding clears the flag.
-    drag(resizer, 0, 150);
-    await tick();
-    expect(resizer.classList.contains("HasCollapsedNeighbour")).toBe(false);
+    // Left pane got its own placeholder.
+    expect(panes[0].querySelector(":scope > .PaneMiniPlaceholder")).not.toBeNull();
+    // Nested placeholder inside right pane is untouched.
+    expect(nestedPlaceholder.isConnected).toBe(true);
+    expect(nestedPane.contains(nestedPlaceholder)).toBe(true);
   });
 });

--- a/tests/mocks/SplitPanesHarness.svelte
+++ b/tests/mocks/SplitPanesHarness.svelte
@@ -9,7 +9,7 @@
   <SplitPanes {defaultRatio}>
     <!-- min-width in px (not rem) so jsdom's getComputedStyle returns a
          pixel value the resizer can parseFloat() correctly. -->
-    <Pane style="height: 100%; min-width: 64px;">left</Pane>
-    <Pane style="height: 100%; min-width: 64px;">right</Pane>
+    <Pane style="height: 100%; min-width: 128px;">left</Pane>
+    <Pane style="height: 100%; min-width: 128px;">right</Pane>
   </SplitPanes>
 </div>


### PR DESCRIPTION
## Summary

Replaces the existing snap-to-zero collapse with a fixed-size **mini state** that shows a blank Card-shaped placeholder.

Previously, dragging a pane below the close threshold collapsed it to `width: 0`. The resizer became almost impossible to re-grab and there was no visual cue that a pane was hidden. Now the pane snaps to a fixed 64 px shell containing a Card-styled placeholder, making the closed state visible and re-openable.

## What changed

**Snap behavior**
- `MINI_PANE_SIZE = 64`, `SNAP_THRESHOLD = 80` — both fixed pixel values for consistent feel across panes with different min sizes.
- Mini snap only activates when the pane''s declared min size exceeds the threshold; smaller panes fall back to plain clamp-to-min.
- 0.18 s width/height transition applied only on mouseup for the snap, removed on the next mousedown so drag stays glued to the cursor.

**Placeholder**
- DOM-injected div styled like `Card.svelte` (header-bar background, border, shadow, rounded corners).
- Real children are hidden via inline `display:none` so nested SplitPanes are not torn down and remount cleanly on re-expand.
- Forced `padding: var(--sp4)` on `.PaneMini` so the placeholder has breathing room even when the pane''s direct child was not a Card (the `.Pane:has(> .Card)` rule from `Pane.svelte` would otherwise leave non-Card panes flush).

**Robustness**
- `:scope >` scoping when finding/removing the placeholder so nested SplitPanes do not clobber each other''s mini state.
- `applyPaneSize` hard-clamps the size to `MINI_PANE_SIZE` whenever `mini=true`, protecting against any caller (or stale ResizeObserver re-entry) passing a raw drag value.
- `ResizeObserver` preserves `.PaneMini` panes at their fixed size and only scales the remaining non-mini panes, so dragging past the viewport followed by a container resize cannot collapse the mini pane to 0 px.

**Cleanup**
- Removed the `HasCollapsedNeighbour` resizer-emphasis styling (wider hit area, colored bar). The placeholder Card itself now communicates the collapsed state, so the extra emphasis is no longer needed.

## Test plan

- [x] Unit tests cover: left snap, right snap, clamp-to-min, re-expand, off-screen drag, nested SplitPanes interference.
- [ ] Manual: drag the horizontal resizer hard left/right past the viewport edge and confirm the pane snaps to 64 px with the Card placeholder.
- [ ] Manual: same for the vertical split inside the task detail (top/bottom).
- [ ] Manual: collapse the top pane of the inner vertical split, then collapse the outer left pane — confirm the inner placeholder is preserved.
- [ ] Manual: re-expand a mini pane by dragging the resizer outward.

🤖 Generated with [Claude Code](https://claude.com/claude-code)