### PR TITLE
fix: UI polish across task tree, sidebar, gantt, and memo editor

### DIFF
--- a/public/global.css
+++ b/public/global.css
@@ -37,6 +37,19 @@
   --font-label-lg: 14px;
   --font-label-md: 12px;
   --font-label-sm: 11px;
+
+  /* Header/Sidebar の濃紺背景上で使う固定色（テーマ非依存）
+     Theme-main (#143693) は Dark/Light どちらでも同じため、その上に
+     乗る要素も常時同じ色で良い。テーマ依存の theme-color-* を使うと
+     ライトテーマで暗色版になり視認性が落ちるので、ダークテーマ寄りの
+     明るめバリアントを採用。 */
+  --on-theme-success: #66bb6a;
+  --on-theme-warning: #ffa726;
+  --on-theme-error: #f44336;
+  --on-theme-error-light: #e57373;
+  --on-theme-primary: #42a5f5;
+  --on-theme-tooltip-bg: #e8edf0;
+  --on-theme-tooltip-fg: #262d32;
 }
 
 html,

--- a/src/App.svelte
+++ b/src/App.svelte
@@ -156,6 +156,11 @@
         saveStatus.set("error");
         return;
       }
+      // "workspace-updated" はヘッダーの保存状態表示と意味が被るので非表示
+      // ("conflicted-copy" 等のユーザ操作が必要な通知のみバナー表示)
+      if (event.kind === "workspace-updated") {
+        return;
+      }
       workspaceNoticeMessage = event.message;
       setTimeout(() => {
         if (workspaceNoticeMessage === event.message) {
@@ -214,7 +219,16 @@
         <MenuList />
       </aside>
     {/if}
-    <div class="Main" class:DetailWindowMain={isTaskDetailWindow}>
+    <div
+      class="Main"
+      class:DetailWindowMain={isTaskDetailWindow}
+      on:pointerdown={() => {
+        if (!isTaskDetailWindow && !$sidebarCollapsed) {
+          $sidebarCollapsed = true;
+        }
+      }}
+      role="presentation"
+    >
       {#if isTaskDetailWindow}
         <TaskDetailWindow
           initialTaskName={detailWindowTaskName}

--- a/src/features/gantt/components/GanttPanel.svelte
+++ b/src/features/gantt/components/GanttPanel.svelte
@@ -170,7 +170,9 @@
   $: totalDays = Math.ceil((timelineEnd.getTime() - timelineStart.getTime()) / DAY_MS);
   $: totalWidthRem = totalDays * remPerDay;
   $: todayTs = startOfDay();
-  $: todayRem = remFromDate(todayTs);
+  // remPerDay も依存に含めて、スケール (日/週/月) 切替時に再計算されるようにする。
+  // (remFromDate の default 引数で間接参照すると Svelte の reactive 解析対象外)
+  $: todayRem = dayOffset(todayTs, timelineStart) * remPerDay;
 
   // ── Header cells ─────────────────────────────────────────────────
 
@@ -1197,30 +1199,23 @@
     position: absolute;
     top: 0;
     bottom: 0;
-    /* Frame the today column with thin top + bottom Accent strips instead
-       of filling the whole cell, so the date text underneath stays
-       readable. The vertical TodayLine handles "where exactly is today". */
-    border-top: 3px solid var(--theme-color-Accent-main);
-    border-bottom: 3px solid var(--theme-color-Accent-main);
-    background-color: transparent;
+    /* 薄い Accent 色でスケール幅 (1日分) をフィル。枠線は付けず、
+       縦線 (.TodayLine) で「今日」の正確な位置を別途示す。 */
+    background-color: color-mix(in srgb, var(--theme-color-Accent-light) 55%, transparent);
     pointer-events: none;
     z-index: 5;
-    /* In week / month modes a single day is only a few pixels wide; bump
-       the visible minimum so the framing is still recognizable. */
-    min-width: 12px;
     box-sizing: border-box;
   }
   .TodayDayBody {
     position: absolute;
     top: 0;
     bottom: 0;
-    background-color: color-mix(in srgb, var(--theme-color-Accent-main) 22%, transparent);
+    background-color: color-mix(in srgb, var(--theme-color-Accent-light) 35%, transparent);
     pointer-events: none;
     /* Above GridCell (0) and GanttRow (1) so the today fill is never
        hidden by a transparent row. */
     z-index: 2;
-    min-width: 12px;
-    box-shadow: inset 0 0 0 1px color-mix(in srgb, var(--theme-color-Accent-main) 55%, transparent);
+    box-sizing: border-box;
   }
 
   .TodayLine {

--- a/src/features/memos/components/MarkdownMemo.svelte
+++ b/src/features/memos/components/MarkdownMemo.svelte
@@ -3,7 +3,8 @@
   import { EditorView, keymap } from "@codemirror/view";
   import { EditorState } from "@codemirror/state";
   import { markdown, markdownLanguage } from "@codemirror/lang-markdown";
-  import { syntaxHighlighting, defaultHighlightStyle } from "@codemirror/language";
+  import { syntaxHighlighting, HighlightStyle } from "@codemirror/language";
+  import { tags as t } from "@lezer/highlight";
   import { languages } from "@codemirror/language-data";
   import { history, defaultKeymap, historyKeymap } from "@codemirror/commands";
   import { highlightSelectionMatches, searchKeymap } from "@codemirror/search";
@@ -484,11 +485,33 @@
     ".cm-gutters": { display: "none" },
   });
 
+  // テーマ非依存の Markdown 用シンタックスハイライト。defaultHighlightStyle は
+  // 白背景前提の固定色 (#708, #a11, #940 など) を使うため、Dark テーマの
+  // 暗い背景 (Main-light = #394249) で見えなくなる。base color は editorTheme
+  // の color (Sub-light) を継承させ、トークンには太字/斜体/テーマ追従の
+  // accent 色のみを乗せて両テーマで可読性を確保する。
+  const markdownHighlightStyle = HighlightStyle.define([
+    { tag: t.heading, fontWeight: "bold" },
+    { tag: t.heading1, fontWeight: "bold" },
+    { tag: t.heading2, fontWeight: "bold" },
+    { tag: t.heading3, fontWeight: "bold" },
+    { tag: t.heading4, fontWeight: "bold" },
+    { tag: t.heading5, fontWeight: "bold" },
+    { tag: t.heading6, fontWeight: "bold" },
+    { tag: t.strong, fontWeight: "bold" },
+    { tag: t.emphasis, fontStyle: "italic" },
+    { tag: t.link, color: "var(--theme-color-Primary-main)", textDecoration: "underline" },
+    { tag: t.url, color: "var(--theme-color-Primary-main)" },
+    { tag: t.monospace, color: "var(--theme-color-Accent-main)" },
+    { tag: t.quote, opacity: "0.78" },
+    { tag: t.meta, opacity: "0.55" },
+  ]);
+
   function buildExtensions() {
     return [
       editorTheme,
       markdown({ base: markdownLanguage, codeLanguages: languages }),
-      syntaxHighlighting(defaultHighlightStyle),
+      syntaxHighlighting(markdownHighlightStyle),
       highlightSelectionMatches(),
       keymap.of([
         {

--- a/src/features/memos/components/MemoTab.svelte
+++ b/src/features/memos/components/MemoTab.svelte
@@ -6,7 +6,7 @@
   import SegmentedControl from "@lib/primitives/SegmentedControl.svelte";
   import Memo from "@features/memos/components/Memo.svelte";
   import Dialog from "@lib/primitives/Dialog.svelte";
-  import { normalizeMemoFormat } from "@features/memos/utils/memo_utils";
+  import { normalizeMemoFormat, isEmptyMemoContent } from "@features/memos/utils/memo_utils";
 
   export let memo = [];
   export let saveMemo;
@@ -167,6 +167,11 @@
   function requestMemoFormatChange(nextFormat) {
     if (!selectedMemo || !changeMemoFormat || nextFormat === selectedMemoFormat) return;
     pendingFormat = nextFormat;
+    // 空メモなら装飾損失が発生し得ないので、確認ダイアログを出さず即変換
+    if (isEmptyMemoContent(selectedMemo.content)) {
+      callback_format_confirm();
+      return;
+    }
     show_format_confirm = true;
   }
 

--- a/src/features/memos/utils/memo_utils.ts
+++ b/src/features/memos/utils/memo_utils.ts
@@ -54,6 +54,24 @@ export function convertMemoContent(
   return markdownToQuillDelta(content);
 }
 
+// 空メモ判定: 装飾損失の警告を出すかどうかの判定に使う
+// Markdown: 空文字 / 空白のみ
+// Quill: ops 空 / 単一の空 insert / 単一の改行のみ insert
+export function isEmptyMemoContent(content: unknown): boolean {
+  if (content == null) return true;
+  if (typeof content === "string") return content.trim() === "";
+  if (isQuillDelta(content)) {
+    const { ops } = content;
+    if (ops.length === 0) return true;
+    if (ops.length === 1) {
+      const insert = ops[0].insert;
+      return insert === "" || insert === "\n";
+    }
+    return false;
+  }
+  return false;
+}
+
 export function toMarkdown(val: unknown): string {
   if (!val) return "";
   if (typeof val === "string") return val;

--- a/src/features/navigation/components/Header.svelte
+++ b/src/features/navigation/components/Header.svelte
@@ -213,6 +213,8 @@
         right={"Light"}
         leftColor="black"
         rightColor="white"
+        leftTextColor="rgba(255,255,255,0.95)"
+        rightTextColor="rgba(255,255,255,0.95)"
         leftColorBack="rgba(0,0,0,0.5)"
         rightColorBack="rgba(255,255,255,0.5)"
         checked={$theme == "light"}
@@ -380,17 +382,17 @@
     width: var(--sp2);
     height: var(--sp2);
     border-radius: 50%;
-    background-color: var(--theme-color-Success-main);
+    background-color: var(--on-theme-success);
     transition: background-color 0.2s ease;
   }
   .SaveIndicator.pending .SaveDot {
-    background-color: var(--theme-color-Warning-main);
+    background-color: var(--on-theme-warning);
   }
   .SaveIndicator.error .SaveDot {
-    background-color: var(--theme-color-Error-main);
+    background-color: var(--on-theme-error);
   }
   .SaveIndicator.error {
-    color: var(--theme-color-Error-light);
+    color: var(--on-theme-error-light);
   }
   .ToggleSwitchContainer {
     flex-shrink: 0;

--- a/src/features/navigation/components/MenuList.svelte
+++ b/src/features/navigation/components/MenuList.svelte
@@ -333,10 +333,11 @@
       <span
         class="SubsectionLabel TextOverFlow"
         use:tooltip={{
-          color: "var(--theme-color-Main-main)",
-          backgroundColor: "var(--theme-color-Sub-main)",
+          color: "var(--on-theme-tooltip-fg)",
+          backgroundColor: "var(--on-theme-tooltip-bg)",
           content:
             "Workspaceフォルダに保存されるプロジェクトです。メモはWorkspaceファイルとして管理されます。",
+          force: true,
         }}>Workspace Projects</span
       >
       <div class="AddButtonContainer">
@@ -376,8 +377,8 @@
             <span
               class="TextOverFlow"
               use:tooltip={{
-                color: "var(--theme-color-Main-main)",
-                backgroundColor: "var(--theme-color-Sub-main)",
+                color: "var(--on-theme-tooltip-fg)",
+                backgroundColor: "var(--on-theme-tooltip-bg)",
                 content: proj.name,
               }}>{proj.name}</span
             >
@@ -415,10 +416,11 @@
       <span
         class="SubsectionLabel TextOverFlow"
         use:tooltip={{
-          color: "var(--theme-color-Main-main)",
-          backgroundColor: "var(--theme-color-Sub-main)",
+          color: "var(--on-theme-tooltip-fg)",
+          backgroundColor: "var(--on-theme-tooltip-bg)",
           content:
             "従来のdb.jsonに保存されるアプリ内プロジェクトです。db.jsonは将来的に非推奨予定です。",
+          force: true,
         }}>InApp Projects (db.json)</span
       >
       <div class="AddButtonContainer">
@@ -458,8 +460,8 @@
           <span
             class:TextOverFlow={true}
             use:tooltip={{
-              color: "var(--theme-color-Main-main)",
-              backgroundColor: "var(--theme-color-Sub-main)",
+              color: "var(--on-theme-tooltip-fg)",
+              backgroundColor: "var(--on-theme-tooltip-bg)",
               content: child.name,
             }}>{child.name}</span
           >
@@ -562,8 +564,8 @@
               <span
                 class:TextOverFlow={true}
                 use:tooltip={{
-                  color: "var(--theme-color-Main-main)",
-                  backgroundColor: "var(--theme-color-Sub-main)",
+                  color: "var(--on-theme-tooltip-fg)",
+                  backgroundColor: "var(--on-theme-tooltip-bg)",
                   content: child.name,
                 }}>{child.name}</span
               >
@@ -791,7 +793,7 @@
     display: block;
   }
   .MenuRow:focus-visible {
-    outline: 2px solid var(--theme-color-Primary-main);
+    outline: 2px solid var(--on-theme-primary);
     outline-offset: -2px;
     z-index: 1;
   }
@@ -815,7 +817,7 @@
     left: 0;
     width: 3px;
     height: 100%;
-    background-color: var(--theme-color-Primary-main);
+    background-color: var(--on-theme-primary);
     z-index: 99999;
   }
   .TextOverFlow {
@@ -836,9 +838,9 @@
     position: absolute;
     top: -1000rem;
     display: inline;
-    background-color: var(--theme-color-Primary-dark);
-    border: 1px solid var(--theme-color-Primary-dark);
-    color: var(--theme-color-Sub-main);
+    background-color: var(--on-theme-primary);
+    border: 1px solid var(--on-theme-primary);
+    color: #ffffff;
     padding: 0 var(--sp2);
     z-index: 10000;
   }
@@ -848,7 +850,7 @@
   }
 
   .MenuRow:global(.DragOverTop):before {
-    border-top: 0.2rem solid var(--theme-color-Primary-dark);
+    border-top: 0.2rem solid var(--on-theme-primary);
     position: absolute;
     content: "";
     height: 2rem;
@@ -860,7 +862,7 @@
   }
 
   .MenuRow:global(.DragOverBottom):before {
-    border-bottom: 0.2rem solid var(--theme-color-Primary-dark);
+    border-bottom: 0.2rem solid var(--on-theme-primary);
     position: absolute;
     content: "";
     height: 2rem;
@@ -960,9 +962,9 @@
     flex-shrink: 0;
   }
   .TagSearch:focus-within {
-    border-color: var(--theme-color-Primary-main);
+    border-color: var(--on-theme-primary);
     color: white;
-    box-shadow: inset 0 0 0 1px var(--theme-color-Primary-main);
+    box-shadow: inset 0 0 0 1px var(--on-theme-primary);
   }
   .TagSearch input {
     min-width: 0;
@@ -986,7 +988,7 @@
     width: 1.25rem;
     height: 1.25rem;
     border-radius: var(--shape-pill);
-    color: var(--theme-color-Primary-main);
+    color: var(--on-theme-primary);
     background-color: rgba(255, 255, 255, 0.07);
     font-size: var(--font-label-md);
   }

--- a/src/features/tasks/components/TaskMenu.svelte
+++ b/src/features/tasks/components/TaskMenu.svelte
@@ -98,62 +98,66 @@
   >
     <ul class="task-menu" role="menu" aria-label="Task actions">
       {#each menuItems as item}
-        <li class="menu-item-shell">
-          <button
-            class="task-menu-item"
-            class:disabled={item.disabled}
-            class:has-children={item.children?.length > 0}
-            disabled={item.disabled}
-            role="menuitem"
-            aria-disabled={item.disabled ? "true" : undefined}
-            on:click={(event) => triggerAction(item, event)}
-          >
-            <span class="menu-item-content">
-              {#if item.icon}
-                <svg
-                  viewBox={item.icon.viewBox}
-                  xmlns="http://www.w3.org/2000/svg"
-                  class="menu-icon"
-                >
-                  <path d={item.icon.path}></path>
-                </svg>
+        {#if item.type === "separator"}
+          <li class="menu-separator" role="separator" aria-hidden="true"></li>
+        {:else}
+          <li class="menu-item-shell">
+            <button
+              class="task-menu-item"
+              class:disabled={item.disabled}
+              class:has-children={item.children?.length > 0}
+              disabled={item.disabled}
+              role="menuitem"
+              aria-disabled={item.disabled ? "true" : undefined}
+              on:click={(event) => triggerAction(item, event)}
+            >
+              <span class="menu-item-content">
+                {#if item.icon}
+                  <svg
+                    viewBox={item.icon.viewBox}
+                    xmlns="http://www.w3.org/2000/svg"
+                    class="menu-icon"
+                  >
+                    <path d={item.icon.path}></path>
+                  </svg>
+                {/if}
+                <span class="menu-label">{item.title}</span>
+              </span>
+              {#if item.children?.length}
+                <span class="submenu-arrow">›</span>
               {/if}
-              <span class="menu-label">{item.title}</span>
-            </span>
-            {#if item.children?.length}
-              <span class="submenu-arrow">›</span>
-            {/if}
-          </button>
+            </button>
 
-          {#if item.children?.length}
-            <div class={`submenu ${submenuSideClass}`}>
-              <ul class="task-menu" role="menu">
-                {#each item.children as child}
-                  <li class="menu-item-shell">
-                    <button
-                      class="task-menu-item"
-                      role="menuitem"
-                      on:click={(event) => triggerAction(child, event)}
-                    >
-                      <span class="menu-item-content">
-                        {#if child.icon}
-                          <svg
-                            viewBox={child.icon.viewBox}
-                            xmlns="http://www.w3.org/2000/svg"
-                            class="menu-icon"
-                          >
-                            <path d={child.icon.path}></path>
-                          </svg>
-                        {/if}
-                        <span class="menu-label">{child.title}</span>
-                      </span>
-                    </button>
-                  </li>
-                {/each}
-              </ul>
-            </div>
-          {/if}
-        </li>
+            {#if item.children?.length}
+              <div class={`submenu ${submenuSideClass}`}>
+                <ul class="task-menu" role="menu">
+                  {#each item.children as child}
+                    <li class="menu-item-shell">
+                      <button
+                        class="task-menu-item"
+                        role="menuitem"
+                        on:click={(event) => triggerAction(child, event)}
+                      >
+                        <span class="menu-item-content">
+                          {#if child.icon}
+                            <svg
+                              viewBox={child.icon.viewBox}
+                              xmlns="http://www.w3.org/2000/svg"
+                              class="menu-icon"
+                            >
+                              <path d={child.icon.path}></path>
+                            </svg>
+                          {/if}
+                          <span class="menu-label">{child.title}</span>
+                        </span>
+                      </button>
+                    </li>
+                  {/each}
+                </ul>
+              </div>
+            {/if}
+          </li>
+        {/if}
       {/each}
     </ul>
   </div>
@@ -258,5 +262,14 @@
 
   .menu-item-shell:hover > .submenu {
     display: block;
+  }
+
+  .menu-separator {
+    height: 1px;
+    margin: 4px 0;
+    padding: 0;
+    background-color: color-mix(in srgb, var(--theme-color-Sub-light) 22%, transparent);
+    list-style: none;
+    pointer-events: none;
   }
 </style>

--- a/src/features/tasks/components/TaskName.svelte
+++ b/src/features/tasks/components/TaskName.svelte
@@ -17,6 +17,7 @@
   export let canMoveDown = false;
   export let canIndent = false;
   export let canOutdent = false;
+  export let nodePath = "";
   let draftText = text ?? "";
   let input;
   let isEditing = false;
@@ -24,58 +25,78 @@
   let menuPosition = { x: 0, y: 0 };
   const menuOwnerId = Math.random().toString(36).slice(2);
 
-  // メニュー項目の定義
-  $: menuItems = [
-    {
-      title: "rename",
-      action: "rename",
-      icon: {
-        viewBox: "-4 -4 32 32",
-        path: "M18.111,2.293,9.384,11.021a.977.977,0,0,0-.241.39L8.052,14.684A1,1,0,0,0,9,16a.987.987,0,0,0,.316-.052l3.273-1.091a.977.977,0,0,0,.39-.241l8.728-8.727a1,1,0,0,0,0-1.414L19.525,2.293A1,1,0,0,0,18.111,2.293Z",
+  // メニュー項目の定義（7グループ。空グループは区切り線が連続しないよう自動的にスキップ）
+  function withSeparators(groups) {
+    const result = [];
+    for (const group of groups) {
+      if (!group.length) continue;
+      if (result.length > 0) result.push({ type: "separator" });
+      result.push(...group);
+    }
+    return result;
+  }
+
+  $: menuItems = withSeparators([
+    // 1. Rename
+    [
+      {
+        title: "rename",
+        action: "rename",
+        icon: {
+          viewBox: "-4 -4 32 32",
+          path: "M18.111,2.293,9.384,11.021a.977.977,0,0,0-.241.39L8.052,14.684A1,1,0,0,0,9,16a.987.987,0,0,0,.316-.052l3.273-1.091a.977.977,0,0,0,.39-.241l8.728-8.727a1,1,0,0,0,0-1.414L19.525,2.293A1,1,0,0,0,18.111,2.293Z",
+        },
       },
-    },
-    ...(!isRoot
-      ? [
-          {
-            title: "add task below",
-            action: "addBelow",
-            icon: {
-              viewBox: "0 0 24 24",
-              path: "M12 5V19M5 12H19",
+    ],
+    // 2. Add
+    [
+      ...(!isRoot
+        ? [
+            {
+              title: "add task below",
+              action: "addBelow",
+              icon: {
+                viewBox: "0 0 24 24",
+                path: "M12 5V19M5 12H19",
+              },
             },
-          },
-        ]
-      : []),
-    {
-      title: "add child task",
-      action: "addChild",
-      icon: {
-        viewBox: "0 0 24 24",
-        path: "M5 5V14H15M11 10L15 14L11 18M19 5V9M17 7H21",
+          ]
+        : []),
+      {
+        title: "add child task",
+        action: "addChild",
+        icon: {
+          viewBox: "0 0 24 24",
+          path: "M5 5V14H15M11 10L15 14L11 18M19 5V9M17 7H21",
+        },
       },
-    },
-    ...(!isRoot
-      ? [
-          {
-            title: "copy",
-            action: "copyTask",
-            icon: {
-              viewBox: "0 0 24 24",
-              path: "M8 4v12a2 2 0 0 0 2 2h8a2 2 0 0 0 2-2V7.242a2 2 0 0 0-.602-1.43L16.083 2.57A2 2 0 0 0 14.685 2H10a2 2 0 0 0-2 2ZM4 8H2v12a2 2 0 0 0 2 2h8v-2H4Z",
+    ],
+    // 3. Clipboard
+    [
+      ...(!isRoot
+        ? [
+            {
+              title: "copy",
+              action: "copyTask",
+              icon: {
+                viewBox: "0 0 24 24",
+                path: "M8 4v12a2 2 0 0 0 2 2h8a2 2 0 0 0 2-2V7.242a2 2 0 0 0-.602-1.43L16.083 2.57A2 2 0 0 0 14.685 2H10a2 2 0 0 0-2 2ZM4 8H2v12a2 2 0 0 0 2 2h8v-2H4Z",
+              },
             },
-          },
-        ]
-      : []),
-    {
-      title: "paste as child",
-      action: "pasteTask",
-      disabled: $copied_task === null,
-      icon: {
-        viewBox: "0 0 24 24",
-        path: "M9 5H7a2 2 0 0 0-2 2v12a2 2 0 0 0 2 2h10a2 2 0 0 0 2-2V7a2 2 0 0 0-2-2h-2M9 5a2 2 0 0 0 2 2h2a2 2 0 0 0 2-2M9 5a2 2 0 0 1 2-2h2a2 2 0 0 1 2 2",
+          ]
+        : []),
+      {
+        title: "paste as child",
+        action: "pasteTask",
+        disabled: $copied_task === null,
+        icon: {
+          viewBox: "0 0 24 24",
+          path: "M9 5H7a2 2 0 0 0-2 2v12a2 2 0 0 0 2 2h10a2 2 0 0 0 2-2V7a2 2 0 0 0-2-2h-2M9 5a2 2 0 0 0 2 2h2a2 2 0 0 0 2-2M9 5a2 2 0 0 1 2-2h2a2 2 0 0 1 2 2",
+        },
       },
-    },
-    ...(hasChildren
+    ],
+    // 4. Expand/collapse
+    hasChildren
       ? [
           {
             title: expanded ? "collapse" : "expand",
@@ -86,52 +107,59 @@
             },
           },
         ]
-      : []),
-    {
-      title: "move up",
-      action: "moveUp",
-      disabled: !canMoveUp,
-      icon: {
-        viewBox: "0 0 24 24",
-        path: "M12 5L6 11H10V19H14V11H18L12 5Z",
+      : [],
+    // 5. Move
+    [
+      {
+        title: "move up",
+        action: "moveUp",
+        disabled: !canMoveUp,
+        icon: {
+          viewBox: "0 0 24 24",
+          path: "M12 5L6 11H10V19H14V11H18L12 5Z",
+        },
       },
-    },
-    {
-      title: "move down",
-      action: "moveDown",
-      disabled: !canMoveDown,
-      icon: {
-        viewBox: "0 0 24 24",
-        path: "M12 19L18 13H14V5H10V13H6L12 19Z",
+      {
+        title: "move down",
+        action: "moveDown",
+        disabled: !canMoveDown,
+        icon: {
+          viewBox: "0 0 24 24",
+          path: "M12 19L18 13H14V5H10V13H6L12 19Z",
+        },
       },
-    },
-    {
-      title: "move right",
-      action: "indentTask",
-      disabled: !canIndent,
-      icon: {
-        viewBox: "0 0 24 24",
-        path: "M4 6H14V8H4V6ZM4 11H14V13H4V11ZM4 16H14V18H4V16ZM12 9L17 14L12 19V16H8V12H12V9Z",
+      {
+        title: "move right",
+        action: "indentTask",
+        disabled: !canIndent,
+        icon: {
+          viewBox: "0 0 24 24",
+          path: "M4 6H14V8H4V6ZM4 11H14V13H4V11ZM4 16H14V18H4V16ZM12 9L17 14L12 19V16H8V12H12V9Z",
+        },
       },
-    },
-    {
-      title: "move left",
-      action: "outdentTask",
-      disabled: !canOutdent,
-      icon: {
-        viewBox: "0 0 24 24",
-        path: "M10 9L5 14L10 19V16H16V12H10V9ZM10 6H20V8H10V6ZM10 16H20V18H10V16Z",
+      {
+        title: "move left",
+        action: "outdentTask",
+        disabled: !canOutdent,
+        icon: {
+          viewBox: "0 0 24 24",
+          path: "M10 9L5 14L10 19V16H16V12H10V9ZM10 6H20V8H10V6ZM10 16H20V18H10V16Z",
+        },
       },
-    },
-    {
-      title: "show details",
-      action: "openTaskDetailWindow",
-      icon: {
-        viewBox: "0 0 24 24",
-        path: "M12 4C7 4 2.73 7.11 1 12c1.73 4.89 6 8 11 8s9.27-3.11 11-8c-1.73-4.89-6-8-11-8Zm0 13a5 5 0 1 1 0-10 5 5 0 0 1 0 10Zm0-8.2A3.2 3.2 0 1 0 12 15.2 3.2 3.2 0 0 0 12 8.8Z",
+    ],
+    // 6. Detail
+    [
+      {
+        title: "show details",
+        action: "openTaskDetailWindow",
+        icon: {
+          viewBox: "0 0 24 24",
+          path: "M12 4C7 4 2.73 7.11 1 12c1.73 4.89 6 8 11 8s9.27-3.11 11-8c-1.73-4.89-6-8-11-8Zm0 13a5 5 0 1 1 0-10 5 5 0 0 1 0 10Zm0-8.2A3.2 3.2 0 1 0 12 15.2 3.2 3.2 0 0 0 12 8.8Z",
+        },
       },
-    },
-    ...(!isRoot
+    ],
+    // 7. Delete
+    !isRoot
       ? [
           {
             title: "delete task",
@@ -142,8 +170,8 @@
             },
           },
         ]
-      : []),
-  ];
+      : [],
+  ]);
 
   const dispatch = createEventDispatcher();
 
@@ -155,15 +183,21 @@
     lastSubmittedText = null;
   }
 
-  const params = {
+  // ノードパス ("root / a / b / current") をツールチップで表示。
+  // nodePath が空のときは従来挙動 (truncated 時のみ value/textContent を表示) に戻す。
+  $: params = {
     color: "var(--theme-color-Main-main)",
     backgroundColor: "var(--theme-color-Sub-main)",
     wrapped: true,
+    content: nodePath || undefined,
+    force: !!nodePath,
   };
 
-  const spanTooltipParams = {
+  $: spanTooltipParams = {
     color: "var(--theme-color-Main-main)",
     backgroundColor: "var(--theme-color-Sub-main)",
+    content: nodePath || undefined,
+    force: !!nodePath,
   };
 
   function splitHighlight(str, query) {

--- a/src/features/tasks/components/TreeTable.svelte
+++ b/src/features/tasks/components/TreeTable.svelte
@@ -15,6 +15,7 @@
   import {
     flattenVisibleTree,
     buildInheritedDueDateMap,
+    buildNodePathMap,
     updateNodeDataById,
     isChild,
     reorderTree,
@@ -48,6 +49,7 @@
 
   $: rows = $filtered_data ? flattenVisibleTree($filtered_data, $closed_node_ids) : [];
   $: inheritedDueDateMap = buildInheritedDueDateMap(rows);
+  $: nodePathMap = buildNodePathMap(rows);
   $: isDark = $theme == "dark";
   $: hasNoTasks = !$tree_data?.data?.children?.length;
   let scrollTop = 0;
@@ -104,19 +106,24 @@
       return [];
     }
 
-    const stickyOverlayRows = 1;
-    const topVisibleIndex = Math.min(
+    // スティッキー表示自体が 1 行分 (2.5rem) を覆い隠す。スクロール量から
+    // 計算される「画面最上段の行」はちょうどスティッキーに覆われている行で、
+    // ユーザが実際に見える最初の本文行 (content-visible) はその 1 つ下。
+    // スティッキー上のパスを「画面で見える行の親パス」と一致させるには、
+    // 覆われている行 (= floor(scrollTop / rowHeight)) の祖先 (自身含む) を
+    // パンくずに使えばよい。
+    const coveredIndex = Math.min(
       visibleRows.length - 1,
-      Math.max(0, Math.floor(currentScrollTop / rowHeightPx) - stickyOverlayRows)
+      Math.max(0, Math.floor(currentScrollTop / rowHeightPx))
     );
-    const topRow = visibleRows[topVisibleIndex];
-    if (!topRow || topRow.depth === 0) {
+    const coveredRow = visibleRows[coveredIndex];
+    if (!coveredRow || coveredRow.depth === 0) {
       return [];
     }
 
     const rowById = new Map(visibleRows.map((row) => [row.id, row]));
     const trail = [];
-    let currentRow = topRow;
+    let currentRow = coveredRow;
 
     while (currentRow) {
       trail.unshift(currentRow);
@@ -676,6 +683,7 @@
         canIndent={row.canIndent}
         canOutdent={row.canOutdent}
         inheritedDueDate={inheritedDueDateMap.get(row.id) ?? ""}
+        nodePath={nodePathMap.get(row.id) ?? ""}
         on:select={handleSelectRow}
         on:toggle={handleToggleRow}
         on:commit={handleCommit}

--- a/src/features/tasks/components/TreeTableRow.svelte
+++ b/src/features/tasks/components/TreeTableRow.svelte
@@ -21,6 +21,7 @@
   export let canIndent = false;
   export let canOutdent = false;
   export let inheritedDueDate = "";
+  export let nodePath = "";
 
   const dispatch = createEventDispatcher();
   let taskName;
@@ -229,6 +230,7 @@
           {canMoveDown}
           {canIndent}
           {canOutdent}
+          {nodePath}
           on:commit={(e) => {
             commitData("name", e.detail.value);
           }}
@@ -434,7 +436,7 @@
   .TableRow:hover .TableData {
     background-color: var(--backgroundColor);
   }
-  .TableRow.Selected::before {
+  .TableRow.Selected::after {
     content: "";
     position: absolute;
     top: 0;
@@ -443,6 +445,7 @@
     height: 100%;
     background-color: var(--theme-color-Primary-main);
     z-index: 999;
+    pointer-events: none;
   }
   .TableData {
     display: flex;

--- a/src/features/tasks/utils/tree_control.ts
+++ b/src/features/tasks/utils/tree_control.ts
@@ -356,6 +356,22 @@ export function flattenVisibleTree(
   return rows;
 }
 
+// 各行に対し、ルートから現在ノードまでの名前パス ("root / a / b / current") を返す。
+// 行は flattenVisibleTree の DFS 順 (親が子より先) なので、親のパスを引いて連結するだけで O(N)。
+export function buildNodePathMap(rows: VisibleTreeRow[]): Map<string, string> {
+  const result = new Map<string, string>();
+  for (const row of rows) {
+    const name = row.node.data["name"] ?? "";
+    if (row.parentId) {
+      const parentPath = result.get(row.parentId);
+      result.set(row.id, parentPath ? `${parentPath} / ${name}` : name);
+    } else {
+      result.set(row.id, name);
+    }
+  }
+  return result;
+}
+
 export function buildInheritedDueDateMap(rows: VisibleTreeRow[]): Map<string, string> {
   const rowMap = new Map(rows.map((r) => [r.id, r]));
   const result = new Map<string, string>();

--- a/src/lib/actions/index.ts
+++ b/src/lib/actions/index.ts
@@ -130,6 +130,12 @@ export function tooltip(
     }
   };
 
+  // mouseenter/leave/move を受ける実 anchor。wrapped:true なら親要素にイベントを
+  // 付けるので、sweepTooltips の :hover 判定も同じ要素で行わないと、カーソルが
+  // 親内の他の子要素 (ボタン等) に乗ったときに原 node の :hover が外れて
+  // safety sweep (1秒) でツールチップが消されてしまう。
+  const target = params.wrapped ? (node.parentElement ?? node) : node;
+
   const handleMouseEnter = (e: MouseEvent) => {
     // Defensive: kill any tooltip we might have left over from a previous
     // anchor (this can happen if mouseleave never fired).
@@ -161,7 +167,7 @@ export function tooltip(
       z-index: 9999999999;
     `;
     document.body.appendChild(element);
-    entry = { node, element };
+    entry = { node: target, element };
     activeTooltips.add(entry);
     scheduleSafetySweep();
   };
@@ -174,7 +180,6 @@ export function tooltip(
       entry.element.style.top = `calc(${e.pageY}px + 1rem)`;
     }
   };
-  const target = params.wrapped ? (node.parentElement ?? node) : node;
   target.addEventListener("mouseenter", handleMouseEnter);
   target.addEventListener("mouseleave", handleMouseLeave);
   target.addEventListener("mousemove", handleMouseMove);

--- a/src/lib/primitives/DateInput.svelte
+++ b/src/lib/primitives/DateInput.svelte
@@ -91,6 +91,8 @@
     top: 50%;
     transform: translateY(-50%);
     flex-shrink: 0;
+    width: var(--sp4);
+    text-align: center;
     font-size: var(--font-label-md);
     color: var(--theme-color-Error-main);
     line-height: 1;
@@ -115,9 +117,9 @@
     font-size: var(--font-label-md);
     cursor: pointer;
   }
-  /* Make room for the leading warning icon */
+  /* Make room for the leading warning icon (icon is sp1 from left + sp4 wide, plus sp1 gap) */
   .Container.Overdue .Date {
-    padding-left: calc(var(--sp1) + var(--sp4));
+    padding-left: calc(var(--sp1) * 2 + var(--sp4));
   }
   .Container.Overdue .Date,
   .Container.DueSoon .Date {

--- a/src/lib/primitives/ToggleSwitch.svelte
+++ b/src/lib/primitives/ToggleSwitch.svelte
@@ -5,11 +5,15 @@
   export let leftColorBack = "#75bbff33";
   export let rightColor = "#ff8d8d";
   export let rightColorBack = "#ff8d8d33";
+  export let leftTextColor = null;
+  export let rightTextColor = null;
   export let checked = true;
+  $: leftTextResolved = leftTextColor ?? leftColor;
+  $: rightTextResolved = rightTextColor ?? rightColor;
 </script>
 
 <div
-  style="--leftColor:{leftColor}; --leftColorBack:{leftColorBack}; --rightColor:{rightColor}; --rightColorBack:{rightColorBack};"
+  style="--leftColor:{leftColor}; --leftColorBack:{leftColorBack}; --rightColor:{rightColor}; --rightColorBack:{rightColorBack}; --leftTextColor:{leftTextResolved}; --rightTextColor:{rightTextResolved};"
 >
   <span class="Left">{left}</span>
   <label class="ToggleButton">
@@ -66,11 +70,11 @@
   }
 
   .Left {
-    color: var(--leftColor);
+    color: var(--leftTextColor);
   }
 
   .Right {
-    color: var(--rightColor);
+    color: var(--rightTextColor);
   }
 
   .ToggleButton input {


### PR DESCRIPTION
## Summary

14 件の UI 不具合 / 視認性問題をまとめて修正:

**タスクツリー**
- ドラッグ＆ドロップのドロップ位置インジケータが選択行で隠れる問題 (`.Selected::before` と `.DragOver*::before` の競合) を解消 — Selected 側を `::after` に
- 名前列にノードパスツールチップ (`root / a / b / current`) を追加
- スクロール時のスティッキーパンくずが 1 段浅いパスを表示する off-by-one を修正
- 3 点メニューを 7 グループに区切り線でグルーピング

**サイドバー / タイトルバー**
- Workspace Projects / InApp Projects のツールチップを `force: true` で表示 (cursor: help だけ効いていた)
- メイン領域クリックでサイドバーを閉じる (モーダルは portal なので自然に除外)
- "Dark" トグル文字を白系にして可読性確保 (`leftTextColor`/`rightTextColor` プロップス新設)
- 濃紺 Theme-main 上に乗る要素 (Save dot / D&D 線 / サイドバー内ツールチップ) を `--on-theme-*` 固定変数に — ライト/ダーク切替で視認性が崩れない

**タスク詳細 / ガント / メモ**
- DateInput の overdue ⚠ が日付テキストに重なる問題を修正 (アイコン固定幅 + padding 増)
- ガントの今日インジケータを「薄い Accent 一色塗り」に簡素化、`todayRem` の reactive 依存に `remPerDay` を含めてスケール切替で再計算
- 空メモでの Markdown↔Quill 変換時に確認ダイアログを出さない
- Markdown エディタのシンタックスハイライトをテーマ追従に (defaultHighlightStyle の固定ダーク色がダーク背景で不可視だった)

**インフラ系**
- `workspace-updated` 通知バナーを抑制 (ヘッダー保存状態と被る) — `conflicted-copy` と `error` は維持
- `tooltip` action: `wrapped: true` のときに safety sweep が原 node の `:hover` を見ていて、親内の別子要素にカーソルが移ると 1 秒以内に消えていた問題を修正

## Test plan

- [ ] タスクツリーで選択行の上下に別タスクをドラッグ → 青ボーダーが選択ハイライトを覆い隠さず表示
- [ ] タスクツリー名前列にホバー → `root / 親 / ... / 現ノード` のツールチップが消えず表示
- [ ] タスクツリーで深い階層までスクロール → スティッキーが画面上で見えている最初の行の親パスと一致
- [ ] 3 点メニューを開く → 区切り線でグルーピング、ルートタスクで非表示要素があっても空グループの区切りが出ない
- [ ] サイドバーの Workspace Projects / InApp Projects にホバー → 説明テキストが表示
- [ ] サイドバーを開いた状態でメイン領域をクリック → 閉じる、モーダル内クリックでは閉じない
- [ ] テーマトグルで Dark/Light 切替 → 両モードでテキスト読める、Save 状態の色が変わらない
- [ ] Start Date / Due Date に過去日 → ⚠ とテキストが重ならない
- [ ] ガント 日 / 週 / 月 切替 → 今日インジケータが正しい位置に再描画、枠線無しの薄ピンクのみ
- [ ] 空メモで Markdown ↔ Quill 切替 → 警告ダイアログが出ない
- [ ] Dark テーマで Markdown エディタの太字/見出し/コード等のトークンが読める
- [ ] 外部からファイル更新 → ヘッダー保存状態は更新されるが "workspace updated on disk" バナーは出ない
- [ ] `svelte-check`: 0 errors / 0 warnings
- [ ] `vitest`: 既存テスト全通過

🤖 Generated with [Claude Code](https://claude.com/claude-code)
