### PR TITLE
[codex] open workspace folders

### DIFF
--- a/electron/index.js
+++ b/electron/index.js
@@ -134,6 +134,34 @@ app.on("ready", () => {
   const dbMetaWriter = createAsyncWriter(db_meta, file_meta, "meta", 100);
   const wsCache = new Map();
 
+  function normalizeForCompare(value) {
+    const resolved = path.resolve(String(value));
+    return process.platform === "win32" ? resolved.toLowerCase() : resolved;
+  }
+
+  function knownWorkspacePaths() {
+    return [
+      ...(db_meta.data.workspaces || []).map((item) => item.path).filter(Boolean),
+      db_meta.data.activeWorkspace,
+    ].filter(Boolean);
+  }
+
+  function isKnownWorkspacePath(workspacePath) {
+    const requestedPath = normalizeForCompare(workspacePath);
+    return knownWorkspacePaths().some(
+      (itemPath) => normalizeForCompare(itemPath) === requestedPath
+    );
+  }
+
+  function isInsideKnownWorkspace(targetPath) {
+    const requestedPath = normalizeForCompare(targetPath);
+    return knownWorkspacePaths().some((workspacePath) => {
+      const rootPath = normalizeForCompare(workspacePath);
+      const relativePath = path.relative(rootPath, requestedPath);
+      return relativePath && !relativePath.startsWith("..") && !path.isAbsolute(relativePath);
+    });
+  }
+
   function sendWorkspaceSaveStatus(payload) {
     BrowserWindow.getAllWindows().forEach((win) => {
       if (!win.isDestroyed()) {
@@ -719,6 +747,87 @@ app.on("ready", () => {
     } catch (err) {
       log.error("ws:list-projects error:", err.message);
       return [];
+    }
+  });
+
+  ipcMain.handle("ws:open-workspace", async (event, { workspacePath }) => {
+    try {
+      if (!workspacePath || typeof workspacePath !== "string") {
+        return { success: false, error: "No workspace is selected" };
+      }
+
+      if (!isKnownWorkspacePath(workspacePath)) {
+        return { success: false, error: "Workspace is not registered" };
+      }
+
+      const requestedPath = path.resolve(workspacePath);
+      const stats = await fs.promises.stat(requestedPath);
+      if (!stats.isDirectory()) {
+        return { success: false, error: "Workspace path is not a directory" };
+      }
+
+      const openError = await shell.openPath(requestedPath);
+      if (openError) {
+        return { success: false, error: openError };
+      }
+
+      return { success: true };
+    } catch (err) {
+      log.error("ws:open-workspace error:", err.message);
+      return { success: false, error: err.message };
+    }
+  });
+
+  ipcMain.handle("ws:open-task-folder", async (event, { projectDir, taskId }) => {
+    try {
+      if (!projectDir || typeof projectDir !== "string") {
+        return { success: false, error: "No workspace project is selected" };
+      }
+      if (!taskId || typeof taskId !== "string") {
+        return { success: false, error: "No task is selected" };
+      }
+      if (!isInsideKnownWorkspace(projectDir)) {
+        return { success: false, error: "Project is not inside a registered workspace" };
+      }
+
+      if (workspaceWriteQueue.hasPending(projectDir)) {
+        await workspaceWriteQueue.flush();
+      }
+
+      let cached = wsCache.get(projectDir);
+      if (!cached || !cached.taskDirs?.has(taskId)) {
+        const { tasks, taskDirs } = workspace.readProject(projectDir);
+        cached = { tasks, taskDirs };
+        wsCache.set(projectDir, cached);
+      }
+
+      const dirName = cached.taskDirs.get(taskId);
+      if (!dirName) {
+        return { success: false, error: "Task folder was not found" };
+      }
+
+      const resolvedProjectDir = path.resolve(projectDir);
+      const targetDir =
+        dirName === "_project" ? resolvedProjectDir : path.resolve(resolvedProjectDir, dirName);
+      const relativePath = path.relative(resolvedProjectDir, targetDir);
+      if (relativePath.startsWith("..") || path.isAbsolute(relativePath)) {
+        return { success: false, error: "Task folder is outside the project" };
+      }
+
+      const stats = await fs.promises.stat(targetDir);
+      if (!stats.isDirectory()) {
+        return { success: false, error: "Task path is not a directory" };
+      }
+
+      const openError = await shell.openPath(targetDir);
+      if (openError) {
+        return { success: false, error: openError };
+      }
+
+      return { success: true };
+    } catch (err) {
+      log.error("ws:open-task-folder error:", err.message);
+      return { success: false, error: err.message };
     }
   });
 

--- a/electron/preload.js
+++ b/electron/preload.js
@@ -123,6 +123,9 @@ const electronAPI = {
   wsDeleteProject: (projectDir) => ipcRenderer.invoke("ws:delete-project", { projectDir }),
   wsResolveConflict: (projectDir, action) =>
     ipcRenderer.invoke("ws:resolve-conflict", { projectDir, action }),
+  wsOpenWorkspace: (workspacePath) => ipcRenderer.invoke("ws:open-workspace", { workspacePath }),
+  wsOpenTaskFolder: (projectDir, taskId) =>
+    ipcRenderer.invoke("ws:open-task-folder", { projectDir, taskId }),
   wsSelectDirectory: () => ipcRenderer.invoke("ws:select-directory"),
   wsGetLegacyProjects: () => ipcRenderer.invoke("ws:get-legacy-projects"),
   wsExportLegacyProjects: (workspacePath, options) =>

--- a/src/features/navigation/components/MenuList.svelte
+++ b/src/features/navigation/components/MenuList.svelte
@@ -4,7 +4,7 @@
 </script>
 
 <script>
-  import { onMount, afterUpdate } from "svelte";
+  import { onMount, afterUpdate, onDestroy } from "svelte";
   import { slide } from "svelte/transition";
   import IconButton from "@lib/primitives/IconButton.svelte";
   import Dialog from "@lib/primitives/Dialog.svelte";
@@ -61,9 +61,24 @@
   };
 
   let show_workspace_setup = false;
+  let workspace_open_error = "";
+  let workspace_open_error_timer;
   let workspaceProjectsExpanded = true;
   let inAppProjectsExpanded = true;
   let tagsExpanded = true;
+
+  async function handleOpenActiveWorkspace(e) {
+    e.stopPropagation();
+    workspace_open_error = "";
+    const result = await workspace_store.openActiveWorkspace();
+    if (!result?.success) {
+      workspace_open_error = result?.error ?? "Workspaceを開けませんでした";
+      if (workspace_open_error_timer) clearTimeout(workspace_open_error_timer);
+      workspace_open_error_timer = setTimeout(() => {
+        workspace_open_error = "";
+      }, 4000);
+    }
+  }
 
   // Dialog
   let show_confirm = false;
@@ -289,6 +304,10 @@
     setDND();
   });
 
+  onDestroy(() => {
+    if (workspace_open_error_timer) clearTimeout(workspace_open_error_timer);
+  });
+
   afterUpdate(() => {
     // Update drag & drop settings when project list changes
     setDND();
@@ -328,6 +347,36 @@
     {:else}
       <span class="NoWorkspaceHint TextOverFlow">ワークスペース未設定</span>
     {/if}
+    {#if $workspace_store.activeWorkspacePath}
+      <button
+        class="WorkspaceIconBtn"
+        type="button"
+        on:click={handleOpenActiveWorkspace}
+        aria-label="Workspaceをファイルエクスプローラーで開く"
+        use:tooltip={{
+          color: "var(--on-theme-tooltip-fg)",
+          backgroundColor: "var(--on-theme-tooltip-bg)",
+          content: "Workspaceをファイルエクスプローラーで開く",
+          force: true,
+        }}
+      >
+        <svg viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg" aria-hidden="true">
+          <path
+            d="M3 7.5C3 6.4 3.9 5.5 5 5.5H9.4L11.2 7.3H19C20.1 7.3 21 8.2 21 9.3V10.5"
+            stroke="currentColor"
+            stroke-width="2"
+            stroke-linecap="round"
+            stroke-linejoin="round"
+          />
+          <path
+            d="M3.4 10.5H20.6L18.8 18.5C18.6 19.4 17.8 20 16.9 20H5.5C4.6 20 3.8 19.4 3.6 18.5L2.3 12C2.1 11.2 2.7 10.5 3.4 10.5Z"
+            stroke="currentColor"
+            stroke-width="2"
+            stroke-linejoin="round"
+          />
+        </svg>
+      </button>
+    {/if}
     <button
       class="WorkspaceManageBtn"
       on:click={() => {
@@ -347,6 +396,9 @@
       <span>管理</span>
     </button>
   </div>
+  {#if workspace_open_error}
+    <div class="WorkspaceOpenError" role="alert">{workspace_open_error}</div>
+  {/if}
   <br />
   <div class:Section={true}>
     <svg class="Logo" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg" mirror-in-rtl="true"
@@ -1031,11 +1083,10 @@
     color: rgba(255, 255, 255, 0.5);
     font-style: italic;
   }
+  .WorkspaceIconBtn,
   .WorkspaceManageBtn {
     display: inline-flex;
     align-items: center;
-    gap: var(--sp1);
-    padding: 0.2rem var(--sp2);
     border: 1px solid rgba(255, 255, 255, 0.32);
     border-radius: var(--shape-xs);
     background-color: rgba(255, 255, 255, 0.08);
@@ -1048,14 +1099,31 @@
       background-color 0.12s ease,
       border-color 0.12s ease;
   }
+  .WorkspaceIconBtn {
+    justify-content: center;
+    width: 1.75rem;
+    height: 1.75rem;
+    padding: 0;
+  }
+  .WorkspaceManageBtn {
+    gap: var(--sp1);
+    padding: 0.2rem var(--sp2);
+  }
+  .WorkspaceIconBtn:hover,
   .WorkspaceManageBtn:hover {
     background-color: rgba(255, 255, 255, 0.18);
     border-color: rgba(255, 255, 255, 0.5);
   }
+  .WorkspaceIconBtn svg,
   .WorkspaceManageBtn svg {
     width: 0.9rem;
     height: 0.9rem;
     flex-shrink: 0;
+  }
+  .WorkspaceOpenError {
+    padding: 0 var(--sp2) var(--sp2) var(--sp4);
+    color: var(--theme-color-Error-light, #ffb4ab);
+    font-size: var(--font-label-md);
   }
   .TagRowMark {
     display: inline-flex;

--- a/src/features/tasks/components/TaskName.svelte
+++ b/src/features/tasks/components/TaskName.svelte
@@ -16,6 +16,7 @@
   export let canMoveDown = false;
   export let canIndent = false;
   export let canOutdent = false;
+  export let canOpenTaskFolder = false;
   export let nodePath = "";
   /** When >1, the menu acts on the whole multi-selection (label gets count prefix). */
   export let selectionCount = 1;
@@ -158,6 +159,19 @@
     ],
     // 6. Detail — anchor-only; disabled in multi.
     [
+      ...(canOpenTaskFolder
+        ? [
+            {
+              title: "open folder",
+              action: "openTaskFolder",
+              disabled: isMulti,
+              icon: {
+                viewBox: "0 0 24 24",
+                path: "M3 7.5C3 6.4 3.9 5.5 5 5.5H9.4L11.2 7.3H19C20.1 7.3 21 8.2 21 9.3V10.5M3.4 10.5H20.6L18.8 18.5C18.6 19.4 17.8 20 16.9 20H5.5C4.6 20 3.8 19.4 3.6 18.5L2.3 12C2.1 11.2 2.7 10.5 3.4 10.5Z",
+              },
+            },
+          ]
+        : []),
       {
         title: "show details",
         action: "openTaskDetailWindow",
@@ -343,6 +357,8 @@
       toggle();
     } else if (data && data.action === "openTaskDetailWindow") {
       dispatch("openTaskDetailWindow", { text: text ?? draftText });
+    } else if (data && data.action === "openTaskFolder") {
+      dispatch("openTaskFolder");
     } else if (data?.action) {
       dispatch(data.action, data);
     }
@@ -440,6 +456,7 @@
     on:indentTask={handleMenuAction}
     on:outdentTask={handleMenuAction}
     on:openTaskDetailWindow={handleMenuAction}
+    on:openTaskFolder={handleMenuAction}
     on:deleteTask={handleMenuAction}
     on:copyTask={handleMenuAction}
     on:pasteTask={handleMenuAction}

--- a/src/features/tasks/components/TreeTable.svelte
+++ b/src/features/tasks/components/TreeTable.svelte
@@ -1,11 +1,12 @@
 ﻿<script>
-  import { onMount } from "svelte";
+  import { onDestroy, onMount } from "svelte";
   import TreeTableHeader from "@features/tasks/components/TreeTableHeader.svelte";
   import TreeTableRow from "@features/tasks/components/TreeTableRow.svelte";
   import BulkActionBar from "@features/tasks/components/BulkActionBar.svelte";
   import Dialog from "@lib/primitives/Dialog.svelte";
   import {
     tree_data,
+    selected_type,
     filtered_data,
     closed_node_ids,
     table_selected_id,
@@ -13,6 +14,7 @@
     column_settings,
     ganttScrollTop,
   } from "@stores";
+  import { workspace_store } from "@features/workspace/stores/workspace";
   import {
     flattenVisibleTree,
     buildInheritedDueDateMap,
@@ -163,6 +165,8 @@
   let deleteTargetName = "";
   let bulkDeleteCount = 0;
   let bulkDeleteIsBulk = false;
+  let taskFolderOpenError = "";
+  let taskFolderOpenErrorTimer;
 
   // Visible row ids excluding the project root (root is not selectable).
   $: visibleSelectableIds = rows.filter((r) => r.id !== $tree_data?.data?.id).map((r) => r.id);
@@ -248,6 +252,10 @@
       handlers = setResizersEvents(resizers, newDomHeaders, newDataRows);
     });
     mutation_observer.observe(table_root, { subtree: true, childList: true });
+  });
+
+  onDestroy(() => {
+    if (taskFolderOpenErrorTimer) clearTimeout(taskFolderOpenErrorTimer);
   });
 
   const syncResizerBounds = (targetResizers = resizers) => {
@@ -765,6 +773,22 @@
     focusNewNode(cloned.id);
   }
 
+  function showTaskFolderOpenError(message) {
+    taskFolderOpenError = message;
+    if (taskFolderOpenErrorTimer) clearTimeout(taskFolderOpenErrorTimer);
+    taskFolderOpenErrorTimer = setTimeout(() => {
+      taskFolderOpenError = "";
+    }, 4000);
+  }
+
+  async function handleOpenTaskFolder(event) {
+    const { id } = event.detail;
+    const result = await workspace_store.openTaskFolder(id);
+    if (!result?.success) {
+      showTaskFolderOpenError(result?.error ?? "Task folderを開けませんでした");
+    }
+  }
+
   // --- Bulk operation handlers ---------------------------------------------
 
   function handleBulkStatus(event) {
@@ -955,6 +979,9 @@
     if (e.key === "Escape") handleBackgroundClick();
   }}
 >
+  {#if taskFolderOpenError}
+    <div class="TaskFolderOpenError" role="alert">{taskFolderOpenError}</div>
+  {/if}
   <TreeTableHeader
     headers={visibleHeaders}
     {allHeaders}
@@ -994,6 +1021,8 @@
         canMoveDown={row.canMoveDown}
         canIndent={row.canIndent}
         canOutdent={row.canOutdent}
+        canOpenTaskFolder={$selected_type === "WorkspaceProject" &&
+          Boolean($workspace_store.activeProjectDir)}
         bulkCanMove={canSiblingMove}
         bulkCanTreeOp={canTreeOp}
         bulkCanOutdent={canBulkOutdent}
@@ -1013,6 +1042,7 @@
         on:deleteTask={requestDelete}
         on:copyTask={handleCopyTask}
         on:pasteTask={handlePasteTask}
+        on:openTaskFolder={handleOpenTaskFolder}
       />
     {/each}
   {:else}
@@ -1142,6 +1172,19 @@
     height: 100%;
     background-color: var(--theme-color-Primary-main);
     opacity: 0.9;
+  }
+  .TaskFolderOpenError {
+    position: absolute;
+    top: var(--sp2);
+    right: var(--sp2);
+    z-index: 10001;
+    max-width: min(28rem, calc(100% - var(--sp4)));
+    padding: var(--sp1) var(--sp2);
+    border-radius: var(--shape-xs);
+    background-color: var(--theme-color-Error-main);
+    color: #fff;
+    font-size: var(--font-body-sm);
+    box-shadow: var(--elevation-1);
   }
   .EmptyState {
     display: flex;

--- a/src/features/tasks/components/TreeTableRow.svelte
+++ b/src/features/tasks/components/TreeTableRow.svelte
@@ -28,6 +28,7 @@
   export let canMoveDown = false;
   export let canIndent = false;
   export let canOutdent = false;
+  export let canOpenTaskFolder = false;
   export let inheritedDueDate = "";
   export let nodePath = "";
   // Capabilities for bulk operations (used when this row is part of multi-selection).
@@ -299,6 +300,7 @@
           canMoveDown={effectiveCanMoveDown}
           canIndent={effectiveCanIndent}
           canOutdent={effectiveCanOutdent}
+          {canOpenTaskFolder}
           selectionCount={selectionCountForMenu}
           {nodePath}
           on:commit={(e) => {
@@ -339,6 +341,9 @@
           }}
           on:openTaskDetailWindow={({ detail }) => {
             openTaskDetailInWindow(detail.text);
+          }}
+          on:openTaskFolder={() => {
+            dispatch("openTaskFolder", { id });
           }}
         />
       {:else if header.name == "status"}

--- a/src/features/workspace/stores/workspace.ts
+++ b/src/features/workspace/stores/workspace.ts
@@ -27,6 +27,8 @@ export interface WorkspaceStore extends Writable<WorkspaceState> {
     summary: { rootId?: string; name?: string; order?: number }
   ) => void;
   setActiveProject: (projectDir: string) => void;
+  openActiveWorkspace: () => Promise<{ success: boolean; error?: string }>;
+  openTaskFolder: (taskId: string) => Promise<{ success: boolean; error?: string }>;
   createProject: (
     name: string,
     id: string
@@ -169,6 +171,22 @@ function createWorkspaceStore(): WorkspaceStore {
 
     setActiveProject(projectDir: string) {
       update((s) => ({ ...s, activeProjectDir: projectDir }));
+    },
+
+    async openActiveWorkspace() {
+      const { activeWorkspacePath } = get({ subscribe } as WorkspaceStore);
+      if (!activeWorkspacePath) {
+        return { success: false, error: "No active workspace" };
+      }
+      return platform.wsOpenWorkspace(activeWorkspacePath);
+    },
+
+    async openTaskFolder(taskId: string) {
+      const { activeProjectDir } = get({ subscribe } as WorkspaceStore);
+      if (!activeProjectDir) {
+        return { success: false, error: "No active workspace project" };
+      }
+      return platform.wsOpenTaskFolder(activeProjectDir, taskId);
     },
 
     async createProject(name: string, id: string) {

--- a/src/lib/ipc/platform.ts
+++ b/src/lib/ipc/platform.ts
@@ -297,6 +297,25 @@ export function wsResolveConflict(
   );
 }
 
+export function wsOpenWorkspace(
+  workspacePath: string
+): Promise<{ success: boolean; error?: string }> {
+  return (
+    api()?.wsOpenWorkspace?.(workspacePath) ??
+    Promise.resolve({ success: false, error: "API unavailable" })
+  );
+}
+
+export function wsOpenTaskFolder(
+  projectDir: string,
+  taskId: string
+): Promise<{ success: boolean; error?: string }> {
+  return (
+    api()?.wsOpenTaskFolder?.(projectDir, taskId) ??
+    Promise.resolve({ success: false, error: "API unavailable" })
+  );
+}
+
 export interface WsSelectDirectoryResult {
   path: string | null;
   error?: string;

--- a/src/types/app.ts
+++ b/src/types/app.ts
@@ -153,6 +153,11 @@ export interface ElectronAPI {
     projectDir: string,
     action: "reload" | "keep-local"
   ) => Promise<{ success: boolean; error?: string }>;
+  wsOpenWorkspace: (workspacePath: string) => Promise<{ success: boolean; error?: string }>;
+  wsOpenTaskFolder: (
+    projectDir: string,
+    taskId: string
+  ) => Promise<{ success: boolean; error?: string }>;
   wsSelectDirectory: () => Promise<{ path: string | null; error?: string }>;
   wsGetLegacyProjects: () => Promise<{ id: string; name: string; taskCount: number }[]>;
   wsExportLegacyProjects: (

--- a/tests/component/MenuList.test.js
+++ b/tests/component/MenuList.test.js
@@ -50,6 +50,7 @@ describe("MenuList project subsections", () => {
     selected_id.set(undefined);
     tag_index.set(new Map());
     active_tag.set(null);
+    delete window.electronAPI;
   });
 
   test("collapses Workspace and InApp project lists independently", async () => {
@@ -82,5 +83,21 @@ describe("MenuList project subsections", () => {
     await fireEvent.click(screen.getByRole("button", { name: "Workspace Projectsを展開" }));
     expect(screen.getByText("Workspace Alpha")).toBeInTheDocument();
     expect(screen.queryByText("InApp Alpha")).not.toBeInTheDocument();
+  });
+
+  test("opens the active workspace from the sidebar", async () => {
+    const wsOpenWorkspace = vi.fn().mockResolvedValue({ success: true });
+    Object.defineProperty(window, "electronAPI", {
+      configurable: true,
+      value: { wsOpenWorkspace },
+    });
+    seedProjects();
+    render(MenuList);
+
+    await fireEvent.click(
+      screen.getByRole("button", { name: "Workspaceをファイルエクスプローラーで開く" })
+    );
+
+    expect(wsOpenWorkspace).toHaveBeenCalledWith("C:/workspace");
   });
 });

--- a/tests/component/TaskName.test.js
+++ b/tests/component/TaskName.test.js
@@ -126,6 +126,16 @@ describe("TaskName", () => {
   });
 
   describe("three-dot menu toggle", () => {
+    test("dispatches open folder from the task actions menu", async () => {
+      render(TaskNameCommitHarness, { initialText: "Original", canOpenTaskFolder: true });
+
+      const menuButton = screen.getByRole("button", { name: /open task actions/i });
+      await fireEvent.click(menuButton);
+      await fireEvent.click(await screen.findByRole("menuitem", { name: /open folder/i }));
+
+      expect(screen.getByTestId("open-folder-count")).toHaveTextContent("1");
+    });
+
     test("clicking the trigger button a second time closes the menu", async () => {
       // Regression: previously the menu's outside-click handler closed the
       // menu on the same pointerdown that the trigger's click then re-opened,

--- a/tests/component/TreeTable.test.js
+++ b/tests/component/TreeTable.test.js
@@ -23,10 +23,12 @@ import {
   closed_node_ids,
   filtered_data,
   selected_id,
+  selected_type,
   table_selected_id,
   theme,
   tree_data,
 } from "@stores";
+import { workspace_store } from "@features/workspace/stores/workspace";
 
 function createProjectData() {
   return {
@@ -92,9 +94,16 @@ describe("TreeTable", () => {
     tree_data.set(projectData);
     filtered_data.set(projectData.data);
     selected_id.set("project-1");
+    selected_type.set("Projects");
     table_selected_id.set(undefined);
     closed_node_ids.set(new Set());
     theme.set("dark");
+    workspace_store.set({
+      workspaces: [],
+      activeWorkspacePath: null,
+      activeProjectDir: null,
+      projects: [],
+    });
   });
 
   test("selects a row and reflects the selected state", async () => {
@@ -123,5 +132,28 @@ describe("TreeTable", () => {
 
     expect(get(closed_node_ids).has("task-1")).toBe(false);
     expect(screen.getByText("Nested Task")).toBeInTheDocument();
+  });
+
+  test("opens a workspace task folder from the row action", async () => {
+    const wsOpenTaskFolder = vi.fn().mockResolvedValue({ success: true });
+    Object.defineProperty(window, "electronAPI", {
+      configurable: true,
+      value: {
+        setMetaData: vi.fn(),
+        wsOpenTaskFolder,
+      },
+    });
+    selected_type.set("WorkspaceProject");
+    workspace_store.set({
+      workspaces: [{ path: "C:/workspace", label: "Workspace" }],
+      activeWorkspacePath: "C:/workspace",
+      activeProjectDir: "C:/workspace/project",
+      projects: [],
+    });
+    render(TreeTable);
+
+    await fireEvent.click(screen.getByTestId("open-folder-task-1"));
+
+    expect(wsOpenTaskFolder).toHaveBeenCalledWith("C:/workspace/project", "task-1");
   });
 });

--- a/tests/mocks/TaskNameCommitHarness.svelte
+++ b/tests/mocks/TaskNameCommitHarness.svelte
@@ -2,9 +2,11 @@
   import TaskName from "@features/tasks/components/TaskName.svelte";
 
   export let initialText = "Task 1";
+  export let canOpenTaskFolder = false;
   let currentText = initialText;
   let committedCount = 0;
   let lastCommitted = "";
+  let openFolderCount = 0;
 
   function handleCommit(event) {
     currentText = event.detail.value;
@@ -13,8 +15,14 @@
   }
 </script>
 
-<TaskName text={currentText} on:commit={handleCommit} />
+<TaskName
+  text={currentText}
+  {canOpenTaskFolder}
+  on:commit={handleCommit}
+  on:openTaskFolder={() => (openFolderCount += 1)}
+/>
 
 <p data-testid="current-text">{currentText}</p>
 <p data-testid="committed-count">{committedCount}</p>
 <p data-testid="last-committed">{lastCommitted}</p>
+<p data-testid="open-folder-count">{openFolderCount}</p>

--- a/tests/mocks/TreeTableRowTestStub.svelte
+++ b/tests/mocks/TreeTableRowTestStub.svelte
@@ -10,6 +10,7 @@
   export let canMoveDown = false;
   export let canIndent = false;
   export let canOutdent = false;
+  export let canOpenTaskFolder = false;
 
   const dispatch = createEventDispatcher();
 </script>
@@ -48,6 +49,17 @@
             }}
           >
             {row.expanded ? "collapse" : "expand"}
+          </button>
+        {/if}
+        {#if canOpenTaskFolder}
+          <button
+            type="button"
+            data-testid={"open-folder-" + row.id}
+            on:click={() => {
+              dispatch("openTaskFolder", { id: row.id });
+            }}
+          >
+            open folder
           </button>
         {/if}
       {/if}

--- a/tests/unit/workspace_store.test.ts
+++ b/tests/unit/workspace_store.test.ts
@@ -119,4 +119,60 @@ describe("workspace_store", () => {
       "Gamma",
     ]);
   });
+
+  it("opens the active workspace through the platform API", async () => {
+    const wsOpenWorkspace = vi.fn().mockResolvedValue({ success: true });
+    testWindow.electronAPI = { wsOpenWorkspace };
+    workspace_store.set({
+      workspaces: [{ path: "C:/workspace", label: "Workspace" }],
+      activeWorkspacePath: "C:/workspace",
+      activeProjectDir: null,
+      projects: [],
+    });
+
+    const result = await workspace_store.openActiveWorkspace();
+
+    expect(result.success).toBe(true);
+    expect(wsOpenWorkspace).toHaveBeenCalledWith("C:/workspace");
+  });
+
+  it("does not open a workspace when none is active", async () => {
+    const wsOpenWorkspace = vi.fn().mockResolvedValue({ success: true });
+    testWindow.electronAPI = { wsOpenWorkspace };
+    workspace_store.set(emptyState);
+
+    const result = await workspace_store.openActiveWorkspace();
+
+    expect(result.success).toBe(false);
+    expect(result.error).toBe("No active workspace");
+    expect(wsOpenWorkspace).not.toHaveBeenCalled();
+  });
+
+  it("opens a task folder through the active workspace project", async () => {
+    const wsOpenTaskFolder = vi.fn().mockResolvedValue({ success: true });
+    testWindow.electronAPI = { wsOpenTaskFolder };
+    workspace_store.set({
+      workspaces: [{ path: "C:/workspace", label: "Workspace" }],
+      activeWorkspacePath: "C:/workspace",
+      activeProjectDir: "C:/workspace/project",
+      projects: [],
+    });
+
+    const result = await workspace_store.openTaskFolder("task-1");
+
+    expect(result.success).toBe(true);
+    expect(wsOpenTaskFolder).toHaveBeenCalledWith("C:/workspace/project", "task-1");
+  });
+
+  it("does not open a task folder when no workspace project is active", async () => {
+    const wsOpenTaskFolder = vi.fn().mockResolvedValue({ success: true });
+    testWindow.electronAPI = { wsOpenTaskFolder };
+    workspace_store.set(emptyState);
+
+    const result = await workspace_store.openTaskFolder("task-1");
+
+    expect(result.success).toBe(false);
+    expect(result.error).toBe("No active workspace project");
+    expect(wsOpenTaskFolder).not.toHaveBeenCalled();
+  });
 });


### PR DESCRIPTION
## Summary
- Add Electron IPC for opening the active workspace and workspace task folders in the OS file explorer.
- Add sidebar and task context-menu actions for those folder opens, scoped to registered workspace paths.
- Cover the new store, sidebar, task menu, and tree row flows with focused tests.

## Impact
Workspace users can jump from the app to the backing folder for the whole workspace or an individual task. Newly-created or pending task folders flush before opening so Explorer lands on the real on-disk target.

## Validation
- svelte-check --tsconfig ./tsconfig.json
- vitest run tests/unit/workspace_store.test.ts tests/component/MenuList.test.js tests/component/TreeTable.test.js tests/component/TaskName.test.js
- node --check electron/index.js
- node --check electron/preload.js