### PR TITLE
feat(tasks): show stable line numbers in task tree

### DIFF
--- a/src/features/tasks/components/TreeTable.svelte
+++ b/src/features/tasks/components/TreeTable.svelte
@@ -18,6 +18,7 @@
   import {
     flattenVisibleTree,
     buildInheritedDueDateMap,
+    buildLineNumberMap,
     buildNodePathMap,
     updateNodeDataById,
     isChild,
@@ -75,6 +76,7 @@
   $: rows = $filtered_data ? flattenVisibleTree($filtered_data, $closed_node_ids) : [];
   $: inheritedDueDateMap = buildInheritedDueDateMap(rows);
   $: nodePathMap = buildNodePathMap(rows);
+  $: lineNumberMap = buildLineNumberMap($filtered_data);
   $: isDark = $theme == "dark";
   $: hasNoTasks = !$tree_data?.data?.children?.length;
   let scrollTop = 0;
@@ -1038,6 +1040,7 @@
         bulkCanOutdent={canBulkOutdent}
         inheritedDueDate={inheritedDueDateMap.get(row.id) ?? ""}
         nodePath={nodePathMap.get(row.id) ?? ""}
+        lineNumber={lineNumberMap.get(row.id) ?? 0}
         on:select={handleSelectRow}
         on:toggleCheckbox={handleToggleCheckbox}
         on:toggle={handleToggleRow}

--- a/src/features/tasks/components/TreeTableRow.svelte
+++ b/src/features/tasks/components/TreeTableRow.svelte
@@ -29,6 +29,7 @@
   export let canOpenTaskFolder = false;
   export let inheritedDueDate = "";
   export let nodePath = "";
+  export let lineNumber = 0;
   // Capabilities for bulk operations (used when this row is part of multi-selection).
   export let bulkCanMove = false;
   export let bulkCanTreeOp = false;
@@ -229,6 +230,7 @@
   <div
     class="CheckboxCell"
     class:Visible={selected || anyMultiSelected}
+    class:HasCheckbox={depth > 0}
     role="gridcell"
     tabindex="-1"
     draggable="false"
@@ -236,6 +238,9 @@
     on:keydown|stopPropagation
     on:dragstart|preventDefault|stopPropagation
   >
+    {#if lineNumber > 0}
+      <span class="RowNumber" aria-hidden="true" data-page-search-skip>{lineNumber}</span>
+    {/if}
     {#if depth > 0}
       <input
         type="checkbox"
@@ -520,20 +525,34 @@
     align-items: center;
     justify-content: center;
     height: 100%;
-    visibility: hidden;
     background-color: var(--backgroundColor);
     border-right: 1px solid var(--theme-color-Main-dark);
   }
-  .TableRow:hover .CheckboxCell,
-  .CheckboxCell.Visible {
-    visibility: visible;
+  .RowNumber {
+    font-size: 0.7rem;
+    line-height: 1;
+    color: var(--theme-color-Sub-dark);
+    opacity: 0.55;
+    user-select: none;
+    pointer-events: none;
+    font-variant-numeric: tabular-nums;
   }
   .RowCheckbox {
+    display: none;
     width: 0.95rem;
     height: 0.95rem;
     margin: 0;
     cursor: pointer;
     accent-color: var(--theme-color-Primary-dark);
+  }
+  /* チェックボックスを持つ行で hover / 選択中のとき、番号を隠してチェックボックスを出す */
+  .TableRow:hover .CheckboxCell.HasCheckbox .RowNumber,
+  .CheckboxCell.HasCheckbox.Visible .RowNumber {
+    display: none;
+  }
+  .TableRow:hover .CheckboxCell.HasCheckbox .RowCheckbox,
+  .CheckboxCell.HasCheckbox.Visible .RowCheckbox {
+    display: inline-block;
   }
   .TableData {
     display: flex;

--- a/src/features/tasks/utils/tree_control.ts
+++ b/src/features/tasks/utils/tree_control.ts
@@ -373,6 +373,24 @@ export function buildNodePathMap(rows: VisibleTreeRow[]): Map<string, string> {
   return result;
 }
 
+// ツリー全体を DFS して各ノードに 1 始まりの通し番号を割り当てる。
+// flattenVisibleTree と違い折り畳み状態を無視するので、ノードを開閉しても番号は動かない。
+export function buildLineNumberMap(tree: TreeData | null | undefined): Map<string, number> {
+  const result = new Map<string, number>();
+  if (!tree) return result;
+
+  let counter = 0;
+  const visit = (node: TreeData) => {
+    counter += 1;
+    result.set(node.id, counter);
+    for (const child of node.children ?? []) {
+      visit(child);
+    }
+  };
+  visit(tree);
+  return result;
+}
+
 export function buildInheritedDueDateMap(rows: VisibleTreeRow[]): Map<string, string> {
   const rowMap = new Map(rows.map((r) => [r.id, r]));
   const result = new Map<string, string>();


### PR DESCRIPTION
## Summary
- Render a 1-based sequential number in each task-tree row, taken from a full DFS of the (filtered) tree so the numbers stay stable when nodes are collapsed or expanded.
- Show the number inside the existing checkbox column; on hover or when a multi-selection is active the number is swapped out for the row checkbox, so the column width does not change.
- Skip the numbers in page-search highlighting via `data-page-search-skip` so searching for a digit does not light up every row.

## Test plan
- [ ] `npm run check` passes
- [ ] `npm run lint` passes
- [ ] `npm run test:unit` passes (266 tests)
- [ ] Visual: open the app, confirm each row shows a number starting at 1 from the project root
- [ ] Collapse / expand a parent — numbers on other rows do not shift
- [ ] Hover a non-root row — number is replaced by the checkbox; leaving hover restores the number
- [ ] Multi-select a row — all non-root rows show their checkbox instead of the number
- [ ] Apply a filter — numbering re-runs against the filtered tree
- [ ] Use the header search box with a digit query — row numbers are not highlighted

🤖 Generated with [Claude Code](https://claude.com/claude-code)