### PR TITLE
feat(search): AND search by space, phrase by quotes, per-token chips

### DIFF
--- a/src/features/search/components/ActiveFilterBar.svelte
+++ b/src/features/search/components/ActiveFilterBar.svelte
@@ -1,14 +1,21 @@
 <script lang="ts">
   import { filter } from "@features/search/stores/search";
   import { active_tag } from "@features/memos/stores/tags";
+  import { tokenizeFullTextQuery } from "@features/tasks/utils/tree_control";
 
-  $: fullText = (
+  $: rawFullText = (
     ($filter as Record<string, string[] | null | undefined>)?.full_text?.[0] ?? ""
   ).trim();
+  $: fullTextTokens = rawFullText ? tokenizeFullTextQuery(rawFullText) : [];
   $: searchMemoOn =
     ((($filter as Record<string, string[] | null | undefined>)?.search_memo ?? []).length ?? 0) > 0;
   $: activeTag = $active_tag ?? "";
-  $: hasFilters = Boolean(fullText) || Boolean(activeTag);
+  $: hasFilters = fullTextTokens.length > 0 || Boolean(activeTag);
+  $: showClearAll = fullTextTokens.length + (activeTag ? 1 : 0) > 1;
+
+  function serializeTokens(tokens: string[]): string {
+    return tokens.map((t) => (/\s/.test(t) ? `"${t}"` : t)).join(" ");
+  }
 
   function clearFullText() {
     filter.update((f) => {
@@ -18,6 +25,22 @@
     });
   }
 
+  function removeToken(index: number) {
+    const remaining = fullTextTokens.filter((_, i) => i !== index);
+    if (remaining.length === 0) {
+      clearFullText();
+      return;
+    }
+    const serialized = serializeTokens(remaining);
+    filter.update(
+      (f) =>
+        ({
+          ...(f as Record<string, unknown>),
+          full_text: [serialized],
+        }) as typeof f
+    );
+  }
+
   function clearTag() {
     // active_tag drives filter.tags via the subscriber in src/stores/index.ts
     active_tag.set(null);
@@ -25,7 +48,7 @@
 
   function clearAll() {
     if (activeTag) active_tag.set(null);
-    if (fullText) clearFullText();
+    if (fullTextTokens.length > 0) clearFullText();
   }
 </script>
 
@@ -41,16 +64,16 @@
       <span class="LabelText">絞り込み中</span>
     </span>
 
-    {#if fullText}
+    {#each fullTextTokens as token, i (i + ":" + token)}
       <span class="Chip" title={searchMemoOn ? "全文検索（メモ本文を含む）" : "全文検索"}>
         <span class="ChipKind">{searchMemoOn ? "検索(メモ含む)" : "検索"}</span>
-        <span class="ChipValue">{fullText}</span>
+        <span class="ChipValue">{token}</span>
         <button
           type="button"
           class="ChipClear"
-          aria-label="全文フィルタをクリア"
-          title="全文フィルタをクリア"
-          on:click={clearFullText}
+          aria-label={`全文フィルタ「${token}」を削除`}
+          title={`「${token}」を削除`}
+          on:click={() => removeToken(i)}
         >
           <svg viewBox="0 0 24 24" aria-hidden="true">
             <path
@@ -63,7 +86,7 @@
           </svg>
         </button>
       </span>
-    {/if}
+    {/each}
 
     {#if activeTag}
       <span class="Chip" title="タグフィルタ">
@@ -89,7 +112,7 @@
       </span>
     {/if}
 
-    {#if Boolean(fullText) && Boolean(activeTag)}
+    {#if showClearAll}
       <button type="button" class="ClearAll" on:click={clearAll}>すべてクリア</button>
     {/if}
   </div>

--- a/src/features/tasks/utils/tree_control.ts
+++ b/src/features/tasks/utils/tree_control.ts
@@ -62,6 +62,17 @@ function valueForFullText(value: unknown): string {
   return JSON.stringify(value);
 }
 
+export function tokenizeFullTextQuery(input: string): string[] {
+  const tokens: string[] = [];
+  const regex = /"([^"]*)"|(\S+)/g;
+  let m: RegExpExecArray | null;
+  while ((m = regex.exec(input)) !== null) {
+    const token = m[1] !== undefined ? m[1] : m[2];
+    if (token) tokens.push(token);
+  }
+  return tokens;
+}
+
 function fullTextMatches(data: TreeNodeData, keywords: string[], includeMemo: boolean): boolean {
   const fieldText = Object.entries(data)
     .filter(([key]) => key !== "memo")
@@ -77,7 +88,9 @@ function fullTextMatches(data: TreeNodeData, keywords: string[], includeMemo: bo
         .join(" ")
     : "";
   const text = `${fieldText} ${memoText}`.toLowerCase();
-  return keywords.some((keyword) => text.includes(keyword.toLowerCase()));
+  const tokens = keywords.flatMap((keyword) => tokenizeFullTextQuery(keyword));
+  if (tokens.length === 0) return true;
+  return tokens.every((token) => text.includes(token.toLowerCase()));
 }
 
 export function filterTree(

--- a/tests/unit/tree_control.test.js
+++ b/tests/unit/tree_control.test.js
@@ -112,6 +112,42 @@ describe("tree_control", () => {
     expect(filtered.children[0].id).toBe("task-1");
   });
 
+  test("filterTree treats space-separated full-text query as AND search", () => {
+    const tree = createTree();
+
+    // "ship release" matches task-2 ("Ship release") — both tokens present
+    const both = filterTree(tree, { full_text: ["ship release"] });
+    expect(both.children).toHaveLength(1);
+    expect(both.children[0].id).toBe("task-2");
+
+    // Order does not matter for AND
+    const reversed = filterTree(tree, { full_text: ["release ship"] });
+    expect(reversed.children).toHaveLength(1);
+    expect(reversed.children[0].id).toBe("task-2");
+
+    // No single task contains both "ship" and "tests"
+    expect(filterTree(tree, { full_text: ["ship tests"] })).toBeNull();
+  });
+
+  test("filterTree treats double-quoted substrings as a single phrase", () => {
+    const tree = createTree();
+
+    // Quoted phrase requires the contiguous "ship release" substring
+    const quoted = filterTree(tree, { full_text: ['"ship release"'] });
+    expect(quoted.children).toHaveLength(1);
+    expect(quoted.children[0].id).toBe("task-2");
+
+    // Quoted phrase in the wrong order does NOT match (because the space matters)
+    expect(filterTree(tree, { full_text: ['"release ship"'] })).toBeNull();
+
+    // Mixed: phrase + standalone token must both match within the same node
+    // task-2 has name "Ship release" AND status "Pending"
+    expect(filterTree(tree, { full_text: ['"ship release" pending'] }).children[0].id).toBe(
+      "task-2"
+    );
+    expect(filterTree(tree, { full_text: ['"ship release" missing'] })).toBeNull();
+  });
+
   test("filterTree can include memo content in full-text search", () => {
     const tree = createTree();
     tree.children[0].data.memo = [{ id: "m1", title: "Note", content: "launch notes", tags: [] }];


### PR DESCRIPTION
## Summary
- 全文検索クエリをトークン化: スペース区切りは AND、`"..."` 内はスペース込みのフレーズとして扱う
- ActiveFilterBar をトークンごとの個別チップ表示に変更（各チップに削除 × ボタン）
- 「すべてクリア」はアクティブなチップが 2 件以上ある時に表示するよう拡張

## Details
- `tokenizeFullTextQuery` を `tree_control.ts` に追加・export。`/"([^"]*)"|(\S+)/g` で `"foo bar" baz` → `["foo bar", "baz"]` に分解
- `fullTextMatches` を `keywords.some` → 解析後トークンの `every` に変更（全トークンが同一ノードのテキストに含まれる必要あり）
- ActiveFilterBar は `full_text[0]` の生テキストを再度トークン化し、`{#each}` で 1 トークン 1 チップ描画。削除時はスペース含みトークンを `"..."` で再シリアライズして filter に戻す

## Examples
| 入力 | 挙動 |
|---|---|
| `ship release` | "ship" AND "release"（順不同） |
| `"ship release"` | 連続文字列 `ship release` を要求 |
| `foo "bar baz" qux` | 3 つすべてが含まれる必要あり |

## Test plan
- [x] `tests/unit/tree_control.test.js` に AND 検索 / 引用符フレーズの新規テスト追加（53/53 passing）
- [x] `svelte-check`: 0 errors
- [x] pre-push hook: lint + format + 全 385 テスト通過
- [ ] 手動: 検索ボックスに `foo bar` と入力 → チップが 2 つ表示・両単語含むタスクのみヒット
- [ ] 手動: `"foo bar"` と入力 → 1 チップ「foo bar」表示・連続文字列で一致
- [ ] 手動: 個別 × でトークン削除、残りはバーに残ること

🤖 Generated with [Claude Code](https://claude.com/claude-code)
