### PR TITLE
fix: drawer-style mask blocks main while sidebar is open

### DIFF
--- a/src/App.svelte
+++ b/src/App.svelte
@@ -220,16 +220,7 @@
         <MenuList />
       </aside>
     {/if}
-    <div
-      class="Main"
-      class:DetailWindowMain={isTaskDetailWindow}
-      on:pointerdown={() => {
-        if (!isTaskDetailWindow && !$sidebarCollapsed) {
-          $sidebarCollapsed = true;
-        }
-      }}
-      role="presentation"
-    >
+    <div class="Main" class:DetailWindowMain={isTaskDetailWindow}>
       {#if isTaskDetailWindow}
         <TaskDetailWindow
           initialTaskName={detailWindowTaskName}
@@ -272,6 +263,18 @@
             {/each}
           </div>
         {/if}
+      {/if}
+      {#if !isTaskDetailWindow && !$sidebarCollapsed}
+        <!-- Drawer 風マスク: サイドバー表示中はメイン領域への操作を遮断し、
+             クリックでサイドバーを閉じる。これがないと SplitPane のリサイザを
+             掴んだ瞬間にサイドバーが閉じて Main 幅が変わり、リサイザの初期計算
+             がずれてしまう。 -->
+        <button
+          type="button"
+          class="SidebarMask"
+          aria-label="サイドバーを閉じる"
+          on:click={() => ($sidebarCollapsed = true)}
+        ></button>
       {/if}
     </div>
   </div>
@@ -353,10 +356,27 @@
     flex: 1 1 auto;
     min-width: 0;
     height: 100%;
+    position: relative;
   }
   div.Main.DetailWindowMain {
     height: 100%;
     flex: 1;
+  }
+  /* SplitPanes 内の Resizer は z-index: 999。マスクはそれより上に置く。 */
+  .SidebarMask {
+    position: absolute;
+    inset: 0;
+    width: 100%;
+    height: 100%;
+    margin: 0;
+    padding: 0;
+    border: none;
+    background-color: rgba(0, 0, 0, 0.35);
+    cursor: pointer;
+    z-index: 1000;
+  }
+  .SidebarMask:focus {
+    outline: none;
   }
   .save-error-banner {
     display: flex;


### PR DESCRIPTION
## Summary
- サイドバー表示中に SplitPane のリサイザを掴むと、サイドバーが閉じる動作とリサイザ初期化が同時に走り、狭い Main 幅を捕捉したまま位置がずれていた問題を修正
- Main の `pointerdown` でサイドバーを閉じていた旧処理を廃止し、サイドバー表示中だけ Main 全面に Drawer 風のグレー透明マスクを重ねる方式に変更（z-index 1000 で Resizer (999) より上）
- マスクは `<button aria-label=サイドバーを閉じる>` として実装し、クリックでサイドバーを閉じるだけ。配下の Resizer は次のクリックまで触られない

## Test plan
- [x] `svelte-check` 0 errors / 0 warnings
- [x] `vitest run tests/component/App.test.js tests/component/Header.test.js tests/component/SplitPanes.test.js tests/unit/sidebarCollapsed.test.js` 全 17 件パス
- [ ] サイドバーを開いた状態で SplitPane のリサイザをクリック → サイドバーだけ閉じ、リサイザ位置は変わらない
- [ ] その状態でもう一度リサイザを掴むと、Main 全幅基準で正しくドラッグできる
- [ ] サイドバーを開いた状態でメイン領域のボタン類（タスクツリー、ガント、メモなど）がクリックできないこと
- [ ] マスククリックでサイドバーが閉じること

🤖 Generated with [Claude Code](https://claude.com/claude-code)