### PR TITLE
タスクツリーのデフォルト並び順を frontmatter に保存する

### DIFF
--- a/electron/workspace.js
+++ b/electron/workspace.js
@@ -599,6 +599,7 @@ function taskFrontmatterData(task) {
   if (task.startDate) data.start = task.startDate;
   if (task.dueDate) data.due = task.dueDate;
   if (task.parents?.length > 0) data.parents = task.parents;
+  if (typeof task.order === "number") data.order = task.order;
   data.created = task.createdAt || new Date().toISOString().slice(0, 10);
   return data;
 }
@@ -646,6 +647,8 @@ function readRootTask(projectDir) {
     parents: [],
     memos: readMemos(projectDir, ["_project.md"]),
     createdAt: data.created || "",
+    order:
+      data.order != null && Number.isFinite(Number(data.order)) ? Number(data.order) : undefined,
   };
 }
 
@@ -663,6 +666,8 @@ function readTaskDir(taskDir) {
     parents,
     memos: readMemos(taskDir),
     createdAt: data.created || "",
+    order:
+      data.order != null && Number.isFinite(Number(data.order)) ? Number(data.order) : undefined,
   };
 }
 
@@ -1060,7 +1065,7 @@ function exportProjectData(workspacePath, projectData, options = {}) {
   const exportMemoFormat = options.memoFormat === "markdown" ? "markdown" : "preserve";
   const exportedProjectId = crypto.randomUUID();
 
-  function traverse(node, parentIds) {
+  function traverse(node, parentIds, siblingIndex) {
     const memos = (node.data.memo || []).map((m) => {
       const title = String(m.title || "Memo");
       const sourceFormat = normalizeMemoFormat(m.format, "quill");
@@ -1087,15 +1092,16 @@ function exportProjectData(workspacePath, projectData, options = {}) {
       parents: [...parentIds],
       memos,
       createdAt: today,
+      order: siblingIndex,
     });
 
-    for (const child of node.children || []) {
-      traverse(child, [exportedTaskId]);
+    for (const [index, child] of (node.children || []).entries()) {
+      traverse(child, [exportedTaskId], index);
     }
   }
 
   if (!projectData || !projectData.data) throw new Error("Invalid project data");
-  traverse(projectData.data, []);
+  traverse(projectData.data, [], 0);
 
   const rootName = tasks[0].name || "project";
   const dirName = uniqueName(workspacePath, slugify(rootName) || "project");

--- a/src/features/workspace/utils/workspace_tree.ts
+++ b/src/features/workspace/utils/workspace_tree.ts
@@ -27,6 +27,17 @@ export function workspaceToProjectData(
     }
   }
 
+  for (const children of childrenMap.values()) {
+    children.sort((a, b) => {
+      const aOrder = tasks[a]?.order;
+      const bOrder = tasks[b]?.order;
+      if (aOrder === undefined && bOrder === undefined) return 0;
+      if (aOrder === undefined) return 1;
+      if (bOrder === undefined) return -1;
+      return aOrder - bOrder;
+    });
+  }
+
   const visited = new Set<string>();
 
   function buildNode(id: string): TreeData {
@@ -83,7 +94,7 @@ export function projectDataToWorkspaceTasks(
   const result: WorkspaceTask[] = [];
   const today = new Date().toISOString().slice(0, 10);
 
-  function traverse(node: TreeData, parentIds: string[]) {
+  function traverse(node: TreeData, parentIds: string[], siblingIndex: number) {
     const existing = existingTasks[node.id];
     result.push({
       id: node.id,
@@ -103,14 +114,15 @@ export function projectDataToWorkspaceTasks(
         };
       }),
       createdAt: existing?.createdAt || today,
+      order: siblingIndex,
     });
-    for (const child of node.children || []) {
-      traverse(child, [node.id]);
+    for (const [index, child] of (node.children || []).entries()) {
+      traverse(child, [node.id], index);
     }
   }
 
   if (projectData.data) {
-    traverse(projectData.data, []);
+    traverse(projectData.data, [], 0);
   }
   return result;
 }

--- a/src/types/workspace.ts
+++ b/src/types/workspace.ts
@@ -20,6 +20,7 @@ export interface WorkspaceTask {
   parents: string[];
   memos: WorkspaceMemo[];
   createdAt: string; // YYYY-MM-DD
+  order?: number;
 }
 
 export interface WorkspaceInfo {

--- a/tests/unit/workspace.test.js
+++ b/tests/unit/workspace.test.js
@@ -346,6 +346,45 @@ describe("file system operations", () => {
     expect(loaded.memos[0].title).toBe("Notes");
   });
 
+  it("writeTask + readProject round-trips order field", () => {
+    const { projectDir } = createProject(tmpDir, "Proj", "root-id");
+    const taskDirs = new Map([["root-id", "_project"]]);
+    const task = {
+      id: "task-order",
+      name: "Ordered Task",
+      status: "Open",
+      parents: ["root-id"],
+      memos: [],
+      createdAt: "2026-04-24",
+      order: 2,
+    };
+    writeTask(projectDir, task, taskDirs);
+
+    const { tasks } = readProject(projectDir);
+    const loaded = tasks.get("task-order");
+    expect(loaded).toBeDefined();
+    expect(loaded.order).toBe(2);
+  });
+
+  it("writeTask + readProject: task without order reads as undefined", () => {
+    const { projectDir } = createProject(tmpDir, "Proj", "root-id");
+    const taskDirs = new Map([["root-id", "_project"]]);
+    const task = {
+      id: "task-no-order",
+      name: "No Order Task",
+      status: "Open",
+      parents: ["root-id"],
+      memos: [],
+      createdAt: "2026-04-24",
+    };
+    writeTask(projectDir, task, taskDirs);
+
+    const { tasks } = readProject(projectDir);
+    const loaded = tasks.get("task-no-order");
+    expect(loaded).toBeDefined();
+    expect(loaded.order).toBeUndefined();
+  });
+
   it("writeTask + readProject round-trips memo tags", () => {
     const { projectDir } = createProject(tmpDir, "Proj", "root-id");
     const taskDirs = new Map([["root-id", "_project"]]);
@@ -872,6 +911,9 @@ describe("migrateProjectData", () => {
     expect(tasks.get("child-a").startDate).toBe("2026-04-20");
     expect(tasks.get("child-a").dueDate).toBe("2026-05-01");
     expect(tasks.get("child-b").status).toBe("Completed");
+    expect(tasks.get("child-a").order).toBe(0);
+    expect(tasks.get("child-b").order).toBe(1);
+    expect(tasks.get("grandchild").order).toBe(0);
   });
 
   it("exports Quill Delta memo content to Markdown without mutating source data", () => {


### PR DESCRIPTION
WorkspaceTask に order フィールドを追加し、各タスクの _index.md frontmatter
に兄弟間の順序（0始まりインデックス）を永続化する。

- WorkspaceTask 型に order?: number を追加
- taskFrontmatterData で order を frontmatter に書き出し
- readTaskDir / readRootTask で order を読み込み
- workspaceToProjectData でツリー構築時に order でソート
- projectDataToWorkspaceTasks でツリーを保存する際に siblingIndex を order に設定
- exportProjectData（Legacy→Workspace 移行）でも同様に order を設定

ヘッダーソートは filtered_data（表示専用）に影響するのみで
tree_data（保存元）には影響しないため、デグレなし。

https://claude.ai/code/session_01RdSs5rkZEidMu8bjLcrZzY