### PR TITLE
fix: suppress spurious sync conflicts and remove task rename auto-commit

### DIFF
--- a/electron/workspace-reconciler.js
+++ b/electron/workspace-reconciler.js
@@ -3,8 +3,6 @@ const fs = require("fs");
 const path = require("path");
 const chokidar = require("chokidar");
 
-const RECENT_WRITE_TTL_MS = 5000;
-
 function hashBuffer(buffer) {
   return crypto.createHash("sha256").update(buffer).digest("hex");
 }
@@ -50,6 +48,43 @@ async function collectFileHashes(rootDir) {
   return result;
 }
 
+function collectFileHashesSync(rootDir) {
+  const result = new Map();
+
+  function walk(dir) {
+    let entries = [];
+    try {
+      entries = fs.readdirSync(dir, { withFileTypes: true });
+    } catch {
+      return;
+    }
+
+    for (const entry of entries) {
+      const fullPath = path.join(dir, entry.name);
+      if (entry.isDirectory()) {
+        walk(fullPath);
+      } else if (entry.isFile() && !entry.name.includes(".tmp")) {
+        try {
+          result.set(fullPath, hashBuffer(fs.readFileSync(fullPath)));
+        } catch {
+          // Ignore files that disappear during a scan.
+        }
+      }
+    }
+  }
+
+  walk(rootDir);
+  return result;
+}
+
+function isFileWithinDir(filePath, dirPath) {
+  const dir = path.resolve(dirPath);
+  const file = path.resolve(filePath);
+  if (file === dir) return false;
+  const rel = path.relative(dir, file);
+  return Boolean(rel) && !rel.startsWith("..") && !path.isAbsolute(rel);
+}
+
 class WorkspaceReconciler {
   constructor({
     readProject,
@@ -71,7 +106,12 @@ class WorkspaceReconciler {
     this.onNotice = onNotice;
     this.stateRootDir = stateRootDir;
     this.watchFactory = watchFactory;
-    this.recentlyWritten = new Map();
+    // Persistent file -> sha256 map. Updated whenever WE write to a file or
+    // accept an external update; never expires by time alone. A file event
+    // whose content hash matches the stored value is treated as a no-op
+    // (e.g. OneDrive re-touching files after sync), avoiding spurious
+    // "external update" / "conflict" notifications.
+    this.knownFileHashes = new Map();
     this.projectTimers = new Map();
     this.workspacePath = null;
     this.watcher = null;
@@ -82,6 +122,10 @@ class WorkspaceReconciler {
     if (!workspacePath) return;
 
     this.workspacePath = workspacePath;
+    // Treat the current disk state as the baseline. Any change while the app
+    // was closed is implicitly accepted; subsequent divergence will be
+    // detected by hash mismatch.
+    await this.rebuildKnownHashesFromDisk(workspacePath);
     await this.writeSnapshot();
 
     this.watcher = this.watchFactory(workspacePath, {
@@ -109,16 +153,30 @@ class WorkspaceReconciler {
     this.workspacePath = null;
   }
 
+  async rebuildKnownHashesFromDisk(rootDir) {
+    const hashes = await collectFileHashes(rootDir);
+    this.knownFileHashes = new Map();
+    for (const [filePath, hash] of hashes) {
+      this.knownFileHashes.set(path.resolve(filePath), hash);
+    }
+  }
+
   async markProjectWritten(projectDir) {
     const hashes = await collectFileHashes(projectDir);
-    const now = Date.now();
-    for (const [filePath, hash] of hashes) {
-      this.recentlyWritten.set(path.resolve(filePath), {
-        hash,
-        expiresAt: now + RECENT_WRITE_TTL_MS,
-      });
+    const resolvedProject = path.resolve(projectDir);
+
+    // Remove stale entries: files that used to be in this project but no
+    // longer exist (e.g. task deleted).
+    for (const filePath of [...this.knownFileHashes.keys()]) {
+      if (isFileWithinDir(filePath, resolvedProject) && !hashes.has(filePath)) {
+        this.knownFileHashes.delete(filePath);
+      }
     }
-    this.cleanupRecentlyWritten(now);
+
+    for (const [filePath, hash] of hashes) {
+      this.knownFileHashes.set(path.resolve(filePath), hash);
+    }
+
     await this.writeSnapshot();
   }
 
@@ -135,17 +193,20 @@ class WorkspaceReconciler {
       return;
     }
 
-    if (eventName !== "unlink") {
+    if (eventName === "unlink") {
+      // If we don't know this file, we've already accepted the deletion
+      // (either we deleted it, or it was never tracked).
+      if (!this.knownFileHashes.has(resolvedPath)) return;
+    } else {
       let fileHash;
       try {
         fileHash = await hashFile(resolvedPath);
       } catch {
         return;
       }
-
-      if (this.isRecentlyWritten(resolvedPath, fileHash)) {
-        return;
-      }
+      // No content change since we last saw it — likely a sync-driven touch
+      // (e.g. OneDrive). Suppress.
+      if (this.knownFileHashes.get(resolvedPath) === fileHash) return;
     }
 
     const projectDir = this.resolveProjectDir(resolvedPath);
@@ -169,6 +230,15 @@ class WorkspaceReconciler {
   }
 
   async reconcileProject(projectDir) {
+    // Re-check at reconcile time: if everything matches knownFileHashes by
+    // now, the triggering event was stale (e.g. raced with our own write
+    // batch that has since completed and called markProjectWritten). This
+    // check is intentionally synchronous so the subsequent side effects
+    // (onConflict / onProjectUpdated) run before any await yields control.
+    if (this.projectMatchesKnown(projectDir)) {
+      return;
+    }
+
     if (this.hasPendingWrite(projectDir)) {
       const event = {
         projectDir,
@@ -191,7 +261,8 @@ class WorkspaceReconciler {
         projectDir,
         message: "Workspace updated on disk.",
       });
-      await this.writeSnapshot();
+      // Adopt the new disk state as the new baseline.
+      await this.markProjectWritten(projectDir);
     } catch (err) {
       this.onNotice({
         kind: "error",
@@ -199,6 +270,35 @@ class WorkspaceReconciler {
         message: err.message,
       });
     }
+  }
+
+  projectMatchesKnown(projectDir) {
+    const resolvedProject = path.resolve(projectDir);
+    let currentHashes;
+    try {
+      currentHashes = collectFileHashesSync(projectDir);
+    } catch {
+      return false;
+    }
+
+    if (currentHashes.size !== this.countKnownFilesIn(resolvedProject)) {
+      return false;
+    }
+
+    for (const [filePath, hash] of currentHashes) {
+      if (this.knownFileHashes.get(path.resolve(filePath)) !== hash) {
+        return false;
+      }
+    }
+    return true;
+  }
+
+  countKnownFilesIn(resolvedProjectDir) {
+    let count = 0;
+    for (const filePath of this.knownFileHashes.keys()) {
+      if (isFileWithinDir(filePath, resolvedProjectDir)) count += 1;
+    }
+    return count;
   }
 
   resolveProjectDir(filePath) {
@@ -217,27 +317,13 @@ class WorkspaceReconciler {
     return projectDir;
   }
 
-  isRecentlyWritten(filePath, fileHash) {
-    const now = Date.now();
-    this.cleanupRecentlyWritten(now);
-    const entry = this.recentlyWritten.get(path.resolve(filePath));
-    return Boolean(entry && entry.hash === fileHash);
-  }
-
-  cleanupRecentlyWritten(now = Date.now()) {
-    for (const [filePath, entry] of this.recentlyWritten) {
-      if (entry.expiresAt <= now) {
-        this.recentlyWritten.delete(filePath);
-      }
-    }
-  }
-
   async writeSnapshot() {
     if (!this.workspacePath || !this.stateRootDir) return;
-    const hashes = await collectFileHashes(this.workspacePath);
     const files = {};
-    for (const [filePath, hash] of hashes) {
-      files[path.relative(this.workspacePath, filePath)] = hash;
+    for (const [filePath, hash] of this.knownFileHashes) {
+      if (isFileWithinDir(filePath, this.workspacePath)) {
+        files[path.relative(this.workspacePath, filePath)] = hash;
+      }
     }
 
     await fs.promises.mkdir(this.stateRootDir, { recursive: true });

--- a/src/features/tasks/components/TaskName.svelte
+++ b/src/features/tasks/components/TaskName.svelte
@@ -1,6 +1,5 @@
 ﻿<script>
-  import { tick, createEventDispatcher, onDestroy } from "svelte";
-  import { debounce } from "lodash";
+  import { tick, createEventDispatcher } from "svelte";
   import { ripple, tooltip } from "@lib/actions";
   import TaskMenu from "@features/tasks/components/TaskMenu.svelte";
   import { pageSearchQuery } from "@features/search/stores/search";
@@ -235,12 +234,6 @@
     dispatch("commit", { value: draftText });
   };
 
-  const debouncedCommit = debounce(dispatchCommitIfChanged, 300);
-
-  onDestroy(() => {
-    debouncedCommit.cancel();
-  });
-
   const toggle = async () => {
     isEditing = !isEditing;
     if (isEditing) {
@@ -250,7 +243,6 @@
   };
 
   const flushCommit = () => {
-    debouncedCommit.cancel();
     if (!draftText.trim()) {
       draftText = text ?? "";
       return;
@@ -259,7 +251,6 @@
   };
 
   const resetDraft = () => {
-    debouncedCommit.cancel();
     draftText = text ?? "";
   };
 
@@ -371,7 +362,6 @@
     }}
     on:input={(e) => {
       draftText = e.currentTarget.value;
-      debouncedCommit();
     }}
     on:click={(e) => {
       if (isEditing) {

--- a/tests/component/TaskName.test.js
+++ b/tests/component/TaskName.test.js
@@ -4,6 +4,13 @@ import { tick } from "svelte";
 import TaskNameClickHarness from "../mocks/TaskNameClickHarness.svelte";
 import TaskNameCommitHarness from "../mocks/TaskNameCommitHarness.svelte";
 
+async function openRenameEditor() {
+  const menuButton = screen.getByRole("button", { name: /open task actions/i });
+  await fireEvent.click(menuButton);
+  const renameItem = await screen.findByRole("menuitem", { name: /rename/i });
+  await fireEvent.click(renameItem);
+}
+
 describe("TaskName", () => {
   test("keeps the task name disabled until editing while row clicks still select", async () => {
     render(TaskNameClickHarness);
@@ -71,6 +78,47 @@ describe("TaskName", () => {
       const input = screen.getByDisplayValue("Original");
       await fireEvent.input(input, { target: { value: "Updated" } });
       await fireEvent.blur(input);
+
+      expect(screen.getByTestId("committed-count")).toHaveTextContent("1");
+      expect(screen.getByTestId("last-committed")).toHaveTextContent("Updated");
+    });
+  });
+
+  describe("no auto-commit while typing", () => {
+    // Regression: previously typing into the input fired a debounced commit
+    // (~300ms after the last keystroke), so a pause in typing committed the
+    // partial value before the user pressed Enter. The fix removes the
+    // debounced commit entirely; commit only happens on Enter or blur.
+
+    test("typing alone does not fire commit, even after a pause", async () => {
+      vi.useFakeTimers();
+      try {
+        render(TaskNameCommitHarness, { initialText: "Original" });
+        await openRenameEditor();
+
+        const input = screen.getByDisplayValue("Original");
+        await fireEvent.input(input, { target: { value: "U" } });
+        await fireEvent.input(input, { target: { value: "Up" } });
+        await fireEvent.input(input, { target: { value: "Updat" } });
+
+        // Advance far past any plausible debounce window.
+        vi.advanceTimersByTime(5000);
+        await tick();
+
+        expect(screen.getByTestId("committed-count")).toHaveTextContent("0");
+        expect(screen.getByTestId("current-text")).toHaveTextContent("Original");
+      } finally {
+        vi.useRealTimers();
+      }
+    });
+
+    test("Enter commits the typed value", async () => {
+      render(TaskNameCommitHarness, { initialText: "Original" });
+      await openRenameEditor();
+
+      const input = screen.getByDisplayValue("Original");
+      await fireEvent.input(input, { target: { value: "Updated" } });
+      await fireEvent.keyDown(input, { key: "Enter" });
 
       expect(screen.getByTestId("committed-count")).toHaveTextContent("1");
       expect(screen.getByTestId("last-committed")).toHaveTextContent("Updated");

--- a/tests/unit/workspace-reconciler.test.js
+++ b/tests/unit/workspace-reconciler.test.js
@@ -19,6 +19,11 @@ function makeWatcher() {
   };
 }
 
+function modifyProjectFile(projectFile, newName) {
+  const { data } = parseFrontmatter(fs.readFileSync(projectFile, "utf8"));
+  fs.writeFileSync(projectFile, stringifyFrontmatter({ ...data, name: newName }));
+}
+
 describe("WorkspaceReconciler", () => {
   let tmpDir;
   let stateDir;
@@ -59,8 +64,6 @@ describe("WorkspaceReconciler", () => {
   test("pushes an external update when no local write is pending", async () => {
     const { projectDir } = createProject(tmpDir, "Proj", "root-id");
     const projectFile = path.join(projectDir, "_project.md");
-    const { data } = parseFrontmatter(fs.readFileSync(projectFile, "utf8"));
-    fs.writeFileSync(projectFile, stringifyFrontmatter({ ...data, name: "Updated" }));
     const updates = [];
     const notices = [];
     const reconciler = new WorkspaceReconciler({
@@ -71,6 +74,9 @@ describe("WorkspaceReconciler", () => {
       watchFactory: () => makeWatcher(),
     });
     await reconciler.start(tmpDir);
+
+    // External modification after the reconciler has captured the baseline.
+    modifyProjectFile(projectFile, "Updated");
 
     await reconciler.handleFileEvent("change", projectFile);
     await vi.runAllTimersAsync();
@@ -84,6 +90,7 @@ describe("WorkspaceReconciler", () => {
 
   test("reports a conflict when a local write is pending", async () => {
     const { projectDir } = createProject(tmpDir, "Proj", "root-id");
+    const projectFile = path.join(projectDir, "_project.md");
     const conflicts = [];
     const reconciler = new WorkspaceReconciler({
       readProject: () => {
@@ -96,7 +103,10 @@ describe("WorkspaceReconciler", () => {
     });
     await reconciler.start(tmpDir);
 
-    await reconciler.handleFileEvent("change", path.join(projectDir, "_project.md"));
+    // Real divergence on disk (else the new content-hash check would skip).
+    modifyProjectFile(projectFile, "Updated");
+
+    await reconciler.handleFileEvent("change", projectFile);
     await vi.runAllTimersAsync();
 
     expect(conflicts).toEqual([
@@ -124,6 +134,124 @@ describe("WorkspaceReconciler", () => {
 
     expect(notices).toHaveLength(1);
     expect(notices[0].kind).toBe("conflicted-copy");
+    await reconciler.stop();
+  });
+
+  test("suppresses content-unchanged touches (OneDrive sync touch case)", async () => {
+    const { projectDir } = createProject(tmpDir, "Proj", "root-id");
+    const projectFile = path.join(projectDir, "_project.md");
+    const updates = [];
+    const conflicts = [];
+    const reconciler = new WorkspaceReconciler({
+      readProject: () => {
+        throw new Error("should not read for no-op touches");
+      },
+      // Even if we happen to have a pending write, content-unchanged touches
+      // must NOT be reported as conflicts.
+      hasPendingWrite: () => true,
+      onProjectUpdated: (event) => updates.push(event),
+      onConflict: (event) => conflicts.push(event),
+      stateRootDir: stateDir,
+      watchFactory: () => makeWatcher(),
+    });
+    await reconciler.start(tmpDir);
+
+    // Simulate OneDrive touching the file without changing content: re-write
+    // identical bytes (mtime changes, hash does not).
+    const original = fs.readFileSync(projectFile);
+    fs.writeFileSync(projectFile, original);
+
+    await reconciler.handleFileEvent("change", projectFile);
+    await vi.runAllTimersAsync();
+
+    expect(updates).toEqual([]);
+    expect(conflicts).toEqual([]);
+    await reconciler.stop();
+  });
+
+  test("skips reconcile when disk matches known by the time the timer fires", async () => {
+    // Race scenario: chokidar fires a "change" event during our own batched
+    // write; by the time the 100ms reconcile timer fires, markProjectWritten
+    // has caught up and the disk state equals knownFileHashes. We must not
+    // call readProject in that case.
+    const { projectDir } = createProject(tmpDir, "Proj", "root-id");
+    const projectFile = path.join(projectDir, "_project.md");
+    const updates = [];
+    const conflicts = [];
+    const reconciler = new WorkspaceReconciler({
+      readProject: () => {
+        throw new Error("should not read when state matches known");
+      },
+      hasPendingWrite: () => true,
+      onProjectUpdated: (event) => updates.push(event),
+      onConflict: (event) => conflicts.push(event),
+      stateRootDir: stateDir,
+      watchFactory: () => makeWatcher(),
+    });
+    await reconciler.start(tmpDir);
+
+    // Stage real divergence — this would normally trigger a reconcile.
+    modifyProjectFile(projectFile, "Updated");
+    await reconciler.handleFileEvent("change", projectFile);
+
+    // Before the reconcile timer fires, our own write completes and resyncs
+    // knownFileHashes to the current disk state.
+    await reconciler.markProjectWritten(projectDir);
+
+    await vi.runAllTimersAsync();
+
+    expect(updates).toEqual([]);
+    expect(conflicts).toEqual([]);
+    await reconciler.stop();
+  });
+
+  test("markProjectWritten clears entries for files that no longer exist", async () => {
+    const { projectDir } = createProject(tmpDir, "Proj", "root-id");
+    const projectFile = path.join(projectDir, "_project.md");
+    const extraFile = path.join(projectDir, "stray.md");
+    fs.writeFileSync(extraFile, "hello");
+
+    const reconciler = new WorkspaceReconciler({
+      readProject,
+      stateRootDir: stateDir,
+      watchFactory: () => makeWatcher(),
+    });
+    await reconciler.start(tmpDir);
+
+    expect(reconciler.knownFileHashes.has(path.resolve(extraFile))).toBe(true);
+
+    // Remove the stray file and notify reconciler that we wrote the project.
+    fs.unlinkSync(extraFile);
+    await reconciler.markProjectWritten(projectDir);
+
+    expect(reconciler.knownFileHashes.has(path.resolve(extraFile))).toBe(false);
+    expect(reconciler.knownFileHashes.has(path.resolve(projectFile))).toBe(true);
+    await reconciler.stop();
+  });
+
+  test("ignores unlink events for files we never tracked", async () => {
+    const { projectDir } = createProject(tmpDir, "Proj", "root-id");
+    const updates = [];
+    const conflicts = [];
+    const reconciler = new WorkspaceReconciler({
+      readProject: () => {
+        throw new Error("should not read for untracked unlinks");
+      },
+      hasPendingWrite: () => true,
+      onProjectUpdated: (event) => updates.push(event),
+      onConflict: (event) => conflicts.push(event),
+      stateRootDir: stateDir,
+      watchFactory: () => makeWatcher(),
+    });
+    await reconciler.start(tmpDir);
+
+    // We never knew about this file (it isn't in knownFileHashes).
+    const phantom = path.join(projectDir, "phantom.md");
+    await reconciler.handleFileEvent("unlink", phantom);
+    await vi.runAllTimersAsync();
+
+    expect(updates).toEqual([]);
+    expect(conflicts).toEqual([]);
     await reconciler.stop();
   });
 });


### PR DESCRIPTION
## Summary

2 つのバグを修正。

### 1. OneDrive 同期下で発生する誤検知の競合状態 (`electron/workspace-reconciler.js`)

`WorkspaceReconciler` の自前書き込み識別が **5 秒 TTL の `recentlyWritten` Map** で実装されており、TTL 切れ後に OneDrive が再 touch (内容無変更で mtime のみ書き換え) するとそれを「外部変更」として誤検知していた。さらに、awaitWriteFinish の 150ms と複数ファイル書き込みのタイミング差で、自前書き込み中に conflict が誤発火する race も存在。

**修整内容:**

- `recentlyWritten` (TTL 付き) → `knownFileHashes` (TTL なし、永続) に置換
- watcher イベントのファイルハッシュが known と一致するなら「内容無変更の touch」として無視 (OneDrive 対策)
- `reconcileProject` の冒頭で同期的に `projectMatchesKnown(projectDir)` を再チェック → 100ms のスケジュール窓内に自前書き込み + `markProjectWritten` が間に合えば、副作用 (conflict / external-update) を発火しない
- `markProjectWritten` は project 範囲で hash を refresh し、削除済みファイルのエントリも pruning
- `start()` でディスク全体をスキャンして known を populate (再起動後の baseline)
- 外部変更受容後にも `markProjectWritten` を呼んで baseline を更新

### 2. タスクツリーのリネームが Enter 前に確定される (`src/features/tasks/components/TaskName.svelte`)

`on:input` で `debouncedCommit()` (lodash debounce 300ms) を呼んでいたため、タイプ停止後 300ms で `commit` イベントが発火していた。TaskDetail 側にはこの debounce が無いので挙動が不一致だった。

**修整内容:**

- `debouncedCommit` 定義、`lodash.debounce` import を削除
- `on:input` から呼び出しを削除 (`draftText` 更新のみ残す)
- `flushCommit` / `resetDraft` / `onDestroy` 内の `debouncedCommit.cancel()` も削除
- 結果: 確定タイミングは Enter / blur のみ (TaskDetail と一致)

## Test plan

- [x] `tests/unit/workspace-reconciler.test.js` 8/8 pass
  - 既存 4 件 + 新規 4 件: 内容無変更 touch の抑止 / 再 reconcile スキップ / `markProjectWritten` の prune / 未追跡 unlink の無視
- [x] `tests/component/TaskName.test.js` 9/9 pass
  - 既存 7 件 + 新規 2 件: タイプ単独で commit 発火しない / Enter で commit
- [x] フル vitest 走行 (GanttPanel の flaky 1 件は無関係で再実行で pass)
- [x] svelte-check: 0 errors / 0 warnings (160 files)
- [x] prettier --check 修正済み
- [ ] GUI 手動確認 (出先から戻り次第): OneDrive 同期フォルダで複数ファイル編集を繰り返しても conflict が出ないこと / タスクツリー上でリネーム中に手を止めても確定されないこと
