### PR TITLE
[codex] reset project view while switching

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -343,6 +343,8 @@ import LocalComponent from "./LocalComponent.svelte";
 
 メモリ上の `tree_data` を単一の真実とし、main プロセスが非同期にディスクへ反映する。renderer は保存完了を待たず（fire-and-forget）、状態は main からの IPC push で更新する。
 
+この原則はタスク本体だけでなく、Workspace プロジェクトのサイドバー summary にも適用する。root task 名、rootId、並び順など、現在の `tree_data` または `workspace_store.projects` から決まる値は renderer の store で派生更新し、通常の編集後にディスクを読み直して UI を正す実装にしない。ディスクから store へ取り込む経路は、起動・workspace 切替・project 選択・migration/export 後の明示 refresh・外部更新リコンサイル・競合 reload の境界に限定する。
+
 ```
 [ renderer ]
   tree_data (Svelte store)

--- a/docs/data.md
+++ b/docs/data.md
@@ -149,6 +149,14 @@
 
 ### 4.1 永続化の挙動
 
+Workspace の通常編集では、renderer 側の Svelte store を単一の信頼元とする。
+
+- `tree_data` は現在開いている Workspace プロジェクトのタスクツリー本体であり、保存処理はこのメモリスナップショットを main プロセスへ渡して非同期にディスクへ反映する
+- `workspace_store.projects` はサイドバー用のプロジェクト summary であり、root task 名や並び順など `tree_data` から派生できる情報はメモリ上で同期する。通常操作の直後に `ws:list-projects` でディスクを読み直して UI を補正してはならない
+- `workspace_tasks_cache` は保存時に `createdAt` など tree 表現に含まれないメタデータを保つ補助キャッシュであり、summary 側から task cache へ逆流させない
+- ディスクから renderer のメモリへ取り込むのは、起動、workspace 切替、project 選択、migration/export 後の明示 refresh、外部更新リコンサイル、ユーザーが競合解決で reload を選んだ場合に限る
+- 書込失敗時もディスクを読み戻してメモリ状態を勝手に巻き戻さない。エラー状態を通知し、ユーザー操作または明示的な reload で解決する
+
 ワークスペース保存は、メモリ上の `tree_data` を唯一の正として、main プロセスが非同期にディスクへ反映する形をとる。renderer は保存完了を待たず（fire-and-forget）、状態は main からの IPC push で更新する。
 
 - **増分書込**: `electron/workspace.js` の `writeFileIfChanged` が既存ファイルとバイト比較し、内容に差がなければ書込をスキップする。OneDrive 等の同期フォルダで、変更のないタスク/メモが無用にアップロードされない

--- a/electron/index.js
+++ b/electron/index.js
@@ -604,6 +604,19 @@ app.on("ready", () => {
     }
   });
 
+  ipcMain.handle("ws:set-project-order", async (event, { workspacePath, projects }) => {
+    try {
+      const result = await workspace.setProjectOrderAsync(workspacePath, projects);
+      for (const projectDir of result.changedProjectDirs) {
+        await workspaceReconciler.markProjectWritten(projectDir);
+      }
+      return { success: true, projects: result.projects };
+    } catch (err) {
+      log.error("ws:set-project-order error:", err.message);
+      return { success: false, error: err.message };
+    }
+  });
+
   ipcMain.handle("ws:read-project", async (event, { projectDir }) => {
     try {
       const { tasks, taskDirs } = workspace.readProject(projectDir);
@@ -792,9 +805,9 @@ app.on("ready", () => {
     return { path: selected };
   });
 
-  ipcMain.handle("ws:create-project", async (event, { workspacePath, name, id }) => {
+  ipcMain.handle("ws:create-project", async (event, { workspacePath, name, id, order }) => {
     try {
-      const result = await workspace.createProjectAsync(workspacePath, name, id);
+      const result = await workspace.createProjectAsync(workspacePath, name, id, order);
       return { success: true, ...result };
     } catch (err) {
       log.error("ws:create-project error:", err.message);

--- a/electron/preload.js
+++ b/electron/preload.js
@@ -96,6 +96,8 @@ const electronAPI = {
   wsGetWorkspaces: () => ipcRenderer.invoke("ws:get-workspaces"),
   wsSetWorkspaces: (config) => ipcRenderer.send("ws:set-workspaces", config),
   wsListProjects: (workspacePath) => ipcRenderer.invoke("ws:list-projects", { workspacePath }),
+  wsSetProjectOrder: (workspacePath, projects) =>
+    ipcRenderer.invoke("ws:set-project-order", { workspacePath, projects }),
   wsReadProject: (projectDir) => ipcRenderer.invoke("ws:read-project", { projectDir }),
   wsWriteTask: (projectDir, task) => ipcRenderer.invoke("ws:write-task", { projectDir, task }),
   wsSaveMemoImage: (projectDir, taskId, bytes, mimeType) =>
@@ -106,8 +108,8 @@ const electronAPI = {
     ipcRenderer.invoke("ws:write-project", { projectDir, tasks }),
   wsDeleteTask: (projectDir, taskId) =>
     ipcRenderer.invoke("ws:delete-task", { projectDir, taskId }),
-  wsCreateProject: (workspacePath, name, id) =>
-    ipcRenderer.invoke("ws:create-project", { workspacePath, name, id }),
+  wsCreateProject: (workspacePath, name, id, order) =>
+    ipcRenderer.invoke("ws:create-project", { workspacePath, name, id, order }),
   wsDeleteProject: (projectDir) => ipcRenderer.invoke("ws:delete-project", { projectDir }),
   wsResolveConflict: (projectDir, action) =>
     ipcRenderer.invoke("ws:resolve-conflict", { projectDir, action }),

--- a/electron/workspace.js
+++ b/electron/workspace.js
@@ -635,6 +635,10 @@ function readMemos(taskDir, reservedFiles = ["_index.md"]) {
 }
 
 /** Read the root task from _project.md inside projectDir. */
+function parseOrderValue(value) {
+  return value != null && Number.isFinite(Number(value)) ? Number(value) : undefined;
+}
+
 function readRootTask(projectDir) {
   const content = fs.readFileSync(path.join(projectDir, "_project.md"), "utf8");
   const { data } = parseFrontmatter(content);
@@ -647,8 +651,7 @@ function readRootTask(projectDir) {
     parents: [],
     memos: readMemos(projectDir, ["_project.md"]),
     createdAt: data.created || "",
-    order:
-      data.order != null && Number.isFinite(Number(data.order)) ? Number(data.order) : undefined,
+    order: parseOrderValue(data.order),
   };
 }
 
@@ -666,8 +669,7 @@ function readTaskDir(taskDir) {
     parents,
     memos: readMemos(taskDir),
     createdAt: data.created || "",
-    order:
-      data.order != null && Number.isFinite(Number(data.order)) ? Number(data.order) : undefined,
+    order: parseOrderValue(data.order),
   };
 }
 
@@ -937,16 +939,24 @@ async function writeProjectAsync(projectDir, tasks) {
  * Create a new project directory with a root _project.md.
  * Returns { dirName, projectDir }.
  */
-function createProject(workspacePath, name, id) {
+function createProject(workspacePath, name, id, order) {
   const dirName = uniqueName(workspacePath, slugify(name) || "project");
   const projectDir = path.join(workspacePath, dirName);
   fs.mkdirSync(projectDir, { recursive: true });
   const today = new Date().toISOString().slice(0, 10);
-  writeRootTask(projectDir, { id, name, status: "Open", parents: [], memos: [], createdAt: today });
+  writeRootTask(projectDir, {
+    id,
+    name,
+    status: "Open",
+    parents: [],
+    memos: [],
+    createdAt: today,
+    order,
+  });
   return { dirName, projectDir };
 }
 
-async function createProjectAsync(workspacePath, name, id) {
+async function createProjectAsync(workspacePath, name, id, order) {
   const dirName = uniqueName(workspacePath, slugify(name) || "project");
   const projectDir = path.join(workspacePath, dirName);
   await fs.promises.mkdir(projectDir, { recursive: true });
@@ -958,6 +968,7 @@ async function createProjectAsync(workspacePath, name, id) {
     parents: [],
     memos: [],
     createdAt: today,
+    order,
   });
   return { dirName, projectDir };
 }
@@ -966,6 +977,18 @@ async function createProjectAsync(workspacePath, name, id) {
  * List all projects (directories containing _project.md) inside a workspace.
  * Returns WorkspaceProjectListItem[].
  */
+function compareProjectListItems(a, b) {
+  const aHasOrder = typeof a.order === "number";
+  const bHasOrder = typeof b.order === "number";
+  if (aHasOrder && bHasOrder && a.order !== b.order) return a.order - b.order;
+  if (aHasOrder && !bHasOrder) return -1;
+  if (!aHasOrder && bHasOrder) return 1;
+  return String(a.name || a.dirName).localeCompare(String(b.name || b.dirName), undefined, {
+    numeric: true,
+    sensitivity: "base",
+  });
+}
+
 function listProjects(workspacePath) {
   if (!fs.existsSync(workspacePath)) return [];
   const entries = fs.readdirSync(workspacePath, { withFileTypes: true });
@@ -982,12 +1005,77 @@ function listProjects(workspacePath) {
         rootId: data.id,
         dirName: entry.name,
         projectDir: path.join(workspacePath, entry.name),
+        order: parseOrderValue(data.order),
       });
     } catch {
       // Ignore malformed project entries
     }
   }
-  return projects;
+  return projects.sort(compareProjectListItems);
+}
+
+function projectListIdentity(project) {
+  return project?.rootId || project?.id || project?.dirName || project?.projectDir || null;
+}
+
+function projectListIdentities(project) {
+  return [project?.rootId, project?.id, project?.dirName, project?.projectDir].filter(Boolean);
+}
+
+async function writeProjectRootOrder(projectDir, order) {
+  const projectFile = path.join(projectDir, "_project.md");
+  const content = await fs.promises.readFile(projectFile, "utf8");
+  const { data, body } = parseFrontmatter(content);
+  if (parseOrderValue(data.order) === order) {
+    return false;
+  }
+  return writeFileIfChanged(projectFile, stringifyFrontmatter({ ...data, order }, body), "utf8");
+}
+
+async function setProjectOrderAsync(workspacePath, orderedProjects) {
+  if (!workspacePath || typeof workspacePath !== "string") {
+    throw new Error("Invalid workspacePath");
+  }
+  if (!fs.existsSync(workspacePath)) {
+    throw new Error("workspacePath does not exist");
+  }
+
+  const currentProjects = listProjects(workspacePath);
+  const currentByIdentity = new Map();
+  for (const project of currentProjects) {
+    for (const identity of projectListIdentities(project)) {
+      currentByIdentity.set(identity, project);
+    }
+  }
+
+  const nextProjects = [];
+  const seen = new Set();
+  for (const project of Array.isArray(orderedProjects) ? orderedProjects : []) {
+    const identity = projectListIdentity(project);
+    const current = identity ? currentByIdentity.get(identity) : null;
+    const currentIdentity = projectListIdentity(current);
+    if (!current || !currentIdentity || seen.has(currentIdentity)) continue;
+    nextProjects.push(current);
+    seen.add(currentIdentity);
+  }
+
+  for (const project of currentProjects) {
+    const identity = projectListIdentity(project);
+    if (!identity || seen.has(identity)) continue;
+    nextProjects.push(project);
+    seen.add(identity);
+  }
+
+  const changedProjectDirs = [];
+  for (const [index, project] of nextProjects.entries()) {
+    const changed = await writeProjectRootOrder(project.projectDir, index);
+    project.order = index;
+    if (changed) {
+      changedProjectDirs.push(project.projectDir);
+    }
+  }
+
+  return { projects: nextProjects, changedProjectDirs };
 }
 
 /**
@@ -1175,6 +1263,7 @@ module.exports = {
   deleteProject,
   deleteProjectAsync,
   listProjects,
+  setProjectOrderAsync,
   wouldCreateCycle,
   bfsFromRoot,
   exportProjectData,

--- a/src/App.svelte
+++ b/src/App.svelte
@@ -11,6 +11,7 @@
     undoHistory,
     redoHistory,
     saveStatus,
+    projectLoading,
   } from "@stores";
   import { onMount, onDestroy } from "svelte";
   import * as platform from "@lib/ipc/platform";
@@ -242,7 +243,11 @@
             No data.
           </h1>
         {/if}
-        {#if $selected_type == "Projects" || $selected_type == "WorkspaceProject"}
+        {#if ($selected_type == "Projects" || $selected_type == "WorkspaceProject") && $projectLoading}
+          <h1 style="color:var(--theme-color-Sub-main); display:flex; justify-content:center">
+            Loading...
+          </h1>
+        {:else if $selected_type == "Projects" || $selected_type == "WorkspaceProject"}
           <ProjectPage />
         {/if}
         {#if $selected_type == "Info"}

--- a/src/features/navigation/components/MenuList.svelte
+++ b/src/features/navigation/components/MenuList.svelte
@@ -1,5 +1,6 @@
 ﻿<script context="module">
   let dragged_id; // Project ID being dragged
+  let dragged_section; // Sidebar project section being dragged
 </script>
 
 <script>
@@ -112,16 +113,42 @@
   // Drag and drop
   let dragOverTarget;
   let dragOverType;
+  const reorderSections = new Set(["Projects", "WorkspaceProject"]);
+
+  function canReorderSection(section) {
+    return reorderSections.has(section);
+  }
 
   // Function to get the list of projects
   function getProjectElements() {
-    return document.querySelectorAll('.MenuRow[data-section="Projects"]');
+    return document.querySelectorAll(
+      '.MenuRow[data-section="Projects"], .MenuRow[data-section="WorkspaceProject"]'
+    );
+  }
+
+  function getProjectsForSection(section) {
+    return section === "WorkspaceProject"
+      ? ($workspace_store.projects ?? [])
+      : ($project_ids ?? []);
+  }
+
+  function getProjectId(project, section) {
+    return section === "WorkspaceProject" ? project.rootId : project.id;
+  }
+
+  function saveProjectOrder(section, projects) {
+    if (section === "WorkspaceProject") {
+      workspace_store.setProjectOrder(projects);
+      return;
+    }
+    project_ids.update(() => projects);
+    project_ids.setProjectOrder(projects);
   }
 
   // Drag start
   function dragStart(e) {
     const el = e.currentTarget;
-    if (el.dataset.section !== "Projects") return;
+    if (!canReorderSection(el.dataset.section)) return;
 
     el.classList.add("Dragging");
 
@@ -135,6 +162,7 @@
     e.dataTransfer.setDragImage(name_tag, -rem, -rem);
 
     dragged_id = el.dataset.id;
+    dragged_section = el.dataset.section;
   }
 
   // Drag end
@@ -142,6 +170,8 @@
     const el = e.currentTarget;
     dragOverType = undefined;
     dragOverTarget = undefined;
+    dragged_id = undefined;
+    dragged_section = undefined;
     el.classList.remove("Dragging");
     const nameTag = document.querySelector(".NameTag");
     if (nameTag) nameTag.remove();
@@ -152,8 +182,7 @@
     e.preventDefault();
     const el = e.currentTarget;
 
-    // Only the project section can be reordered
-    if (el.dataset.section !== "Projects") return;
+    if (!canReorderSection(el.dataset.section) || el.dataset.section !== dragged_section) return;
 
     // If not the dragging item itself or the currently dragged item
     if (!el.classList.contains("Dragging") && el.dataset.id !== dragged_id) {
@@ -186,14 +215,16 @@
   // Drop
   function dragDrop(e) {
     const el = e.currentTarget;
-    if (el.dataset.section !== "Projects" || !dragOverType) return;
+    const section = el.dataset.section;
+    if (!canReorderSection(section) || section !== dragged_section || !dragOverType) return;
 
-    const draggedIndex = $project_ids.findIndex((p) => p.id === dragged_id);
-    const targetIndex = $project_ids.findIndex((p) => p.id === el.dataset.id);
+    const projects = getProjectsForSection(section);
+    const draggedIndex = projects.findIndex((p) => getProjectId(p, section) === dragged_id);
+    const targetIndex = projects.findIndex((p) => getProjectId(p, section) === el.dataset.id);
 
     if (draggedIndex !== -1 && targetIndex !== -1) {
       // Clone the project array
-      const newProjects = [...$project_ids];
+      const newProjects = [...projects];
 
       // Remove the dragged item
       const [draggedProject] = newProjects.splice(draggedIndex, 1);
@@ -209,11 +240,7 @@
       // Reinsert into the array
       newProjects.splice(Math.max(0, insertAt), 0, draggedProject);
 
-      // Update the store
-      project_ids.update(() => newProjects);
-
-      // Save the new order to backend
-      project_ids.setProjectOrder(newProjects);
+      saveProjectOrder(section, newProjects);
     }
 
     // Reset
@@ -221,6 +248,7 @@
     el.classList.remove("DragOverBottom");
     dragOverType = undefined;
     dragged_id = undefined;
+    dragged_section = undefined;
   }
 
   // Add cleanup function to prevent duplicate event listeners

--- a/src/features/tasks/stores/tree.ts
+++ b/src/features/tasks/stores/tree.ts
@@ -18,9 +18,13 @@ import {
   clearPendingTaskDetailSelection,
   saveStatus,
 } from "@stores/ui";
-import { workspace_store, workspace_tasks_cache } from "@features/workspace/stores/workspace";
+import {
+  workspace_store,
+  workspace_tasks_cache,
+  type WorkspaceState,
+} from "@features/workspace/stores/workspace";
 import type { SelectedType } from "@app-types/app";
-import type { WorkspaceTask } from "@app-types/workspace";
+import type { WorkspaceProjectListItem, WorkspaceTask } from "@app-types/workspace";
 
 export interface TreeDataStore extends Writable<ProjectData | undefined> {
   init: () => void;
@@ -32,6 +36,7 @@ interface PersistContext {
   selectedType: SelectedType;
   selectedId: string | undefined;
   activeProjectDir: string | null;
+  activeWorkspaceProject: WorkspaceProjectListItem | undefined;
   cachedWorkspaceTasks: Record<string, WorkspaceTask>;
 }
 
@@ -55,6 +60,48 @@ export function clearHistory() {
   undoStack = [];
   redoStack = [];
   skipSnapshot = true;
+}
+
+function getWorkspaceRootTask(tasks: WorkspaceTask[]): WorkspaceTask | undefined {
+  return tasks.find((task) => task.parents.length === 0);
+}
+
+function getWorkspaceRootTaskFromRecord(
+  tasks: Record<string, WorkspaceTask>
+): WorkspaceTask | undefined {
+  return Object.values(tasks).find((task) => task.parents.length === 0);
+}
+
+function getActiveWorkspaceProject(
+  projects: WorkspaceProjectListItem[],
+  activeProjectDir: string | null,
+  selectedId: string | undefined
+): WorkspaceProjectListItem | undefined {
+  return projects.find(
+    (project) => project.projectDir === activeProjectDir || project.rootId === selectedId
+  );
+}
+
+function syncWorkspaceProjectSummaryFromTree(
+  current: ProjectData | undefined,
+  selectedType: SelectedType,
+  selectedId: string | undefined,
+  workspaceState: WorkspaceState
+) {
+  if (selectedType !== "WorkspaceProject" || !workspaceState.activeProjectDir || !current?.data) {
+    return;
+  }
+
+  const activeProject = getActiveWorkspaceProject(
+    workspaceState.projects,
+    workspaceState.activeProjectDir,
+    selectedId
+  );
+  workspace_store.syncProjectListItem(workspaceState.activeProjectDir, {
+    rootId: current.data.id,
+    name: current.data.data.name,
+    order: activeProject?.order,
+  });
 }
 
 function createTreeData(initialValue: ProjectData | undefined): TreeDataStore {
@@ -130,6 +177,10 @@ function createTreeData(initialValue: ProjectData | undefined): TreeDataStore {
         if (!activeProjectDir) return;
         const cachedTasks = context.cachedWorkspaceTasks;
         const tasks = projectDataToWorkspaceTasks(current, cachedTasks);
+        const rootTask = getWorkspaceRootTask(tasks);
+        if (rootTask && typeof context.activeWorkspaceProject?.order === "number") {
+          rootTask.order = context.activeWorkspaceProject.order;
+        }
         try {
           platform
             .wsWriteProject(activeProjectDir, tasks)
@@ -181,6 +232,15 @@ function createTreeData(initialValue: ProjectData | undefined): TreeDataStore {
           }
         });
         platform.onWorkspaceProjectUpdated((event) => {
+          const rootTask = getWorkspaceRootTaskFromRecord(event.tasks);
+          if (rootTask) {
+            workspace_store.syncProjectListItem(event.projectDir, {
+              rootId: rootTask.id,
+              name: rootTask.name,
+              order: rootTask.order,
+            });
+          }
+
           const currentSelectedType = get(selected_type);
           const currentSelectedId = get(selected_id);
           const activeProjectDir = get(workspace_store).activeProjectDir;
@@ -229,6 +289,10 @@ function createTreeData(initialValue: ProjectData | undefined): TreeDataStore {
       }
 
       subscribe((current) => {
+        const currentSelectedType = get(selected_type);
+        const currentSelectedId = get(selected_id);
+        const workspaceState = get(workspace_store);
+
         if (current === undefined) {
           if (pendingTaskDetailSelection?.projectId) {
             selected_type.set("Projects");
@@ -245,6 +309,13 @@ function createTreeData(initialValue: ProjectData | undefined): TreeDataStore {
             });
           }
         }
+
+        syncWorkspaceProjectSummaryFromTree(
+          current,
+          currentSelectedType,
+          currentSelectedId,
+          workspaceState
+        );
 
         if (skipPersistOnce) {
           skipPersistOnce = false;
@@ -276,9 +347,14 @@ function createTreeData(initialValue: ProjectData | undefined): TreeDataStore {
           saveStatus.set("idle");
         }
         persistTreeData(current, {
-          selectedType: get(selected_type),
-          selectedId: get(selected_id),
-          activeProjectDir: get(workspace_store).activeProjectDir,
+          selectedType: currentSelectedType,
+          selectedId: currentSelectedId,
+          activeProjectDir: workspaceState.activeProjectDir,
+          activeWorkspaceProject: getActiveWorkspaceProject(
+            workspaceState.projects,
+            workspaceState.activeProjectDir,
+            currentSelectedId
+          ),
           cachedWorkspaceTasks: get(workspace_tasks_cache),
         });
       });

--- a/src/features/tasks/stores/tree.ts
+++ b/src/features/tasks/stores/tree.ts
@@ -29,6 +29,7 @@ import type { WorkspaceProjectListItem, WorkspaceTask } from "@app-types/workspa
 export interface TreeDataStore extends Writable<ProjectData | undefined> {
   init: () => void;
   setFromSource: (value: ProjectData | undefined) => void;
+  resetForLoad: () => void;
   flushPendingPersist: () => void;
 }
 
@@ -108,6 +109,7 @@ function createTreeData(initialValue: ProjectData | undefined): TreeDataStore {
   const { subscribe, set, update } = writable<ProjectData | undefined>(initialValue);
   let previousData: ProjectData | null = null;
   let skipPersistOnce = false;
+  let suppressInitialLoadOnce = false;
   let syncListenerRegistered = false;
 
   const findRemovedNodeIds = (
@@ -219,6 +221,11 @@ function createTreeData(initialValue: ProjectData | undefined): TreeDataStore {
       skipPersistOnce = true;
       set(value);
     },
+    resetForLoad: () => {
+      suppressInitialLoadOnce = true;
+      skipPersistOnce = true;
+      set(undefined);
+    },
     flushPendingPersist: () => {
       persistTreeData.flush();
     },
@@ -294,7 +301,9 @@ function createTreeData(initialValue: ProjectData | undefined): TreeDataStore {
         const workspaceState = get(workspace_store);
 
         if (current === undefined) {
-          if (pendingTaskDetailSelection?.projectId) {
+          if (suppressInitialLoadOnce) {
+            suppressInitialLoadOnce = false;
+          } else if (pendingTaskDetailSelection?.projectId) {
             selected_type.set("Projects");
             selected_id.set(pendingTaskDetailSelection.projectId);
             if (pendingTaskDetailSelection.taskId) {

--- a/src/features/workspace/stores/workspace.ts
+++ b/src/features/workspace/stores/workspace.ts
@@ -19,6 +19,13 @@ export interface WorkspaceStore extends Writable<WorkspaceState> {
   removeWorkspace: (path: string) => void;
   setActive: (path: string) => Promise<void>;
   refreshProjects: () => Promise<void>;
+  setProjectOrder: (
+    projects: WorkspaceProjectListItem[]
+  ) => Promise<{ success: boolean; error?: string }>;
+  syncProjectListItem: (
+    projectDir: string,
+    summary: { rootId?: string; name?: string; order?: number }
+  ) => void;
   setActiveProject: (projectDir: string) => void;
   createProject: (
     name: string,
@@ -48,6 +55,17 @@ function createWorkspaceStore(): WorkspaceStore {
     } catch {
       return [];
     }
+  }
+
+  function nextProjectOrder(projects: WorkspaceProjectListItem[]) {
+    const ordered = projects
+      .map((project) => project.order)
+      .filter((order): order is number => typeof order === "number" && Number.isFinite(order));
+    return ordered.length > 0 ? Math.max(...ordered) + 1 : projects.length;
+  }
+
+  function withSequentialProjectOrder(projects: WorkspaceProjectListItem[]) {
+    return projects.map((project, index) => ({ ...project, order: index }));
   }
 
   return {
@@ -110,25 +128,71 @@ function createWorkspaceStore(): WorkspaceStore {
       update((s) => ({ ...s, projects }));
     },
 
-    setActiveProject(projectDir: string) {
-      update((s) => ({ ...s, activeProjectDir: projectDir }));
-    },
-
-    async createProject(name: string, id: string) {
+    async setProjectOrder(projects: WorkspaceProjectListItem[]) {
       const { activeWorkspacePath } = get({ subscribe } as WorkspaceStore);
       if (!activeWorkspacePath) {
         return { success: false, error: "No active workspace" };
       }
 
-      const result = await platform.wsCreateProject(activeWorkspacePath, name, id);
+      const orderedProjects = withSequentialProjectOrder(projects);
+      update((s) => ({ ...s, projects: orderedProjects }));
+      let result: { success: boolean; projects?: WorkspaceProjectListItem[]; error?: string };
+      try {
+        result = await platform.wsSetProjectOrder(activeWorkspacePath, orderedProjects);
+      } catch {
+        return { success: false, error: "Failed to save project order" };
+      }
+      if (!result?.success) {
+        return { success: false, error: result?.error ?? "Failed to save project order" };
+      }
+
+      return { success: true };
+    },
+
+    syncProjectListItem(projectDir, summary) {
+      update((state) => ({
+        ...state,
+        projects: state.projects.map((project) => {
+          const matchesProject =
+            project.projectDir === projectDir ||
+            (Boolean(summary.rootId) && project.rootId === summary.rootId);
+          if (!matchesProject) return project;
+          return {
+            ...project,
+            rootId: summary.rootId ?? project.rootId,
+            name: summary.name ?? project.name,
+            order: summary.order ?? project.order,
+          };
+        }),
+      }));
+    },
+
+    setActiveProject(projectDir: string) {
+      update((s) => ({ ...s, activeProjectDir: projectDir }));
+    },
+
+    async createProject(name: string, id: string) {
+      const { activeWorkspacePath, projects } = get({ subscribe } as WorkspaceStore);
+      if (!activeWorkspacePath) {
+        return { success: false, error: "No active workspace" };
+      }
+
+      const order = nextProjectOrder(projects);
+      const result = await platform.wsCreateProject(activeWorkspacePath, name, id, order);
       if (!result?.success || !result.projectDir) {
         return { success: false, error: result?.error ?? "Failed to create workspace project" };
       }
 
-      const projects = await loadProjects(activeWorkspacePath);
+      const project: WorkspaceProjectListItem = {
+        name,
+        rootId: id,
+        dirName: result.dirName ?? result.projectDir.split(/[/\\]/).pop() ?? name,
+        projectDir: result.projectDir,
+        order,
+      };
       update((s) => ({
         ...s,
-        projects,
+        projects: [...s.projects.filter((item) => item.projectDir !== project.projectDir), project],
         activeProjectDir: result.projectDir ?? s.activeProjectDir,
       }));
       return { success: true, projectDir: result.projectDir };
@@ -139,13 +203,12 @@ function createWorkspaceStore(): WorkspaceStore {
       if (!result?.success) {
         return { success: false, error: result?.error ?? "Failed to delete workspace project" };
       }
-      const { activeWorkspacePath, activeProjectDir } = get({
+      const { activeProjectDir } = get({
         subscribe,
       } as WorkspaceStore);
-      const projects = activeWorkspacePath ? await loadProjects(activeWorkspacePath) : [];
       update((s) => ({
         ...s,
-        projects,
+        projects: s.projects.filter((project) => project.projectDir !== projectDir),
         activeProjectDir: activeProjectDir === projectDir ? null : activeProjectDir,
       }));
       return { success: true };

--- a/src/features/workspace/utils/workspace_tree.ts
+++ b/src/features/workspace/utils/workspace_tree.ts
@@ -114,7 +114,7 @@ export function projectDataToWorkspaceTasks(
         };
       }),
       createdAt: existing?.createdAt || today,
-      order: siblingIndex,
+      order: parentIds.length === 0 ? existing?.order : siblingIndex,
     });
     for (const [index, child] of (node.children || []).entries()) {
       traverse(child, [node.id], index);

--- a/src/lib/ipc/platform.ts
+++ b/src/lib/ipc/platform.ts
@@ -188,6 +188,16 @@ export function wsListProjects(workspacePath: string): Promise<WorkspaceProjectL
   return api()?.wsListProjects?.(workspacePath) ?? Promise.resolve([]);
 }
 
+export function wsSetProjectOrder(
+  workspacePath: string,
+  projects: WorkspaceProjectListItem[]
+): Promise<{ success: boolean; projects?: WorkspaceProjectListItem[]; error?: string }> {
+  return (
+    api()?.wsSetProjectOrder?.(workspacePath, projects) ??
+    Promise.resolve({ success: false, error: "API unavailable" })
+  );
+}
+
 export function wsReadProject(projectDir: string): Promise<WorkspaceProject | undefined> {
   return api()?.wsReadProject?.(projectDir) ?? Promise.resolve(undefined);
 }
@@ -248,10 +258,11 @@ export function wsDeleteTask(
 export function wsCreateProject(
   workspacePath: string,
   name: string,
-  id: string
+  id: string,
+  order?: number
 ): Promise<{ success: boolean; projectDir?: string; dirName?: string; error?: string }> {
   return (
-    api()?.wsCreateProject?.(workspacePath, name, id) ??
+    api()?.wsCreateProject?.(workspacePath, name, id, order) ??
     Promise.resolve({ success: false, error: "API unavailable" })
   );
 }

--- a/src/stores/ui.ts
+++ b/src/stores/ui.ts
@@ -54,6 +54,8 @@ function collectNodeAndDescendantIds(node: TreeData | undefined): string[] {
   return ids;
 }
 
+export const projectLoading = writable(false);
+
 function createSelectedID(initialValue: string | undefined): SelectedIdStore {
   const { subscribe, set, update } = writable<string | undefined>(initialValue);
 
@@ -72,53 +74,102 @@ function createSelectedID(initialValue: string | undefined): SelectedIdStore {
           loadQueued = false;
           const current = get({ subscribe } as SelectedIdStore);
           const currentSelectedType = get(selected_type);
-          if (!current) return;
+          const version = ++loadVersion;
+          if (!current) {
+            projectLoading.set(false);
+            return;
+          }
 
           tree_data.flushPendingPersist();
           table_selected_id.set(undefined);
-          const version = ++loadVersion;
           if (currentSelectedType === "Projects") {
+            projectLoading.set(true);
+            tree_data.resetForLoad();
             loadProjectsData(current, version);
           } else if (currentSelectedType === "WorkspaceProject") {
+            projectLoading.set(true);
+            tree_data.resetForLoad();
             loadWorkspaceData(current, version);
+          } else {
+            projectLoading.set(false);
           }
         });
       }
 
+      function finishLoad(version: number) {
+        if (version === loadVersion) {
+          projectLoading.set(false);
+        }
+      }
+
       function loadProjectsData(current: string, version: number) {
         clearHistory();
-        platform.getTreeData(current).then((result) => {
-          if (version !== loadVersion) return;
-          tree_data.setFromSource(result);
+        platform
+          .getTreeData(current)
+          .then((result) => {
+            if (version !== loadVersion) return;
+            if (!result) {
+              tree_data.resetForLoad();
+              table_selected_id.set(undefined);
+              finishLoad(version);
+              return;
+            }
+            tree_data.setFromSource(result);
 
-          if (
-            pendingTaskDetailSelection?.projectId === current &&
-            pendingTaskDetailSelection.taskId
-          ) {
-            if (result?.data && getNode(pendingTaskDetailSelection.taskId, result.data)) {
-              table_selected_id.set(pendingTaskDetailSelection.taskId);
+            if (
+              pendingTaskDetailSelection?.projectId === current &&
+              pendingTaskDetailSelection.taskId
+            ) {
+              if (getNode(pendingTaskDetailSelection.taskId, result.data)) {
+                table_selected_id.set(pendingTaskDetailSelection.taskId);
+              } else {
+                clearPendingTaskDetailSelection();
+                table_selected_id.set(undefined);
+              }
             } else {
-              clearPendingTaskDetailSelection();
               table_selected_id.set(undefined);
             }
-          } else {
-            table_selected_id.set(undefined);
-          }
-        });
+            finishLoad(version);
+          }, () => {
+            if (version === loadVersion) {
+              tree_data.resetForLoad();
+              table_selected_id.set(undefined);
+            }
+            finishLoad(version);
+          });
       }
 
       function loadWorkspaceData(current: string, version: number) {
         clearHistory();
         const { activeProjectDir } = get(workspace_store);
-        if (!activeProjectDir) return;
-        platform.wsReadProject(activeProjectDir).then((result) => {
-          if (version !== loadVersion) return;
-          if (!result) return;
-          workspace_tasks_cache.set(result.tasks);
-          const converted = workspaceToProjectData(result.tasks, current);
-          tree_data.setFromSource(converted);
+        if (!activeProjectDir) {
+          tree_data.resetForLoad();
           table_selected_id.set(undefined);
-        });
+          finishLoad(version);
+          return;
+        }
+        platform
+          .wsReadProject(activeProjectDir)
+          .then((result) => {
+            if (version !== loadVersion) return;
+            if (!result) {
+              tree_data.resetForLoad();
+              table_selected_id.set(undefined);
+              finishLoad(version);
+              return;
+            }
+            workspace_tasks_cache.set(result.tasks);
+            const converted = workspaceToProjectData(result.tasks, current);
+            tree_data.setFromSource(converted);
+            table_selected_id.set(undefined);
+            finishLoad(version);
+          }, () => {
+            if (version === loadVersion) {
+              tree_data.resetForLoad();
+              table_selected_id.set(undefined);
+            }
+            finishLoad(version);
+          });
       }
 
       subscribe(() => {

--- a/src/stores/ui.ts
+++ b/src/stores/ui.ts
@@ -104,9 +104,8 @@ function createSelectedID(initialValue: string | undefined): SelectedIdStore {
 
       function loadProjectsData(current: string, version: number) {
         clearHistory();
-        platform
-          .getTreeData(current)
-          .then((result) => {
+        platform.getTreeData(current).then(
+          (result) => {
             if (version !== loadVersion) return;
             if (!result) {
               tree_data.resetForLoad();
@@ -130,13 +129,15 @@ function createSelectedID(initialValue: string | undefined): SelectedIdStore {
               table_selected_id.set(undefined);
             }
             finishLoad(version);
-          }, () => {
+          },
+          () => {
             if (version === loadVersion) {
               tree_data.resetForLoad();
               table_selected_id.set(undefined);
             }
             finishLoad(version);
-          });
+          }
+        );
       }
 
       function loadWorkspaceData(current: string, version: number) {
@@ -148,9 +149,8 @@ function createSelectedID(initialValue: string | undefined): SelectedIdStore {
           finishLoad(version);
           return;
         }
-        platform
-          .wsReadProject(activeProjectDir)
-          .then((result) => {
+        platform.wsReadProject(activeProjectDir).then(
+          (result) => {
             if (version !== loadVersion) return;
             if (!result) {
               tree_data.resetForLoad();
@@ -163,13 +163,15 @@ function createSelectedID(initialValue: string | undefined): SelectedIdStore {
             tree_data.setFromSource(converted);
             table_selected_id.set(undefined);
             finishLoad(version);
-          }, () => {
+          },
+          () => {
             if (version === loadVersion) {
               tree_data.resetForLoad();
               table_selected_id.set(undefined);
             }
             finishLoad(version);
-          });
+          }
+        );
       }
 
       subscribe(() => {

--- a/src/types/app.ts
+++ b/src/types/app.ts
@@ -101,6 +101,10 @@ export interface ElectronAPI {
   wsGetWorkspaces: () => Promise<{ workspaces: WorkspaceInfo[]; activeWorkspace: string | null }>;
   wsSetWorkspaces: (config: { workspaces: WorkspaceInfo[]; activeWorkspace?: string }) => void;
   wsListProjects: (workspacePath: string) => Promise<WorkspaceProjectListItem[]>;
+  wsSetProjectOrder: (
+    workspacePath: string,
+    projects: WorkspaceProjectListItem[]
+  ) => Promise<{ success: boolean; projects?: WorkspaceProjectListItem[]; error?: string }>;
   wsReadProject: (projectDir: string) => Promise<WorkspaceProject>;
   wsWriteTask: (
     projectDir: string,
@@ -128,7 +132,8 @@ export interface ElectronAPI {
   wsCreateProject: (
     workspacePath: string,
     name: string,
-    id: string
+    id: string,
+    order?: number
   ) => Promise<{ success: boolean; projectDir?: string; dirName?: string; error?: string }>;
   wsDeleteProject: (projectDir: string) => Promise<{ success: boolean; error?: string }>;
   wsResolveConflict: (

--- a/src/types/workspace.ts
+++ b/src/types/workspace.ts
@@ -33,6 +33,7 @@ export interface WorkspaceProjectListItem {
   rootId: string;
   dirName: string;
   projectDir: string;
+  order?: number;
 }
 
 export interface WorkspaceProject {

--- a/tests/component/AppWorkspaceProject.test.js
+++ b/tests/component/AppWorkspaceProject.test.js
@@ -32,12 +32,14 @@ vi.mock("@pages/TaskDetailPage.svelte", async () => {
 });
 
 import App from "../../src/App.svelte";
-import { selected_id, selected_type } from "@stores";
+import { get } from "svelte/store";
+import { projectLoading, selected_id, selected_type, tree_data, workspace_store } from "@stores";
 
 function makeElectronAPI() {
   return {
     getInitialTreeData: vi.fn().mockResolvedValue(undefined),
     getProjectIDs: vi.fn().mockResolvedValue([]),
+    wsReadProject: vi.fn().mockResolvedValue(undefined),
     onProjectDeleted: vi.fn(),
     onTreeDataUpdated: vi.fn(),
     onThemeChanged: vi.fn(),
@@ -52,6 +54,14 @@ describe("App - workspace project rendering", () => {
   afterEach(() => {
     selected_type.set(undefined);
     selected_id.set(undefined);
+    projectLoading.set(false);
+    tree_data.resetForLoad();
+    workspace_store.set({
+      workspaces: [],
+      activeWorkspacePath: null,
+      activeProjectDir: null,
+      projects: [],
+    });
     delete window.electronAPI;
   });
 
@@ -70,5 +80,68 @@ describe("App - workspace project rendering", () => {
     await tick();
 
     expect(screen.getByTestId("tree-table-stub")).toBeInTheDocument();
+  });
+
+  test("resets the project page while a workspace project switch is loading", async () => {
+    let resolveReadProject;
+    const readProject = new Promise((resolve) => {
+      resolveReadProject = resolve;
+    });
+    const api = {
+      ...makeElectronAPI(),
+      wsReadProject: vi.fn().mockReturnValue(readProject),
+    };
+    Object.defineProperty(window, "electronAPI", {
+      configurable: true,
+      value: api,
+    });
+
+    render(App);
+    await tick();
+    await tick();
+
+    workspace_store.set({
+      workspaces: [],
+      activeWorkspacePath: "C:/workspace",
+      activeProjectDir: "C:/workspace/beta",
+      projects: [
+        {
+          name: "Beta",
+          rootId: "root-beta",
+          dirName: "beta",
+          projectDir: "C:/workspace/beta",
+          order: 0,
+        },
+      ],
+    });
+    selected_type.set("WorkspaceProject");
+    selected_id.set("root-beta");
+    await tick();
+    await tick();
+
+    expect(get(projectLoading)).toBe(true);
+    expect(screen.getByText("Loading...")).toBeInTheDocument();
+    expect(screen.queryByTestId("tree-table-stub")).toBeNull();
+
+    resolveReadProject({
+      tasks: {
+        "root-beta": {
+          id: "root-beta",
+          name: "Beta",
+          status: "Open",
+          parents: [],
+          memos: [],
+          createdAt: "2026-01-01",
+        },
+      },
+    });
+    await readProject;
+    await tick();
+    await tick();
+
+    expect(get(projectLoading)).toBe(false);
+    expect(screen.getByTestId("tree-table-stub")).toBeInTheDocument();
+    expect(get(tree_data).data.data.name).toBe("Beta");
+    expect(api.wsReadProject).toHaveBeenCalledWith("C:/workspace/beta");
   });
 });

--- a/tests/unit/workspace.test.js
+++ b/tests/unit/workspace.test.js
@@ -26,6 +26,7 @@ import {
   deleteProject,
   deleteProjectAsync,
   listProjects,
+  setProjectOrderAsync,
   exportProjectData,
   legacyMemoContentToMarkdown,
   migrateProjectData,
@@ -236,6 +237,36 @@ describe("file system operations", () => {
     const projects = listProjects(tmpDir);
     expect(projects).toHaveLength(2);
     expect(projects.map((p) => p.name)).toEqual(expect.arrayContaining(["Alpha", "Beta"]));
+  });
+
+  it("setProjectOrderAsync persists workspace project order in root frontmatter", async () => {
+    createProject(tmpDir, "Alpha", "alpha-id");
+    createProject(tmpDir, "Beta", "beta-id");
+    createProject(tmpDir, "Gamma", "gamma-id");
+    const initial = listProjects(tmpDir);
+
+    const result = await setProjectOrderAsync(tmpDir, [
+      initial.find((p) => p.rootId === "gamma-id"),
+      initial.find((p) => p.rootId === "alpha-id"),
+      initial.find((p) => p.rootId === "beta-id"),
+    ]);
+
+    expect(result.changedProjectDirs).toHaveLength(3);
+    expect(listProjects(tmpDir).map((p) => p.rootId)).toEqual(["gamma-id", "alpha-id", "beta-id"]);
+
+    const gamma = listProjects(tmpDir).find((p) => p.rootId === "gamma-id");
+    const gammaProject = fs.readFileSync(path.join(gamma.projectDir, "_project.md"), "utf8");
+    expect(parseFrontmatter(gammaProject).data.order).toBe("0");
+  });
+
+  it("setProjectOrderAsync keeps unknown or newly discovered projects after the saved order", async () => {
+    createProject(tmpDir, "Alpha", "alpha-id");
+    createProject(tmpDir, "Beta", "beta-id");
+    createProject(tmpDir, "Gamma", "gamma-id");
+
+    await setProjectOrderAsync(tmpDir, [{ rootId: "beta-id" }, { rootId: "missing-id" }]);
+
+    expect(listProjects(tmpDir).map((p) => p.rootId)).toEqual(["beta-id", "alpha-id", "gamma-id"]);
   });
 
   it("deleteProject removes the project directory recursively", () => {

--- a/tests/unit/workspace_store.test.ts
+++ b/tests/unit/workspace_store.test.ts
@@ -1,0 +1,122 @@
+import { get } from "svelte/store";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { workspace_store } from "../../src/features/workspace/stores/workspace";
+import type { ElectronAPI } from "../../src/types/app";
+
+const emptyState = {
+  workspaces: [],
+  activeWorkspacePath: null,
+  activeProjectDir: null,
+  projects: [],
+};
+
+const testWindow = window as unknown as { electronAPI?: Partial<ElectronAPI> };
+
+describe("workspace_store", () => {
+  afterEach(() => {
+    workspace_store.set(emptyState);
+    delete testWindow.electronAPI;
+  });
+
+  it("syncProjectListItem updates a workspace project summary from memory", () => {
+    workspace_store.set({
+      workspaces: [],
+      activeWorkspacePath: "C:/workspace",
+      activeProjectDir: "C:/workspace/alpha",
+      projects: [
+        {
+          name: "Alpha",
+          rootId: "root-alpha",
+          dirName: "alpha",
+          projectDir: "C:/workspace/alpha",
+          order: 1,
+        },
+        {
+          name: "Beta",
+          rootId: "root-beta",
+          dirName: "beta",
+          projectDir: "C:/workspace/beta",
+          order: 2,
+        },
+      ],
+    });
+
+    workspace_store.syncProjectListItem("C:/workspace/alpha", {
+      rootId: "root-alpha",
+      name: "Renamed Alpha",
+      order: 1,
+    });
+
+    expect(get(workspace_store).projects.map((project) => project.name)).toEqual([
+      "Renamed Alpha",
+      "Beta",
+    ]);
+  });
+
+  it("keeps memory order when order persistence fails", async () => {
+    const wsSetProjectOrder = vi.fn().mockResolvedValue({ success: false, error: "disk" });
+    const wsListProjects = vi.fn().mockResolvedValue([]);
+    testWindow.electronAPI = { wsSetProjectOrder, wsListProjects };
+    const alpha = {
+      name: "Alpha",
+      rootId: "root-alpha",
+      dirName: "alpha",
+      projectDir: "C:/workspace/alpha",
+      order: 0,
+    };
+    const beta = {
+      name: "Beta",
+      rootId: "root-beta",
+      dirName: "beta",
+      projectDir: "C:/workspace/beta",
+      order: 1,
+    };
+    workspace_store.set({
+      workspaces: [],
+      activeWorkspacePath: "C:/workspace",
+      activeProjectDir: "C:/workspace/alpha",
+      projects: [alpha, beta],
+    });
+
+    const result = await workspace_store.setProjectOrder([beta, alpha]);
+
+    expect(result.success).toBe(false);
+    expect(wsListProjects).not.toHaveBeenCalled();
+    expect(get(workspace_store).projects.map((project) => project.name)).toEqual(["Beta", "Alpha"]);
+    expect(get(workspace_store).projects.map((project) => project.order)).toEqual([0, 1]);
+  });
+
+  it("creates a project by appending the known in-memory summary without rereading the list", async () => {
+    const wsCreateProject = vi.fn().mockResolvedValue({
+      success: true,
+      dirName: "gamma",
+      projectDir: "C:/workspace/gamma",
+    });
+    const wsListProjects = vi.fn().mockResolvedValue([]);
+    testWindow.electronAPI = { wsCreateProject, wsListProjects };
+    workspace_store.set({
+      workspaces: [],
+      activeWorkspacePath: "C:/workspace",
+      activeProjectDir: null,
+      projects: [
+        {
+          name: "Alpha",
+          rootId: "root-alpha",
+          dirName: "alpha",
+          projectDir: "C:/workspace/alpha",
+          order: 0,
+        },
+      ],
+    });
+
+    const result = await workspace_store.createProject("Gamma", "root-gamma");
+
+    expect(result.success).toBe(true);
+    expect(wsCreateProject).toHaveBeenCalledWith("C:/workspace", "Gamma", "root-gamma", 1);
+    expect(wsListProjects).not.toHaveBeenCalled();
+    expect(get(workspace_store).projects.map((project) => project.name)).toEqual([
+      "Alpha",
+      "Gamma",
+    ]);
+  });
+});

--- a/tests/unit/workspace_tree.test.ts
+++ b/tests/unit/workspace_tree.test.ts
@@ -1,0 +1,61 @@
+import { describe, expect, it } from "vitest";
+import { projectDataToWorkspaceTasks } from "../../src/features/workspace/utils/workspace_tree";
+
+describe("workspace tree conversion", () => {
+  it("preserves root order while assigning child sibling order", () => {
+    const tasks = projectDataToWorkspaceTasks(
+      {
+        headers: [],
+        data: {
+          id: "root-id",
+          data: {
+            name: "Project",
+            status: "Open",
+            "start date": undefined,
+            "due date": undefined,
+            memo: [],
+          },
+          children: [
+            {
+              id: "child-a",
+              data: {
+                name: "Child A",
+                status: "Open",
+                "start date": undefined,
+                "due date": undefined,
+                memo: [],
+              },
+              children: [],
+            },
+            {
+              id: "child-b",
+              data: {
+                name: "Child B",
+                status: "Open",
+                "start date": undefined,
+                "due date": undefined,
+                memo: [],
+              },
+              children: [],
+            },
+          ],
+        },
+      },
+      {
+        "root-id": {
+          id: "root-id",
+          name: "Project",
+          status: "Open",
+          parents: [],
+          memos: [],
+          createdAt: "2026-05-20",
+          order: 7,
+        },
+      }
+    );
+
+    expect(tasks.find((task) => task.id === "root-id")?.order).toBe(7);
+    expect(tasks.find((task) => task.id === "child-a")?.order).toBe(0);
+    expect(tasks.find((task) => task.id === "child-b")?.order).toBe(1);
+  });
+});


### PR DESCRIPTION
## Summary
- Clear the current project tree immediately when switching projects.
- Show a loading state until the selected project finishes loading.
- Add component coverage for workspace project switching so stale content is not rendered mid-switch.

## Validation
- svelte-check --tsconfig ./tsconfig.json
- vitest run tests/unit tests/component --pool=threads