### PR TITLE
feat(ui): animate Loading text with shared component

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -12,7 +12,7 @@
 ```
 src/
 ├── lib/                         # 再利用可能な汎用層（ドメイン非依存）
-│   ├── primitives/              # アトミックUI（12 ファイル）
+│   ├── primitives/              # アトミックUI（13 ファイル）
 │   │   ├── Button.svelte
 │   │   ├── IconButton.svelte
 │   │   ├── Card.svelte
@@ -24,7 +24,8 @@ src/
 │   │   ├── Select.svelte
 │   │   ├── MultiSelect.svelte
 │   │   ├── SearchBox.svelte
-│   │   └── DateInput.svelte
+│   │   ├── DateInput.svelte
+│   │   └── Loading.svelte       # 共通ローディング表示（opacity 呼吸アニメ）
 │   ├── layouts/                 # レイアウトプリミティブ
 │   │   ├── Pane.svelte
 │   │   └── SplitPanes.svelte

--- a/src/App.svelte
+++ b/src/App.svelte
@@ -27,6 +27,7 @@
   import { showQuickCapture } from "@stores/ui";
   import Modal from "@lib/primitives/Modal.svelte";
   import Button from "@lib/primitives/Button.svelte";
+  import Loading from "@lib/primitives/Loading.svelte";
   import PageSearchBox from "@features/search/components/PageSearchBox.svelte";
   import TaskDetailWindow from "@pages/TaskDetailPage.svelte";
   import { sidebarCollapsed } from "@stores";
@@ -331,9 +332,7 @@
           </h1>
         {/if}
         {#if ($selected_type == "Projects" || $selected_type == "WorkspaceProject") && $projectLoading}
-          <h1 style="color:var(--theme-color-Sub-main); display:flex; justify-content:center">
-            Loading...
-          </h1>
+          <Loading variant="h1" />
         {:else if $selected_type == "Projects" || $selected_type == "WorkspaceProject"}
           <ProjectPage />
         {:else if $selected_type == "Inbox"}

--- a/src/features/workspace/components/MigrationWizard.svelte
+++ b/src/features/workspace/components/MigrationWizard.svelte
@@ -1,5 +1,6 @@
 ﻿<script lang="ts">
   import Modal from "@lib/primitives/Modal.svelte";
+  import Loading from "@lib/primitives/Loading.svelte";
   import { workspace_store } from "@features/workspace/stores/workspace";
   import * as platform from "@lib/ipc/platform";
 
@@ -82,7 +83,7 @@
 
     <div class="body">
       {#if phase === "loading"}
-        <p class="note">Loading...</p>
+        <Loading variant="note" />
       {:else if phase === "idle"}
         {#if loadError}
           <p class="empty-note">{loadError}</p>
@@ -145,7 +146,7 @@
 
         <p class="warn-note">This exports to Workspace only. The source db.json is not changed.</p>
         {#if phase === "running"}
-          <p class="note">Exporting...</p>
+          <Loading variant="note" text="Exporting..." />
         {/if}
       {:else if phase === "done" && result}
         {#if result.migrated.length > 0}
@@ -245,7 +246,6 @@
   }
 
   .task-count,
-  .note,
   .warn-note,
   .empty-note {
     color: var(--theme-color-Sub-dark);

--- a/src/lib/primitives/Loading.svelte
+++ b/src/lib/primitives/Loading.svelte
@@ -1,0 +1,42 @@
+<script lang="ts">
+  export let variant: "h1" | "h2" | "note" = "h1";
+  export let text: string = "Loading...";
+</script>
+
+{#if variant === "h1"}
+  <h1 class="loading loading-h1">{text}</h1>
+{:else if variant === "h2"}
+  <h2 class="loading loading-h2">{text}</h2>
+{:else}
+  <p class="loading loading-note">{text}</p>
+{/if}
+
+<style>
+  .loading {
+    animation: loading-pulse 1.4s ease-in-out infinite;
+  }
+  .loading-h1,
+  .loading-h2 {
+    color: var(--theme-color-Sub-main);
+    display: flex;
+    justify-content: center;
+  }
+  .loading-note {
+    color: var(--theme-color-Sub-dark);
+    font-size: var(--font-body-sm);
+  }
+  @keyframes loading-pulse {
+    0%,
+    100% {
+      opacity: 1;
+    }
+    50% {
+      opacity: 0.35;
+    }
+  }
+  @media (prefers-reduced-motion: reduce) {
+    .loading {
+      animation: none;
+    }
+  }
+</style>

--- a/src/pages/MainPage.svelte
+++ b/src/pages/MainPage.svelte
@@ -9,6 +9,7 @@
   import Dialog from "@lib/primitives/Dialog.svelte";
   import Modal from "@lib/primitives/Modal.svelte";
   import SearchBox from "@lib/primitives/SearchBox.svelte";
+  import Loading from "@lib/primitives/Loading.svelte";
   import ActiveFilterBar from "@features/search/components/ActiveFilterBar.svelte";
   import { tick } from "svelte";
   import {
@@ -868,9 +869,7 @@
     </div>
   </Modal>
 {:else}
-  <h1 style="color:var(--theme-color-Sub-main); display:flex; justify-content:center">
-    Loading...
-  </h1>
+  <Loading variant="h1" />
 {/if}
 
 <style>

--- a/src/pages/TaskDetailPage.svelte
+++ b/src/pages/TaskDetailPage.svelte
@@ -2,6 +2,7 @@
   import { getNode } from "@features/tasks/utils/tree_control";
   import { selected_id, tree_data } from "@stores";
   import Button from "@lib/primitives/Button.svelte";
+  import Loading from "@lib/primitives/Loading.svelte";
   import TaskDetail from "@features/tasks/components/TaskDetail.svelte";
 
   export let initialTaskName = "Task Detail";
@@ -44,7 +45,7 @@
   <div class="detail-body">
     {#if !ready}
       <div class="empty-state">
-        <h2>Loading...</h2>
+        <Loading variant="h2" />
       </div>
     {:else if isProjectDeleted}
       <div class="empty-state">


### PR DESCRIPTION
## Summary
- Add `src/lib/primitives/Loading.svelte` — a shared primitive that renders animated loading text in three variants (`h1` / `h2` / `note`) with a CSS `@keyframes` opacity pulse (1.4s ease-in-out). Honors `prefers-reduced-motion: reduce`.
- Replace the four scattered `Loading...` markups in `App.svelte`, `MainPage.svelte`, `TaskDetailPage.svelte`, and `MigrationWizard.svelte` with the new component so the animation is consistent everywhere.
- Also swap the `Exporting...` note in `MigrationWizard` to the same component (`<Loading variant="note" text="Exporting..." />`) so all in-progress text shares the same breathing animation.
- Drop the now-unused `.note` CSS selector in `MigrationWizard` and update `docs/architecture.md` (primitives count 12 → 13, list entry added).

## Test plan
- [x] `npx vitest run tests/component/AppWorkspaceProject.test.js` — passes (existing `getByText("Loading...")` still resolves the literal text node).
- [x] Full suite via pre-push hook — 33 files / 383 passed.
- [ ] Manual: open a project to trigger the main loading state and confirm the text pulses smoothly.
- [ ] Manual: open the db.json migration wizard and confirm `Loading...` / `Exporting...` animate identically.
- [ ] Manual: enable OS "reduce motion" and confirm the pulse stops.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
