### PR TITLE
fix(gantt, tree-table): today marker visibility, smarter scroll, Name column resize

### DIFF
--- a/src/features/gantt/components/GanttPanel.svelte
+++ b/src/features/gantt/components/GanttPanel.svelte
@@ -1169,16 +1169,18 @@
     position: absolute;
     top: 0;
     bottom: 0;
-    /* Use the Accent token: it's a saturated pink/magenta that contrasts
-       cleanly with the Primary-blue gantt header in both themes, and
-       isn't reserved for error/overdue semantics. */
-    background-color: var(--theme-color-Accent-main);
+    /* Frame the today column with thin top + bottom Accent strips instead
+       of filling the whole cell, so the date text underneath stays
+       readable. The vertical TodayLine handles "where exactly is today". */
+    border-top: 3px solid var(--theme-color-Accent-main);
+    border-bottom: 3px solid var(--theme-color-Accent-main);
+    background-color: transparent;
     pointer-events: none;
     z-index: 5;
     /* In week / month modes a single day is only a few pixels wide; bump
-       the visible minimum to 8px so it's still recognizable. */
-    min-width: 8px;
-    box-shadow: 0 0 0 1px var(--theme-color-Accent-dark);
+       the visible minimum so the framing is still recognizable. */
+    min-width: 12px;
+    box-sizing: border-box;
   }
   .TodayDayBody {
     position: absolute;
@@ -1189,7 +1191,7 @@
     /* Above GridCell (0) and GanttRow (1) so the today fill is never
        hidden by a transparent row. */
     z-index: 2;
-    min-width: 8px;
+    min-width: 12px;
     box-shadow: inset 0 0 0 1px color-mix(in srgb, var(--theme-color-Accent-main) 55%, transparent);
   }
 
@@ -1197,7 +1199,9 @@
     position: absolute;
     top: 0;
     bottom: 0;
-    width: 2px;
+    /* Wider than a single pixel so the today marker is unambiguously
+       visible in every scale (especially month, where one day is ~4 px). */
+    width: 3px;
     /* Accent instead of Primary: in dark theme Primary-main is nearly
        indistinguishable from the gantt header background. */
     background: var(--theme-color-Accent-main);
@@ -1230,7 +1234,9 @@
     position: absolute;
     top: 0;
     bottom: 0;
-    width: 1px;
+    /* Match TodayLine's 3 px so the marker carries from header into the
+       body without an apparent step change between the two. */
+    width: 3px;
     background: var(--theme-color-Accent-main);
     opacity: 0.6;
     pointer-events: none;

--- a/src/features/gantt/components/GanttPanel.svelte
+++ b/src/features/gantt/components/GanttPanel.svelte
@@ -767,17 +767,29 @@
     }
   }
 
-  function centerOnToday() {
+  // Initial Gantt view places today at this fraction from the left edge,
+  // so the user sees mostly upcoming work with a little context before
+  // today. Centred (0.5) feels symmetric but wastes space showing the
+  // past; 0.25 keeps today recognisable while giving the future ~75%.
+  const TODAY_INITIAL_OFFSET_RATIO = 0.25;
+
+  function scrollToTodayAt(offsetRatio) {
     if (!bodyEl) return;
     const todayPx = todayRem * rootFontSizePx;
     const viewportWidth = bodyEl.clientWidth;
     if (!viewportWidth) return;
-    // Position today around the centre of the viewport, but clamp to the
-    // total scrollable width so we never scroll past either end.
-    const desired = Math.max(0, todayPx - viewportWidth / 2);
+    const desired = Math.max(0, todayPx - viewportWidth * offsetRatio);
     const maxScroll = Math.max(0, bodyEl.scrollWidth - viewportWidth);
     bodyEl.scrollLeft = Math.min(desired, maxScroll);
     headerScrollLeft = bodyEl.scrollLeft;
+  }
+
+  function remPerDayFor(scale) {
+    return scale === "day"
+      ? CELL_REM.day
+      : scale === "week"
+        ? CELL_REM.week / 7
+        : CELL_REM.month / 30;
   }
 
   let didInitialCentre = false;
@@ -786,28 +798,44 @@
     updateRootFontSizePx();
     window.addEventListener("resize", updateRootFontSizePx);
 
-    // Centre on today once the layout has settled. tick + 2 rAFs makes sure
+    // Position today on first paint. tick + 2 rAFs makes sure
     // GanttBodyInner has its real width / scrollWidth before we read them.
     requestAnimationFrame(() => {
       requestAnimationFrame(() => {
         if (!didInitialCentre && totalWidthRem > 0) {
           didInitialCentre = true;
-          centerOnToday();
+          scrollToTodayAt(TODAY_INITIAL_OFFSET_RATIO);
         }
       });
     });
 
-    // Re-centre whenever the user toggles the scale (day / week / month) —
-    // pixel distances change wildly between modes so the previous
-    // scrollLeft no longer points at today. Done via a manual subscription
-    // (rather than `$:`) to avoid Svelte tracking lastScale as a dep and
-    // re-running the block in test environments.
+    // When the user toggles the scale (day / week / month), preserve the
+    // date that was at the left edge of the viewport rather than jumping
+    // back to today. This way they keep their visual context across
+    // scale changes. Done via a manual subscription (rather than `$:`)
+    // to avoid Svelte tracking lastScale as a dep and re-running the
+    // block in test environments.
     let lastScale = $ganttScale;
     scaleUnsub = ganttScale.subscribe((next) => {
       if (next === lastScale) return;
+      // Capture the left-edge date BEFORE the new remPerDay propagates.
+      // We use the previous scale's remPerDay so the conversion from
+      // pixels to days reflects what the user was actually looking at.
+      const oldRemPerDay = remPerDayFor(lastScale);
+      const leftEdgeDays =
+        bodyEl && rootFontSizePx > 0 && oldRemPerDay > 0
+          ? bodyEl.scrollLeft / rootFontSizePx / oldRemPerDay
+          : null;
       lastScale = next;
       requestAnimationFrame(() => {
-        requestAnimationFrame(centerOnToday);
+        requestAnimationFrame(() => {
+          if (leftEdgeDays === null || !bodyEl) return;
+          const newRemPerDay = remPerDayFor(next);
+          const newScrollPx = leftEdgeDays * newRemPerDay * rootFontSizePx;
+          const maxScroll = Math.max(0, bodyEl.scrollWidth - bodyEl.clientWidth);
+          bodyEl.scrollLeft = Math.max(0, Math.min(newScrollPx, maxScroll));
+          headerScrollLeft = bodyEl.scrollLeft;
+        });
       });
     });
 

--- a/src/features/tasks/components/TreeTable.svelte
+++ b/src/features/tasks/components/TreeTable.svelte
@@ -256,39 +256,44 @@
       existingResizeObserver.disconnect(table_root);
     }
     /**
-     * Track the user-set widths of every non-last column. The LAST column
-     * stretches to fill any remaining horizontal space — this way:
-     *  - widening the pane fills the trailing gap (no white space)
-     *  - narrowing the pane leaves the user-resized columns alone (they
-     *    keep their pixel widths and the body scrolls when needed)
+     * The NAME column (index 0) absorbs pane resizes. Name is the only
+     * column guaranteed to exist (the others can be hidden via column
+     * settings) and typically holds the longest content, so making it
+     * the flexible one is both safe and matches users' expectations:
+     *  - widening the pane fills the trailing gap into Name
+     *  - narrowing the pane shrinks Name down to its CSS min-width; the
+     *    other user-resized columns keep their pixel widths and the
+     *    body scrolls when needed
      *  - collapse/expand cycles don't drift column widths because we
-     *    always recompute the last column from a stable formula instead
-     *    of accumulating deltas.
+     *    always recompute Name from a stable formula instead of
+     *    accumulating deltas.
      */
-    function fitLastColumn() {
+    function fitNameColumn() {
       if (domHeaders.length === 0) return;
-      const lastIdx = domHeaders.length - 1;
       const tableWidth = table_root.getBoundingClientRect().width;
       const widths = domHeaders.map((h) => h.getBoundingClientRect().width);
-      const fixedTotal = widths.slice(0, lastIdx).reduce((s, w) => s + w, 0);
-      const lastMin = parseFloat(window.getComputedStyle(domHeaders[lastIdx]).minWidth) || 0;
-      const lastWidth = Math.max(lastMin, tableWidth - fixedTotal);
+      const fixedTotal = widths.slice(1).reduce((s, w) => s + w, 0);
+      const nameMin = parseFloat(window.getComputedStyle(domHeaders[0]).minWidth) || 0;
+      const nameWidth = Math.max(nameMin, tableWidth - fixedTotal);
 
-      domHeaders[lastIdx].style.width = `${lastWidth}px`;
+      domHeaders[0].style.width = `${nameWidth}px`;
       data_rows.forEach((data_row) => {
-        const cell = data_row[lastIdx];
-        if (cell) cell.style.width = `${lastWidth}px`;
+        const cell = data_row[0];
+        if (cell) cell.style.width = `${nameWidth}px`;
       });
-      let left = 0;
-      for (let i = 0; i < lastIdx; i++) {
-        left += widths[i];
-        if (existingResizers[i]) existingResizers[i].style.left = `${left - 3}px`;
-      }
+      // Every resizer sits between two columns; since column 0 changed,
+      // ALL resizer left positions shift by the delta. Re-place them
+      // using the new Name width followed by each fixed downstream width.
+      let left = nameWidth;
+      existingResizers.forEach((resizer, idx) => {
+        resizer.style.left = `${left - 3}px`;
+        left += widths[idx + 1] ?? 0;
+      });
     }
 
     const newResizeObserver = new ResizeObserver(() => {
       syncResizerBounds(existingResizers);
-      fitLastColumn();
+      fitNameColumn();
     });
     newResizeObserver.observe(table_root);
 


### PR DESCRIPTION
## Summary

Three follow-up GUI fixes on top of the merged split-panes work:

1. **Gantt today marker visibility** — the today highlight in the header was an opaque colour fill that obscured the date text. Replaced with thin top/bottom Accent strips, plus a wider (3 px) vertical TodayLine so the marker is unambiguously visible at every scale including month view.

2. **Gantt initial scroll + scale switch** — first paint now places today at 25 % from the left edge (was: centred), so most of the viewport shows upcoming work. Switching scale (day / week / month) no longer jumps back to today; instead the date at the left edge of the current viewport is preserved across the scale change.

3. **TreeTable Name column absorbs pane resize** — pane resize now adjusts the Name column instead of the last column. Name is the only column guaranteed to exist (others can be hidden via column settings) and typically holds the longest content, so making it the flexible one is both safer and more useful.

## Commits

- `fix(gantt): make today marker visible without obscuring the date text`
- `feat(gantt): position today at 25% on mount, preserve left-edge date on scale switch`
- `fix(tree-table): absorb pane resize in Name column instead of the last column`

## Test plan

- [x] `vitest tests/component/GanttPanel.test.js` and `tests/component/TreeTable.test.js` pass.
- [ ] Manual: today marker visible in day / week / month view with the date text readable underneath.
- [ ] Manual: open Gantt → today appears ~25 % from the left.
- [ ] Manual: scroll to some future month → switch day → week → month and back → the left-edge date stays put.
- [ ] Manual: resize the task tree pane → only the Name column grows / shrinks; status / dates / memo columns keep their widths.

Generated with [Claude Code](https://claude.com/claude-code)
