### PR TITLE
[codex] fix workspace task detail regressions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -138,6 +138,7 @@ renderer/
 public/build/
 electron/db.json
 electron/meta.json
+electron/workspace-state/
 image.png
 # Local-only notes
 開発メモ.md

--- a/.prettierignore
+++ b/.prettierignore
@@ -3,4 +3,5 @@ renderer/
 node_modules/
 package-lock.json
 .claude/
+electron/workspace-state/
 docs/

--- a/electron/index.js
+++ b/electron/index.js
@@ -619,9 +619,17 @@ app.on("ready", () => {
         projectId: detailData?.projectId ? String(detailData.projectId) : "",
         taskId: detailData?.taskId ? String(detailData.taskId) : "",
         taskName: detailData?.taskName ? String(detailData.taskName) : "Task Detail",
+        selectedType:
+          detailData?.selectedType === "WorkspaceProject" ? "WorkspaceProject" : "Projects",
+        projectDir: detailData?.projectDir ? String(detailData.projectDir) : "",
       };
 
-      const existing = taskDetailWindows.get(safeDetailData.taskId);
+      const windowKey = [
+        safeDetailData.selectedType,
+        safeDetailData.projectDir || safeDetailData.projectId,
+        safeDetailData.taskId,
+      ].join(":");
+      const existing = taskDetailWindows.get(windowKey);
       if (existing && !existing.isDestroyed()) {
         existing.focus();
         return existing;
@@ -654,6 +662,8 @@ app.on("ready", () => {
             projectId: safeDetailData.projectId,
             taskId: safeDetailData.taskId,
             taskName: safeDetailData.taskName,
+            selectedType: safeDetailData.selectedType,
+            projectDir: safeDetailData.projectDir,
           },
         });
       }
@@ -663,10 +673,10 @@ app.on("ready", () => {
       win.on("unmaximize", () => sendWindowState(win));
       win.on("enter-full-screen", () => sendWindowState(win));
       win.on("leave-full-screen", () => sendWindowState(win));
-      taskDetailWindows.set(safeDetailData.taskId, win);
+      taskDetailWindows.set(windowKey, win);
 
       win.on("closed", () => {
-        taskDetailWindows.delete(safeDetailData.taskId);
+        taskDetailWindows.delete(windowKey);
       });
 
       log.info(`Task detail window created for task: ${safeDetailData.taskId}`);

--- a/electron/workspace.js
+++ b/electron/workspace.js
@@ -630,7 +630,7 @@ function readMemos(taskDir, reservedFiles = ["_index.md"]) {
     .readdirSync(taskDir)
     .filter((f) => f.endsWith(".md") && !reserved.has(f))
     .sort();
-  for (const file of files) {
+  files.forEach((file, fileIndex) => {
     const raw = fs.readFileSync(path.join(taskDir, file), "utf8");
     const { data, body } = parseFrontmatter(raw);
     const id = data.id || crypto.randomUUID();
@@ -647,9 +647,17 @@ function readMemos(taskDir, reservedFiles = ["_index.md"]) {
     const tags = Array.isArray(data.tags) ? data.tags.map(String) : [];
     const format = normalizeMemoFormat(data.format, "markdown");
     const content = format === "quill" ? parseQuillMemoBody(body) : body.trim();
-    memos.push({ id, title, content, tags, format });
-  }
-  return memos;
+    memos.push({ id, title, content, tags, format, order: parseOrderValue(data.order), fileIndex });
+  });
+  return memos
+    .sort((a, b) => {
+      const aHasOrder = typeof a.order === "number";
+      const bHasOrder = typeof b.order === "number";
+      if (aHasOrder && bHasOrder && a.order !== b.order) return a.order - b.order;
+      if (aHasOrder !== bHasOrder) return aHasOrder ? -1 : 1;
+      return a.fileIndex - b.fileIndex;
+    })
+    .map(({ fileIndex, ...memo }) => memo);
 }
 
 /** Read the root task from _project.md inside projectDir. */
@@ -730,12 +738,18 @@ function readProject(projectDir) {
 function writeMemoFiles(taskDir, indexFileName, memos) {
   const existing = fs.readdirSync(taskDir).filter((f) => f.endsWith(".md") && f !== indexFileName);
   for (const f of existing) fs.unlinkSync(path.join(taskDir, f));
-  for (const memo of memos || []) {
+  for (const [index, memo] of (memos || []).entries()) {
     const id = memo.id || crypto.randomUUID();
     fs.writeFileSync(
       path.join(taskDir, `${id}.md`),
       stringifyFrontmatter(
-        { id, title: memo.title, tags: memo.tags ?? [], format: normalizeMemoFormat(memo.format) },
+        {
+          id,
+          title: memo.title,
+          tags: memo.tags ?? [],
+          format: normalizeMemoFormat(memo.format),
+          order: index,
+        },
         serializeMemoBody(memo)
       )
     );
@@ -748,13 +762,19 @@ async function writeMemoFilesAsync(taskDir, indexFileName, memos, onWritten) {
   );
   const nextFiles = new Set();
 
-  for (const memo of memos || []) {
+  for (const [index, memo] of (memos || []).entries()) {
     const id = memo.id || crypto.randomUUID();
     nextFiles.add(`${id}.md`);
     await writeFileIfChanged(
       path.join(taskDir, `${id}.md`),
       stringifyFrontmatter(
-        { id, title: memo.title, tags: memo.tags ?? [], format: normalizeMemoFormat(memo.format) },
+        {
+          id,
+          title: memo.title,
+          tags: memo.tags ?? [],
+          format: normalizeMemoFormat(memo.format),
+          order: index,
+        },
         serializeMemoBody(memo)
       ),
       undefined,

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,6 +8,7 @@
       "name": "task-manage",
       "version": "0.1.24",
       "dependencies": {
+        "@codemirror/autocomplete": "^6.20.1",
         "@codemirror/commands": "^6.10.3",
         "@codemirror/lang-markdown": "^6.5.0",
         "@codemirror/language-data": "^6.5.2",

--- a/package.json
+++ b/package.json
@@ -71,6 +71,7 @@
   },
   "dependencies": {
     "@codemirror/commands": "^6.10.3",
+    "@codemirror/autocomplete": "^6.20.1",
     "@codemirror/lang-markdown": "^6.5.0",
     "@codemirror/language-data": "^6.5.2",
     "@codemirror/search": "^6.7.0",

--- a/src/App.svelte
+++ b/src/App.svelte
@@ -12,9 +12,12 @@
     redoHistory,
     saveStatus,
     projectLoading,
+    workspace_store,
+    workspace_tasks_cache,
   } from "@stores";
   import { onMount, onDestroy } from "svelte";
   import * as platform from "@lib/ipc/platform";
+  import { workspaceToProjectData } from "@features/workspace/utils/workspace_tree";
   import ProjectPage from "@pages/MainPage.svelte";
   import Header from "@features/navigation/components/Header.svelte";
   import MenuList from "@features/navigation/components/MenuList.svelte";
@@ -47,13 +50,51 @@
   let detailWindowProjectId = currentSearch.get("projectId") || "";
   let detailWindowTaskId = currentSearch.get("taskId") || "";
   let detailWindowTaskName = currentSearch.get("taskName") || "Task Detail";
+  let detailWindowSelectedType =
+    currentSearch.get("selectedType") === "WorkspaceProject" ? "WorkspaceProject" : "Projects";
+  let detailWindowProjectDir = currentSearch.get("projectDir") || "";
 
   async function initTaskDetailWindow() {
     try {
       if (!detailWindowProjectId || !detailWindowTaskId) return;
 
       document.title = `${detailWindowTaskName} | Task Detail`;
-      setTaskDetailWindowTarget(detailWindowProjectId, detailWindowTaskId);
+      setTaskDetailWindowTarget(detailWindowProjectId, detailWindowTaskId, {
+        selectedType: detailWindowSelectedType,
+        projectDir: detailWindowProjectDir || null,
+      });
+
+      if (detailWindowSelectedType === "WorkspaceProject") {
+        if (!detailWindowProjectDir) return;
+
+        workspace_store.update((state) => ({
+          ...state,
+          activeProjectDir: detailWindowProjectDir,
+          projects: state.projects.some((project) => project.projectDir === detailWindowProjectDir)
+            ? state.projects
+            : [
+                ...state.projects,
+                {
+                  name: detailWindowTaskName,
+                  rootId: detailWindowProjectId,
+                  dirName: detailWindowProjectDir.split(/[/\\]/).pop() || detailWindowTaskName,
+                  projectDir: detailWindowProjectDir,
+                },
+              ],
+        }));
+
+        const workspaceProject = await platform.wsReadProject(detailWindowProjectDir);
+        if (workspaceProject) {
+          workspace_tasks_cache.set(workspaceProject.tasks);
+          tree_data.setFromSource(
+            workspaceToProjectData(workspaceProject.tasks, detailWindowProjectId)
+          );
+          selected_type.set("WorkspaceProject");
+          selected_id.set(detailWindowProjectId);
+          table_selected_id.set(detailWindowTaskId);
+        }
+        return;
+      }
 
       const result = await platform.getTreeData(detailWindowProjectId);
       if (result) {

--- a/src/features/memos/components/MarkdownMemo.svelte
+++ b/src/features/memos/components/MarkdownMemo.svelte
@@ -2,6 +2,12 @@
   import { tick, onDestroy } from "svelte";
   import { EditorView, keymap, lineNumbers } from "@codemirror/view";
   import { EditorState } from "@codemirror/state";
+  import {
+    autocompletion,
+    completionKeymap,
+    type CompletionContext,
+    type CompletionResult,
+  } from "@codemirror/autocomplete";
   import { markdown, markdownLanguage } from "@codemirror/lang-markdown";
   import { syntaxHighlighting, HighlightStyle } from "@codemirror/language";
   import { tags as t } from "@lezer/highlight";
@@ -21,6 +27,7 @@
   export let content: unknown = "";
   export let readOnly = false;
   export let memoTitles: string[] = [];
+  export let currentMemoTitle = "";
   export let openMemoLink: ((title: string) => void) | undefined = undefined;
   export let workspaceProjectDir: string | null = null;
   export let taskId: string | null = null;
@@ -71,6 +78,39 @@
     { value: "read", label: "Read", className: "read-mode-btn" },
     { value: "edit", label: "Edit", className: "edit-mode-btn" },
   ];
+
+  function memoLinkCompletion(context: CompletionContext): CompletionResult | null {
+    const line = context.state.doc.lineAt(context.pos);
+    const textBefore = line.text.slice(0, context.pos - line.from);
+    const match = /\[\[([^\]\n|]*)$/.exec(textBefore);
+    if (!match) return null;
+
+    const query = normalizeMemoTitle(match[1]);
+    const normalizedCurrentTitle = normalizeMemoTitle(currentMemoTitle);
+    const options = memoTitles
+      .map((title) => {
+        const label = String(title || "").trim();
+        return { label, normalized: normalizeMemoTitle(label) };
+      })
+      .filter(({ label, normalized }) => {
+        if (!label || normalized === normalizedCurrentTitle) return false;
+        return !query || normalized.includes(query);
+      })
+      .map((title) => ({
+        label: title.label,
+        type: "text",
+        apply: title.label,
+        detail: "memo",
+      }));
+
+    if (options.length === 0 && !context.explicit) return null;
+
+    return {
+      from: context.pos - match[1].length,
+      options,
+      validFor: /^[^\]\n|]*$/,
+    };
+  }
 
   function normalizeMemoTitle(title: string): string {
     return title.trim().toLocaleLowerCase();
@@ -605,6 +645,10 @@
       editorTheme,
       lineNumbers(),
       markdown({ base: markdownLanguage, codeLanguages: languages }),
+      autocompletion({
+        override: [memoLinkCompletion],
+        activateOnTyping: true,
+      }),
       syntaxHighlighting(markdownHighlightStyle),
       highlightSelectionMatches(),
       keymap.of([
@@ -629,6 +673,7 @@
             return true;
           },
         },
+        ...completionKeymap,
         ...defaultKeymap,
         ...searchKeymap,
         {
@@ -834,6 +879,7 @@
   }
 
   $: normalizedContent = toMarkdown(content);
+  $: hasRenderedContent = Boolean(currentContent.trim());
   $: if (!isEditing && normalizedContent !== currentContent) {
     currentContent = normalizedContent;
   }
@@ -1012,7 +1058,7 @@
           on:click={handlePreviewClick}
           on:keydown={handlePreviewKeydown}
         >
-          {#if currentContent.trim()}
+          {#if hasRenderedContent}
             <!-- eslint-disable-next-line svelte/no-at-html-tags -->
             <div class="preview" bind:this={livePreviewEl}>{@html renderedHtml}</div>
           {:else}
@@ -1023,7 +1069,12 @@
     </div>
   {:else}
     <!-- svelte-ignore a11y-no-static-element-interactions -->
-    <div class="preview-mode" on:click={handlePreviewClick} on:keydown={handlePreviewKeydown}>
+    <div
+      class="preview-mode"
+      class:emptyContent={!hasRenderedContent}
+      on:click={handlePreviewClick}
+      on:keydown={handlePreviewKeydown}
+    >
       {#if !readOnly}
         <div class="preview-bar">
           <SegmentedControl
@@ -1034,7 +1085,7 @@
           />
         </div>
       {/if}
-      {#if currentContent.trim()}
+      {#if hasRenderedContent}
         <!-- eslint-disable-next-line svelte/no-at-html-tags -->
         <div class="preview" bind:this={previewEl}>{@html renderedHtml}</div>
       {:else if !readOnly}
@@ -1058,6 +1109,19 @@
     min-height: 0;
     overflow: hidden;
     background-color: var(--theme-color-Main-light);
+    border: 1px solid color-mix(in srgb, var(--theme-color-Sub-dark) 45%, transparent);
+    box-sizing: border-box;
+  }
+
+  .wrapper :global(.cm-tooltip-autocomplete) {
+    background-color: var(--theme-color-Main-main);
+    border: 1px solid color-mix(in srgb, var(--theme-color-Sub-main) 28%, transparent);
+    color: var(--theme-color-Sub-main);
+  }
+
+  .wrapper :global(.cm-tooltip-autocomplete ul li[aria-selected]) {
+    background-color: color-mix(in srgb, var(--theme-color-Primary-main) 18%, transparent);
+    color: var(--theme-color-Sub-light);
   }
 
   .edit-mode {
@@ -1333,6 +1397,10 @@
     overflow: auto;
   }
 
+  .preview-mode.emptyContent {
+    overflow: hidden;
+  }
+
   .preview-bar {
     position: sticky;
     top: 0;
@@ -1382,12 +1450,16 @@
 
   .placeholder {
     flex: 1 1 auto;
-    min-height: 100%;
+    min-height: 0;
     box-sizing: border-box;
     padding: var(--sp4);
     color: var(--theme-color-Sub-main);
     font-size: var(--font-body-md);
     font-style: italic;
+  }
+
+  .live-preview .placeholder {
+    min-height: 100%;
   }
 
   .preview :global(h1),

--- a/src/features/memos/components/Memo.svelte
+++ b/src/features/memos/components/Memo.svelte
@@ -7,6 +7,7 @@
   export let content: unknown = "";
   export let readOnly = false;
   export let memoTitles: string[] = [];
+  export let currentMemoTitle = "";
   export let openMemoLink: ((title: string) => void) | undefined = undefined;
   export let workspaceProjectDir: string | null = null;
   export let taskId: string | null = null;
@@ -27,6 +28,7 @@
       {content}
       {readOnly}
       {memoTitles}
+      {currentMemoTitle}
       {openMemoLink}
       {workspaceProjectDir}
       {taskId}

--- a/src/features/memos/components/MemoTab.svelte
+++ b/src/features/memos/components/MemoTab.svelte
@@ -429,6 +429,7 @@
           saveMemo={(editedContent) => saveMemo(editedContent, selectedMemoIndex)}
           content={editedContent}
           memoTitles={memo.map((entry) => entry.title)}
+          currentMemoTitle={selectedMemo?.title ?? ""}
           openMemoLink={selectMemoByTitle}
           {isWorkspaceProject}
           format={selectedMemoFormat}

--- a/src/features/tasks/components/BulkActionBar.svelte
+++ b/src/features/tasks/components/BulkActionBar.svelte
@@ -118,7 +118,7 @@
 
 <svelte:window on:click={handleWindowClick} on:keydown={handleKeydown} />
 
-{#if count > 0}
+{#if count > 1}
   <div
     class="BulkBar"
     role="toolbar"

--- a/src/features/tasks/components/TaskDetail.svelte
+++ b/src/features/tasks/components/TaskDetail.svelte
@@ -17,8 +17,10 @@
   import { get } from "svelte/store";
   import MemoTab from "@features/memos/components/MemoTab.svelte";
   import Card from "@lib/primitives/Card.svelte";
+  import IconButton from "@lib/primitives/IconButton.svelte";
   import StatusSelect from "@features/tasks/components/StatusSelect.svelte";
   import DateInput from "@lib/primitives/DateInput.svelte";
+  import * as platform from "@lib/ipc/platform";
   import {
     convertMemoContent,
     isQuillDelta,
@@ -156,6 +158,9 @@
 
   const addMemo = (newMemoTitle) => {
     if (newMemoTitle) {
+      const editContext = getEditContext();
+      const liveNode = getLiveNode(editContext);
+      if (!liveNode) return false;
       let newMemo = {
         id: uuidV4(),
         title: newMemoTitle,
@@ -163,15 +168,19 @@
         tags: [],
         format: defaultMemoFormat,
       };
-      changeData(node, "memo", [...node.data.memo, newMemo]);
+      changeData(liveNode, "memo", [...(liveNode.data.memo ?? []), newMemo], editContext);
       return true;
     }
   };
   const deleteMemo = (index) => {
+    const editContext = getEditContext();
+    const liveNode = getLiveNode(editContext);
+    if (!liveNode) return false;
     changeData(
-      node,
+      liveNode,
       "memo",
-      node.data.memo.filter((_, i) => i !== index)
+      (liveNode.data.memo ?? []).filter((_, i) => i !== index),
+      editContext
     );
     return true;
   };
@@ -200,10 +209,16 @@
     }
   };
   const reorderMemo = (fromIndex, toIndex) => {
-    const updatedMemo = [...node.data["memo"]];
+    const editContext = getEditContext();
+    const liveNode = getLiveNode(editContext);
+    if (!liveNode) return false;
+    const updatedMemo = [...(liveNode.data["memo"] ?? [])];
+    if (fromIndex < 0 || fromIndex >= updatedMemo.length) return false;
+    if (toIndex < 0 || toIndex >= updatedMemo.length) return false;
     const [moved] = updatedMemo.splice(fromIndex, 1);
     updatedMemo.splice(toIndex, 0, moved);
-    changeData(node, "memo", updatedMemo);
+    changeData(liveNode, "memo", updatedMemo, editContext);
+    return true;
   };
   const saveMemoTags = (selectedMemoIndex, tags) => {
     const editContext = getEditContext();
@@ -410,6 +425,18 @@
         break;
     }
   }
+
+  function openTaskDetailInWindow() {
+    if (!node || !$selected_id || !$table_selected_id) return;
+
+    platform.openTaskDetailWindow({
+      projectId: $selected_id,
+      taskId: node.id,
+      taskName: name,
+      selectedType: isWorkspaceProject ? "WorkspaceProject" : "Projects",
+      projectDir: isWorkspaceProject ? ($workspace_store.activeProjectDir ?? undefined) : undefined,
+    });
+  }
 </script>
 
 {#if is_selected && node}
@@ -418,6 +445,28 @@
     padded={false}
     style={"height: 100%; width: 100%; overflow: hidden;"}
   >
+    {#if !hideDetailTitle}
+      <IconButton
+        slot="header-actions"
+        variant="text"
+        normalColor="var(--theme-color-Sub-main)"
+        activeColor="var(--theme-color-Primary-main)"
+        ariaLabel="タスク詳細を別ウィンドウで開く"
+        tooltipContent="別ウィンドウで開く"
+        style="margin: 0; width: 1.75rem; height: 1.75rem; box-shadow: none;"
+        on:click={openTaskDetailInWindow}
+      >
+        <svg viewBox="0 0 24 24" fill="none" aria-hidden="true" xmlns="http://www.w3.org/2000/svg">
+          <path
+            d="M15 3H21V9M14 10L21 3M21 14V19C21 20.1 20.1 21 19 21H5C3.9 21 3 20.1 3 19V5C3 3.9 3.9 3 5 3H10"
+            stroke="currentColor"
+            stroke-width="2"
+            stroke-linecap="round"
+            stroke-linejoin="round"
+          />
+        </svg>
+      </IconButton>
+    {/if}
     {#if extraSelectedCount > 0}
       <div class="multi-select-indicator" role="status" aria-live="polite">
         他 {extraSelectedCount} 件選択中（一括操作はバーから行えます）

--- a/src/features/tasks/components/TreeTable.svelte
+++ b/src/features/tasks/components/TreeTable.svelte
@@ -293,13 +293,20 @@
       }
     });
 
+    const getLeadingColumnWidth = () =>
+      tableRows[0]?.querySelector(".CheckboxHeaderCell")?.getBoundingClientRect().width ?? 0;
+
     // Set width
     if (is_default) {
       const default_ratio_sum = currentHeaders.reduce(
         (partialSum, header) => partialSum + header.default_ratio,
         0
       );
-      const default_root_width = tableRows[0].getBoundingClientRect().width;
+      const leadingColumnWidth = getLeadingColumnWidth();
+      const default_root_width = Math.max(
+        0,
+        tableRows[0].getBoundingClientRect().width - leadingColumnWidth
+      );
       const default_data_widths = currentHeaders.map(
         (header) => (default_root_width * header.default_ratio) / default_ratio_sum
       );
@@ -311,7 +318,7 @@
       });
 
       // Create resizer elements
-      let left = 0;
+      let left = leadingColumnWidth;
       domHeaders.forEach((header, index) => {
         if (index === 0) {
           left += default_data_widths[index];
@@ -358,10 +365,11 @@
     function fitNameColumn() {
       if (domHeaders.length === 0) return;
       const tableWidth = table_root.getBoundingClientRect().width;
+      const leadingColumnWidth = getLeadingColumnWidth();
       const widths = domHeaders.map((h) => h.getBoundingClientRect().width);
       const fixedTotal = widths.slice(1).reduce((s, w) => s + w, 0);
       const nameMin = parseFloat(window.getComputedStyle(domHeaders[0]).minWidth) || 0;
-      const nameWidth = Math.max(nameMin, tableWidth - fixedTotal);
+      const nameWidth = Math.max(nameMin, tableWidth - leadingColumnWidth - fixedTotal);
 
       domHeaders[0].style.width = `${nameWidth}px`;
       data_rows.forEach((data_row) => {
@@ -371,7 +379,7 @@
       // Every resizer sits between two columns; since column 0 changed,
       // ALL resizer left positions shift by the delta. Re-place them
       // using the new Name width followed by each fixed downstream width.
-      let left = nameWidth;
+      let left = leadingColumnWidth + nameWidth;
       existingResizers.forEach((resizer, idx) => {
         resizer.style.left = `${left - 3}px`;
         left += widths[idx + 1] ?? 0;
@@ -398,7 +406,9 @@
         });
       });
 
-      let left = 0;
+      const leadingColumnWidth =
+        table_root?.querySelector(".CheckboxHeaderCell")?.getBoundingClientRect().width ?? 0;
+      let left = leadingColumnWidth;
       resizers.forEach((columnResizer, index) => {
         left += widths[index];
         columnResizer.style.left = `${left - 3}px`;
@@ -545,7 +555,7 @@
   }
 
   function handleBackgroundClick() {
-    if (selectionSize > 0) clearSelection();
+    table_root?.focus?.();
   }
 
   function handleScroll(event) {
@@ -689,7 +699,7 @@
 
   function focusNewNode(newNodeId) {
     setTimeout(() => {
-      $table_selected_id = newNodeId;
+      selectOnly(newNodeId);
 
       setTimeout(() => {
         const newRow = document.getElementById(newNodeId);
@@ -956,7 +966,7 @@
     const data = rmNode(deleteTargetId, $tree_data.data);
     $tree_data = { ...$tree_data, data };
     if ($table_selected_id === deleteTargetId) {
-      $table_selected_id = undefined;
+      clearSelection();
     }
     deleteTargetId = undefined;
     deleteTargetName = "";

--- a/src/features/tasks/components/TreeTableHeader.svelte
+++ b/src/features/tasks/components/TreeTableHeader.svelte
@@ -835,14 +835,19 @@
     display: flex;
     align-items: center;
     justify-content: center;
+    box-sizing: border-box;
+    line-height: 0;
     background-color: var(--header-bg);
     border-right: 1px solid var(--header-border);
     border-bottom: 1px solid var(--header-border);
   }
   .HeaderCheckbox {
+    display: block;
+    flex: 0 0 0.95rem;
     width: 0.95rem;
     height: 0.95rem;
     margin: 0;
+    line-height: 1;
     cursor: pointer;
     accent-color: var(--theme-color-Primary-dark);
   }
@@ -1011,7 +1016,7 @@
     cursor: pointer;
     user-select: none;
   }
-  input[type="checkbox"] {
+  .SettingsRow input[type="checkbox"] {
     width: 0.9rem;
     height: 0.9rem;
     flex-shrink: 0;

--- a/src/features/tasks/components/TreeTableRow.svelte
+++ b/src/features/tasks/components/TreeTableRow.svelte
@@ -7,8 +7,9 @@
 
 <script>
   import { createEventDispatcher } from "svelte";
-  import { selected_id } from "@stores";
+  import { selected_id, selected_type } from "@stores";
   import { selected_ids } from "@stores/ui";
+  import { workspace_store } from "@features/workspace/stores/workspace";
   import { tree_data } from "@features/tasks/stores/tree";
   import { getNode, getTopLevelSelection } from "@features/tasks/utils/tree_control";
   import { ripple } from "@lib/actions";
@@ -110,6 +111,9 @@
       projectId: $selected_id,
       taskId: id,
       taskName: taskText,
+      selectedType: $selected_type === "WorkspaceProject" ? "WorkspaceProject" : "Projects",
+      projectDir:
+        $selected_type === "WorkspaceProject" ? $workspace_store.activeProjectDir : undefined,
     });
   }
 
@@ -476,17 +480,17 @@
   .TableRow.MenuOpen {
     z-index: 9999;
   }
-  .TableRow :global(*) {
+  .TableRow {
     --backgroundColor: var(--theme-color-Main-light);
   }
-  .TableRow.OverdueRow :global(*) {
+  .TableRow.OverdueRow {
     --backgroundColor: color-mix(
       in srgb,
       var(--theme-color-Error-main) 10%,
       var(--theme-color-Main-light)
     );
   }
-  .TableRow.DueSoonRow :global(*) {
+  .TableRow.DueSoonRow {
     --backgroundColor: color-mix(
       in srgb,
       var(--theme-color-Warning-main) 10%,
@@ -498,10 +502,10 @@
     outline-offset: 2px;
     z-index: 999;
   }
-  .TableRow:hover :global(*) {
+  .TableRow:hover {
     --backgroundColor: var(--theme-color-Main-main);
   }
-  .TableRow.Selected :global(*) {
+  .TableRow.Selected {
     --backgroundColor: color-mix(
       in srgb,
       var(--theme-color-Primary-main) 14%,

--- a/src/features/tasks/stores/tree.ts
+++ b/src/features/tasks/stores/tree.ts
@@ -310,6 +310,7 @@ function createTreeData(initialValue: ProjectData | undefined): TreeDataStore {
           const shouldSyncCurrentProject =
             currentSelectedType === "Projects" && currentSelectedId === nextTreeData.data?.id;
           const shouldSyncTaskDetailWindow =
+            pendingTaskDetailSelection?.selectedType !== "WorkspaceProject" &&
             pendingTaskDetailSelection?.projectId === nextTreeData.data?.id;
 
           if (!shouldSyncCurrentProject && !shouldSyncTaskDetailWindow) {
@@ -339,7 +340,7 @@ function createTreeData(initialValue: ProjectData | undefined): TreeDataStore {
           if (suppressInitialLoadOnce) {
             suppressInitialLoadOnce = false;
           } else if (pendingTaskDetailSelection?.projectId) {
-            selected_type.set("Projects");
+            selected_type.set(pendingTaskDetailSelection.selectedType ?? "Projects");
             selected_id.set(pendingTaskDetailSelection.projectId);
             if (pendingTaskDetailSelection.taskId) {
               table_selected_id.set(pendingTaskDetailSelection.taskId);

--- a/src/features/workspace/stores/workspace.ts
+++ b/src/features/workspace/stores/workspace.ts
@@ -79,10 +79,11 @@ function createWorkspaceStore(): WorkspaceStore {
       (async () => {
         const { workspaces, activeWorkspace } = await platform.wsGetWorkspaces();
         const projects = activeWorkspace ? await loadProjects(activeWorkspace) : [];
+        const current = get({ subscribe } as WorkspaceStore);
         set({
           workspaces: workspaces ?? [],
           activeWorkspacePath: activeWorkspace,
-          activeProjectDir: null,
+          activeProjectDir: current.activeProjectDir,
           projects,
         });
       })();

--- a/src/features/workspace/utils/workspace_tree.ts
+++ b/src/features/workspace/utils/workspace_tree.ts
@@ -57,6 +57,7 @@ export function workspaceToProjectData(
           content: m.content,
           tags: m.tags,
           format: normalizeMemoFormat(m.format, "markdown"),
+          order: m.order,
         })),
       },
       children: childIds.map((cid) => buildNode(cid)),
@@ -103,7 +104,7 @@ export function projectDataToWorkspaceTasks(
       startDate: node.data["start date"] || undefined,
       dueDate: node.data["due date"] || undefined,
       parents: parentIds,
-      memos: (node.data.memo || []).map((m) => {
+      memos: (node.data.memo || []).map((m, index) => {
         const format = normalizeMemoFormat(m.format, "markdown");
         return {
           id: m.id || "",
@@ -111,6 +112,7 @@ export function projectDataToWorkspaceTasks(
           content: format === "markdown" ? toMarkdown(m.content) : m.content,
           tags: Array.isArray(m.tags) ? m.tags : [],
           format,
+          order: index,
         };
       }),
       createdAt: existing?.createdAt || today,

--- a/src/lib/layouts/SplitPanes.svelte
+++ b/src/lib/layouts/SplitPanes.svelte
@@ -481,6 +481,10 @@
     padding: var(--sp4);
   }
 
+  .SplitPaneRoot > :global(.Pane.PaneMini > :not(.PaneMiniPlaceholder)) {
+    display: none !important;
+  }
+
   /* Blank Card placeholder injected when a pane enters mini state.
      Styled as a Card header bar — the entire strip gets the CardHeader
      blue-tinted background so it reads as "a collapsed card".

--- a/src/pages/MainPage.svelte
+++ b/src/pages/MainPage.svelte
@@ -37,7 +37,7 @@
   } from "@features/tasks/utils/tree_control";
   import { getDefaultNode } from "@features/tasks/utils/tree_control";
   import { undoHistory, redoHistory } from "@features/tasks/stores/tree";
-  import { selected_ids, clearSelection } from "@stores/ui";
+  import { selected_ids, clearSelection, selectOnly } from "@stores/ui";
 
   // ページ内検索はstoresから共有
 
@@ -69,7 +69,7 @@
       return;
     }
     $tree_data.data = rmNode($table_selected_id, $tree_data.data);
-    $table_selected_id = undefined;
+    clearSelection();
   };
 
   // Reactive bulk-capability flags for the toolbar buttons.
@@ -282,7 +282,7 @@
       }
 
       // 新しいノードを選択状態にしてDOMの更新を待つ
-      $table_selected_id = new_node.id;
+      selectOnly(new_node.id);
       await tick();
 
       const newRow = document.getElementById(new_node.id);

--- a/src/stores/ui.ts
+++ b/src/stores/ui.ts
@@ -14,10 +14,18 @@ const currentSearch =
 const isTaskDetailWindow = currentHash === "#task-detail-window";
 const detailProjectId = currentSearch.get("projectId") || undefined;
 const detailTaskId = currentSearch.get("taskId") || undefined;
+const detailSelectedType =
+  currentSearch.get("selectedType") === "WorkspaceProject" ? "WorkspaceProject" : "Projects";
+const detailProjectDir = currentSearch.get("projectDir") || undefined;
 
 export let pendingTaskDetailSelection: PendingTaskDetailSelection | undefined =
   isTaskDetailWindow && detailProjectId && detailTaskId
-    ? { projectId: detailProjectId, taskId: detailTaskId }
+    ? {
+        projectId: detailProjectId,
+        taskId: detailTaskId,
+        selectedType: detailSelectedType,
+        projectDir: detailProjectDir,
+      }
     : undefined;
 
 export function clearPendingTaskDetailSelection() {
@@ -162,7 +170,18 @@ function createSelectedID(initialValue: string | undefined): SelectedIdStore {
             workspace_tasks_cache.set(result.tasks);
             const converted = workspaceToProjectData(result.tasks, current);
             tree_data.setFromSource(converted);
-            table_selected_id.set(undefined);
+            if (
+              pendingTaskDetailSelection?.selectedType === "WorkspaceProject" &&
+              pendingTaskDetailSelection.projectId === current &&
+              (!pendingTaskDetailSelection.projectDir ||
+                pendingTaskDetailSelection.projectDir === activeProjectDir) &&
+              pendingTaskDetailSelection.taskId &&
+              getNode(pendingTaskDetailSelection.taskId, converted.data)
+            ) {
+              table_selected_id.set(pendingTaskDetailSelection.taskId);
+            } else {
+              table_selected_id.set(undefined);
+            }
             finishLoad(version);
           },
           () => {
@@ -423,14 +442,24 @@ export function pruneSelection(existingIds: Set<string>) {
   });
 }
 
-export function setTaskDetailWindowTarget(projectId: string, taskId: string) {
+export function setTaskDetailWindowTarget(
+  projectId: string,
+  taskId: string,
+  options: { selectedType?: "Projects" | "WorkspaceProject"; projectDir?: string | null } = {}
+) {
   if (!projectId || !taskId) {
     pendingTaskDetailSelection = undefined;
     return;
   }
 
-  pendingTaskDetailSelection = { projectId, taskId };
-  selected_type.set("Projects");
+  const selectedType = options.selectedType ?? "Projects";
+  pendingTaskDetailSelection = {
+    projectId,
+    taskId,
+    selectedType,
+    projectDir: options.projectDir ?? null,
+  };
+  selected_type.set(selectedType);
   selected_id.set(projectId);
 }
 

--- a/src/types/app.ts
+++ b/src/types/app.ts
@@ -23,6 +23,8 @@ export interface ProjectListItem {
 export interface PendingTaskDetailSelection {
   projectId: string;
   taskId: string;
+  selectedType?: "Projects" | "WorkspaceProject";
+  projectDir?: string | null;
 }
 
 export interface TaskDetailWindowData extends PendingTaskDetailSelection {

--- a/src/types/workspace.ts
+++ b/src/types/workspace.ts
@@ -8,6 +8,7 @@ export interface WorkspaceMemo {
   content: unknown;
   tags: string[];
   format?: MemoFormat;
+  order?: number;
 }
 
 export interface WorkspaceTask {

--- a/tests/component/BulkActionBar.test.js
+++ b/tests/component/BulkActionBar.test.js
@@ -1,0 +1,27 @@
+import { render } from "@testing-library/svelte";
+import { vi } from "vitest";
+
+import BulkActionBar from "@features/tasks/components/BulkActionBar.svelte";
+
+describe("BulkActionBar", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    vi.runOnlyPendingTimers();
+    vi.useRealTimers();
+  });
+
+  test("stays hidden for a single selected task", () => {
+    render(BulkActionBar, { props: { count: 1 } });
+
+    expect(document.querySelector(".BulkBar")).not.toBeInTheDocument();
+  });
+
+  test("shows for multiple selected tasks", () => {
+    render(BulkActionBar, { props: { count: 2 } });
+
+    expect(document.querySelector(".BulkBar")).toBeInTheDocument();
+  });
+});

--- a/tests/component/Memo.test.js
+++ b/tests/component/Memo.test.js
@@ -1,6 +1,8 @@
 ﻿import { fireEvent, render, waitFor } from "@testing-library/svelte";
 import { tick } from "svelte";
 import { vi } from "vitest";
+import { startCompletion } from "@codemirror/autocomplete";
+import { EditorView } from "@codemirror/view";
 
 const quillInstances = [];
 
@@ -143,6 +145,7 @@ describe("Markdown Memo - view mode", () => {
   test("shows placeholder when content is empty", () => {
     renderMarkdownMemo({ saveMemo, content: "" });
     expect(document.querySelector(".placeholder")).toBeInTheDocument();
+    expect(document.querySelector(".preview-mode")).toHaveClass("emptyContent");
   });
 
   test("renders markdown content as HTML in view mode", () => {
@@ -198,6 +201,7 @@ describe("Markdown Memo - view mode", () => {
   test("readOnly: no placeholder shown when empty", () => {
     renderMarkdownMemo({ saveMemo, content: "", readOnly: true });
     expect(document.querySelector(".placeholder")).not.toBeInTheDocument();
+    expect(document.querySelector(".preview-mode")).toHaveClass("emptyContent");
   });
 });
 
@@ -219,6 +223,60 @@ describe("Markdown Memo - edit mode", () => {
     await fireEvent.click(document.querySelector(".edit-mode-btn"));
     await waitFor(() => {
       expect(document.querySelector(".cm-editor")).toBeInTheDocument();
+    });
+  });
+
+  test("suggests memo titles after a wiki-link opener", async () => {
+    renderMarkdownMemo({
+      saveMemo,
+      content: "",
+      memoTitles: ["Daily Notes", "Research Log"],
+    });
+    await fireEvent.click(document.querySelector(".edit-mode-btn"));
+    await waitFor(() => {
+      expect(document.querySelector(".cm-editor")).toBeInTheDocument();
+    });
+
+    const view = EditorView.findFromDOM(document.querySelector(".cm-editor"));
+    view.focus();
+    view.dispatch({
+      changes: { from: 0, insert: "[[" },
+      selection: { anchor: 2 },
+      userEvent: "input.type",
+    });
+    startCompletion(view);
+
+    await waitFor(() => {
+      expect(document.querySelector(".cm-tooltip-autocomplete")).toHaveTextContent("Daily Notes");
+      expect(document.querySelector(".cm-tooltip-autocomplete")).toHaveTextContent("Research Log");
+    });
+  });
+
+  test("does not suggest the current memo title after a wiki-link opener", async () => {
+    renderMarkdownMemo({
+      saveMemo,
+      content: "",
+      memoTitles: ["Daily Notes", "Research Log"],
+      currentMemoTitle: "Daily Notes",
+    });
+    await fireEvent.click(document.querySelector(".edit-mode-btn"));
+    await waitFor(() => {
+      expect(document.querySelector(".cm-editor")).toBeInTheDocument();
+    });
+
+    const view = EditorView.findFromDOM(document.querySelector(".cm-editor"));
+    view.focus();
+    view.dispatch({
+      changes: { from: 0, insert: "[[" },
+      selection: { anchor: 2 },
+      userEvent: "input.type",
+    });
+    startCompletion(view);
+
+    await waitFor(() => {
+      const tooltip = document.querySelector(".cm-tooltip-autocomplete");
+      expect(tooltip).toHaveTextContent("Research Log");
+      expect(tooltip).not.toHaveTextContent("Daily Notes");
     });
   });
 

--- a/tests/component/ProjectPage.test.js
+++ b/tests/component/ProjectPage.test.js
@@ -25,6 +25,7 @@ vi.mock("@features/gantt/components/GanttPanel.svelte", async () => {
 
 import ProjectPage from "@pages/MainPage.svelte";
 import { closed_node_ids, ganttVisible, selected_id, table_selected_id, tree_data } from "@stores";
+import { clearSelection, selected_ids } from "@stores/ui";
 
 function createProjectData() {
   return {
@@ -69,6 +70,7 @@ describe("ProjectPage", () => {
     });
     tree_data.set(createProjectData());
     selected_id.set("project-1");
+    clearSelection();
     table_selected_id.set("task-1");
     closed_node_ids.set(new Set());
     ganttVisible.set(false);
@@ -90,6 +92,7 @@ describe("ProjectPage", () => {
     expect(get(tree_data).data.children).toHaveLength(2);
     expect(get(tree_data).data.children[1].data.name).toBe("new_task");
     expect(get(table_selected_id)).toBe(get(tree_data).data.children[1].id);
+    expect(get(selected_ids)).toEqual(new Set([get(tree_data).data.children[1].id]));
   });
 
   test("adds the first task under the project root when nothing is selected", async () => {

--- a/tests/component/TaskDetail.test.js
+++ b/tests/component/TaskDetail.test.js
@@ -17,6 +17,7 @@ import {
   tree_data,
   workspace_store,
 } from "@stores";
+import { clearSelection } from "@stores/ui";
 
 function createProjectData() {
   return {
@@ -72,11 +73,13 @@ describe("TaskDetail", () => {
       projects: [],
     });
     tree_data.set(createProjectData());
+    clearSelection();
     table_selected_id.set(undefined);
   });
 
   afterEach(() => {
     delete window.__memoStubSaveOnDestroy;
+    delete window.electronAPI;
   });
 
   test("shows a placeholder when no task is selected", () => {
@@ -94,6 +97,33 @@ describe("TaskDetail", () => {
     expect(screen.getByRole("button", { name: "メモを追加" })).toBeInTheDocument();
     expect(screen.getByText("First Task")).toBeInTheDocument();
     expect(screen.queryByLabelText("Storage mode")).not.toBeInTheDocument();
+  });
+
+  test("opens the selected task detail from the card header action", async () => {
+    window.electronAPI = { openTaskDetailWindow: vi.fn() };
+    workspace_store.set({
+      workspaces: [],
+      activeWorkspacePath: "C:\\workspace",
+      activeProjectDir: "C:\\workspace\\project-1",
+      projects: [],
+    });
+    selected_type.set("WorkspaceProject");
+    table_selected_id.set("task-2");
+
+    render(TaskDetail);
+
+    await fireEvent.click(screen.getByRole("button", { name: "タスク詳細を別ウィンドウで開く" }));
+    await tick();
+
+    expect(window.electronAPI.openTaskDetailWindow).toHaveBeenCalledWith(
+      expect.objectContaining({
+        projectId: "project-1",
+        taskId: "task-2",
+        taskName: "Second Task",
+        selectedType: "WorkspaceProject",
+        projectDir: "C:\\workspace\\project-1",
+      })
+    );
   });
 
   test("edits task detail fields independent of visible table columns", async () => {
@@ -168,6 +198,38 @@ describe("TaskDetail", () => {
     expect(screen.getByRole("button", { name: "Select memo memo" })).toHaveClass("selected");
     expect(get(tree_data).data.children[0].data.memo).toEqual([
       expect.objectContaining({ title: "memo", content: "" }),
+    ]);
+  });
+
+  test("reorders memo tabs and writes the new order into task data", async () => {
+    const project = createProjectData();
+    project.data.children[0].data.memo = [
+      { id: "memo-first", title: "first", content: "" },
+      { id: "memo-second", title: "second", content: "" },
+    ];
+    tree_data.set(project);
+    table_selected_id.set("task-1");
+
+    render(TaskDetail);
+
+    const firstTab = screen.getByRole("button", { name: "Select memo first" });
+    const secondTab = screen.getByRole("button", { name: "Select memo second" });
+    const dataTransfer = { effectAllowed: "", dropEffect: "" };
+    const dragStart = new Event("dragstart", { bubbles: true, cancelable: true });
+    Object.defineProperty(dragStart, "dataTransfer", { value: dataTransfer });
+    const drop = new Event("drop", { bubbles: true, cancelable: true });
+    Object.defineProperties(drop, {
+      dataTransfer: { value: dataTransfer },
+      clientX: { value: 0 },
+    });
+
+    secondTab.dispatchEvent(dragStart);
+    firstTab.dispatchEvent(drop);
+    await tick();
+
+    expect(get(tree_data).data.children[0].data.memo.map((memo) => memo.id)).toEqual([
+      "memo-second",
+      "memo-first",
     ]);
   });
 

--- a/tests/component/TreeTable.test.js
+++ b/tests/component/TreeTable.test.js
@@ -21,6 +21,7 @@ vi.mock("@lib/primitives/Dialog.svelte", async () => {
 import TreeTable from "@features/tasks/components/TreeTable.svelte";
 import {
   closed_node_ids,
+  column_settings,
   filtered_data,
   selected_id,
   selected_type,
@@ -28,6 +29,7 @@ import {
   theme,
   tree_data,
 } from "@stores";
+import { clearSelection, selected_ids } from "@stores/ui";
 import { workspace_store } from "@features/workspace/stores/workspace";
 
 function createProjectData() {
@@ -74,8 +76,11 @@ function createProjectData() {
 }
 
 describe("TreeTable", () => {
+  let originalGetBoundingClientRect;
+
   beforeEach(() => {
     const projectData = createProjectData();
+    originalGetBoundingClientRect = Element.prototype.getBoundingClientRect;
 
     if (!globalThis.ResizeObserver) {
       globalThis.ResizeObserver = class {
@@ -94,9 +99,17 @@ describe("TreeTable", () => {
     tree_data.set(projectData);
     filtered_data.set(projectData.data);
     selected_id.set("project-1");
+    clearSelection();
     selected_type.set("Projects");
     table_selected_id.set(undefined);
     closed_node_ids.set(new Set());
+    column_settings.set([
+      { id: "name", label: "タスク名", visible: true },
+      { id: "status", label: "ステータス", visible: true },
+      { id: "start date", label: "開始日", visible: true },
+      { id: "due date", label: "期限日", visible: true },
+      { id: "memo", label: "メモ数", visible: true },
+    ]);
     theme.set("dark");
     workspace_store.set({
       workspaces: [],
@@ -106,6 +119,10 @@ describe("TreeTable", () => {
     });
   });
 
+  afterEach(() => {
+    Element.prototype.getBoundingClientRect = originalGetBoundingClientRect;
+  });
+
   test("selects a row and reflects the selected state", async () => {
     render(TreeTable);
 
@@ -113,6 +130,20 @@ describe("TreeTable", () => {
     await tick();
 
     expect(get(table_selected_id)).toBe("task-1");
+    expect(screen.getByTestId("row-task-1")).toHaveAttribute("data-selected", "true");
+  });
+
+  test("keeps the current row selected when the tree background is clicked", async () => {
+    const { container } = render(TreeTable);
+
+    await fireEvent.click(screen.getByTestId("select-task-1"));
+    await tick();
+
+    await fireEvent.click(container.querySelector(".TableRoot"));
+    await tick();
+
+    expect(get(table_selected_id)).toBe("task-1");
+    expect(get(selected_ids)).toEqual(new Set(["task-1"]));
     expect(screen.getByTestId("row-task-1")).toHaveAttribute("data-selected", "true");
   });
 
@@ -155,5 +186,61 @@ describe("TreeTable", () => {
     await fireEvent.click(screen.getByTestId("open-folder-task-1"));
 
     expect(wsOpenTaskFolder).toHaveBeenCalledWith("C:/workspace/project", "task-1");
+  });
+
+  test("positions resizers after the selection checkbox column", async () => {
+    const rect = (width, height = 40) => ({
+      x: 0,
+      y: 0,
+      top: 0,
+      left: 0,
+      right: width,
+      bottom: height,
+      width,
+      height,
+      toJSON: () => ({}),
+    });
+
+    Element.prototype.getBoundingClientRect = function () {
+      if (this.classList.contains("TableRoot") || this.classList.contains("TableRow")) {
+        return rect(1000, this.classList.contains("TableRow") ? 40 : 300);
+      }
+      if (
+        this.classList.contains("CheckboxHeaderCell") ||
+        this.classList.contains("CheckboxCell")
+      ) {
+        return rect(28, 40);
+      }
+      if (this.classList.contains("TableHeader") || this.classList.contains("TableData")) {
+        const width = Number.parseFloat(this.style.width.match(/([\d.]+)px/)?.[1] ?? "100");
+        return rect(width, 40);
+      }
+      return originalGetBoundingClientRect.call(this);
+    };
+
+    const { container } = render(TreeTable);
+    await tick();
+
+    const firstResizer = container.querySelector(".Resizer");
+    const nameRatio = 10;
+    const ratioSum = 10 + 4 + 3 + 4 + 2;
+    const checkboxWidth = 28;
+    const expectedNameWidth = ((1000 - checkboxWidth) * nameRatio) / ratioSum;
+
+    expect(firstResizer).toBeInTheDocument();
+    expect(Number.parseFloat(firstResizer.style.left)).toBeCloseTo(
+      checkboxWidth + expectedNameWidth - 3,
+      3
+    );
+
+    await fireEvent.mouseDown(firstResizer, { clientX: 500 });
+    await fireEvent.mouseMove(document, { clientX: 510 });
+
+    expect(Number.parseFloat(firstResizer.style.left)).toBeCloseTo(
+      checkboxWidth + expectedNameWidth + 10 - 3,
+      3
+    );
+
+    await fireEvent.mouseUp(document);
   });
 });

--- a/tests/component/TreeTableRow.test.js
+++ b/tests/component/TreeTableRow.test.js
@@ -1,0 +1,85 @@
+import { fireEvent, render, screen } from "@testing-library/svelte";
+import { tick } from "svelte";
+import { vi } from "vitest";
+
+import TreeTableRow from "@features/tasks/components/TreeTableRow.svelte";
+import { selected_id, selected_type, tree_data } from "@stores";
+import { workspace_store } from "@features/workspace/stores/workspace";
+import { clearSelection } from "@stores/ui";
+
+function rowFixture() {
+  const node = {
+    id: "task-1",
+    data: {
+      name: "Workspace Task",
+      status: "Open",
+      memo: [],
+    },
+    children: [],
+  };
+
+  return {
+    id: "task-1",
+    node,
+    depth: 1,
+    hasChildren: false,
+    expanded: false,
+  };
+}
+
+describe("TreeTableRow", () => {
+  beforeEach(() => {
+    clearSelection();
+    selected_type.set("WorkspaceProject");
+    selected_id.set("root-1");
+    tree_data.set({
+      headers: [{ name: "name", default_ratio: 10 }],
+      data: {
+        id: "root-1",
+        data: { name: "Workspace Project", status: "Open", memo: [] },
+        children: [rowFixture().node],
+      },
+    });
+    workspace_store.set({
+      workspaces: [],
+      activeWorkspacePath: "C:\\workspace",
+      activeProjectDir: "C:\\workspace\\project",
+      projects: [],
+    });
+    Object.defineProperty(window, "electronAPI", {
+      configurable: true,
+      value: {
+        openTaskDetailWindow: vi.fn(),
+      },
+    });
+  });
+
+  afterEach(() => {
+    delete window.electronAPI;
+  });
+
+  test("passes workspace context when opening the detail window", async () => {
+    const { container } = render(TreeTableRow, {
+      props: {
+        row: rowFixture(),
+        headers: [{ name: "name" }],
+      },
+    });
+
+    await fireEvent.contextMenu(container.querySelector(".TableRow"));
+    await tick();
+
+    await fireEvent.click(screen.getByText("show details"));
+    await tick();
+
+    expect(window.electronAPI.openTaskDetailWindow).toHaveBeenCalledWith(
+      expect.objectContaining({
+        projectId: "root-1",
+        taskId: "task-1",
+        taskName: "Workspace Task",
+        selectedType: "WorkspaceProject",
+        projectDir: "C:\\workspace\\project",
+      })
+    );
+  });
+});

--- a/tests/mocks/MemoStub.svelte
+++ b/tests/mocks/MemoStub.svelte
@@ -5,6 +5,7 @@
   export let saveMemo = undefined;
   export let memoIndex = 0;
   export let format = undefined;
+  export let currentMemoTitle = "";
 
   onDestroy(() => {
     if (window.__memoStubSaveOnDestroy) {
@@ -17,6 +18,7 @@
   data-testid="memo-stub"
   data-memo-index={memoIndex}
   data-format={format}
+  data-current-memo-title={currentMemoTitle}
   data-has-save={saveMemo ? "true" : "false"}
 >
   {typeof content === "string" ? content : "memo-content"}

--- a/tests/mocks/TreeTableHeaderTestStub.svelte
+++ b/tests/mocks/TreeTableHeaderTestStub.svelte
@@ -3,6 +3,7 @@
 </script>
 
 <div class="TableRow" data-testid="tree-table-header-stub">
+  <div class="CheckboxHeaderCell" style="width: 28px;"></div>
   {#each headers as header}
     <div
       class="TableHeader"

--- a/tests/mocks/TreeTableRowTestStub.svelte
+++ b/tests/mocks/TreeTableRowTestStub.svelte
@@ -27,6 +27,7 @@
   data-can-outdent={canOutdent ? "true" : "false"}
   data-selected={selected ? "true" : "false"}
 >
+  <div class="CheckboxCell" style="width: 28px;"></div>
   {#each headers as header}
     <div class="TableData" style="width: 100px;">
       {#if header.name === "name"}

--- a/tests/unit/workspace.test.js
+++ b/tests/unit/workspace.test.js
@@ -344,6 +344,38 @@ describe("file system operations", () => {
     expect(loaded.memos[0].content).toContain("Stored here");
   });
 
+  it("writeTask + readProject preserves memo order independently of filenames", () => {
+    const { projectDir } = createProject(tmpDir, "Proj", "root-id");
+    const taskDirs = new Map([["root-id", "_project"]]);
+    const task = {
+      id: "task-memo-order",
+      name: "Memo Order",
+      status: "Open",
+      parents: ["root-id"],
+      memos: [
+        { id: "z-memo", title: "First", content: "First content" },
+        { id: "a-memo", title: "Second", content: "Second content" },
+      ],
+      createdAt: "2026-04-24",
+    };
+
+    writeTask(projectDir, task, taskDirs);
+
+    const firstFile = fs.readFileSync(
+      path.join(projectDir, "task-memo-order", "z-memo.md"),
+      "utf8"
+    );
+    const secondFile = fs.readFileSync(
+      path.join(projectDir, "task-memo-order", "a-memo.md"),
+      "utf8"
+    );
+    expect(firstFile).toContain("order: 0");
+    expect(secondFile).toContain("order: 1");
+
+    const { tasks } = readProject(projectDir);
+    expect(tasks.get("task-memo-order").memos.map((memo) => memo.id)).toEqual(["z-memo", "a-memo"]);
+  });
+
   it("writeTask + readProject round-trips a regular task", () => {
     const { projectDir } = createProject(tmpDir, "Proj", "root-id");
     const taskDirs = new Map([["root-id", "_project"]]);


### PR DESCRIPTION
## Summary
- Fix workspace project task detail windows, memo ordering persistence, memo link completion, and minimized detail placeholder behavior.
- Tighten task tree selection, bulk toolbar visibility, dark-mode row colors, markdown borders, and tree column resizer alignment.
- Add TaskDetail header action to open the selected task in a detail window.

## Root Cause
Several tree/table and workspace paths used slightly different state sources or geometry baselines: workspace detail windows missed workspace context, memo ordering was not serialized, and tree column resizers ignored the leading checkbox column.

## Validation
- npm run lint
- npm run format:check
- npm test
- svelte-check --tsconfig ./tsconfig.json
- vite build