### PR TITLE
[codex] Fix tree grid column alignment

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -309,10 +309,14 @@ import LocalComponent from "./LocalComponent.svelte";
 ### 8.4 ツリー列幅の維持
 
 - ユーザーがドラッグした列幅は inline `style.width` で保持
-- ペインリサイズ時の `ResizeObserver` では、最終列だけ
-  `max(lastMinWidth, tableWidth − fixedTotal)` で再計算する
+- ペインリサイズ時の `ResizeObserver` では、`name` 列だけ
+  `max(nameMinWidth, tableWidth − checkboxColumnWidth − fixedTotal)` で再計算する
 - 折りたたみ・展開時の `MutationObserver` 経由 createResizers は `getBoundingClientRect` ではなく
   `header.style.width` を読む。サブピクセル誤差の累積を避ける目的
+- チェックボックス列はヘッダ・データ行ともに `border-box` の固定外寸として扱う。
+  JS 側の列幅計算はヘッダの `.CheckboxHeaderCell` 幅を基準にするため、行側も同じ外寸に揃える
+- リサイザ位置は `positionResizers()` で一元計算する。初期配置、ドラッグ中、行再同期、
+  ペインリサイズ後の再配置を同じ「チェックボックス列幅 + 各データ列幅」の座標系に揃える
 
 ### 8.5 ステータス選択（`StatusSelect.svelte`）
 

--- a/src/features/tasks/components/TreeTable.svelte
+++ b/src/features/tasks/components/TreeTable.svelte
@@ -280,6 +280,17 @@
     });
   };
 
+  const getLeadingColumnWidth = () =>
+    table_root?.querySelector(".CheckboxHeaderCell")?.getBoundingClientRect().width ?? 0;
+
+  const positionResizers = (targetResizers, widths) => {
+    let left = getLeadingColumnWidth();
+    targetResizers.forEach((resizer, index) => {
+      left += widths[index] ?? 0;
+      resizer.style.left = `${left - 3}px`;
+    });
+  };
+
   const createResizers = (
     currentHeaders,
     existingResizers = [],
@@ -295,9 +306,6 @@
         data_rows.push(data_row.querySelectorAll(".TableData"));
       }
     });
-
-    const getLeadingColumnWidth = () =>
-      tableRows[0]?.querySelector(".CheckboxHeaderCell")?.getBoundingClientRect().width ?? 0;
 
     // Set width
     if (is_default) {
@@ -321,19 +329,14 @@
       });
 
       // Create resizer elements
-      let left = leadingColumnWidth;
-      domHeaders.forEach((header, index) => {
-        if (index === 0) {
-          left += default_data_widths[index];
-          return;
-        }
+      domHeaders.forEach((_header, index) => {
+        if (index === domHeaders.length - 1) return;
         const resizer = document.createElement("div");
         resizer.classList.add("Resizer");
-        resizer.style.left = `${left - 3}px`;
         table_root.insertBefore(resizer, tableRows[0]);
         existingResizers.push(resizer);
-        left += default_data_widths[index];
       });
+      positionResizers(existingResizers, default_data_widths);
     } else {
       domHeaders.forEach((header, index) => {
         // Read the inline style — not getBoundingClientRect, which rounds
@@ -345,6 +348,10 @@
           data_row[index].style.width = w;
         });
       });
+      positionResizers(
+        existingResizers,
+        domHeaders.map((header) => header.getBoundingClientRect().width)
+      );
     }
     syncResizerBounds(existingResizers);
 
@@ -380,13 +387,8 @@
         if (cell) cell.style.width = `${nameWidth}px`;
       });
       // Every resizer sits between two columns; since column 0 changed,
-      // ALL resizer left positions shift by the delta. Re-place them
-      // using the new Name width followed by each fixed downstream width.
-      let left = leadingColumnWidth + nameWidth;
-      existingResizers.forEach((resizer, idx) => {
-        resizer.style.left = `${left - 3}px`;
-        left += widths[idx + 1] ?? 0;
-      });
+      // ALL resizer left positions shift by the delta.
+      positionResizers(existingResizers, [nameWidth, ...widths.slice(1)]);
     }
 
     const newResizeObserver = new ResizeObserver(() => {
@@ -409,13 +411,7 @@
         });
       });
 
-      const leadingColumnWidth =
-        table_root?.querySelector(".CheckboxHeaderCell")?.getBoundingClientRect().width ?? 0;
-      let left = leadingColumnWidth;
-      resizers.forEach((columnResizer, index) => {
-        left += widths[index];
-        columnResizer.style.left = `${left - 3}px`;
-      });
+      positionResizers(resizers, widths);
     };
 
     // Create resizers and their events

--- a/src/features/tasks/components/TreeTableRow.svelte
+++ b/src/features/tasks/components/TreeTableRow.svelte
@@ -531,6 +531,7 @@
     align-items: center;
     justify-content: center;
     height: 100%;
+    box-sizing: border-box;
     background-color: var(--backgroundColor);
     border-right: 1px solid var(--theme-color-Main-dark);
   }

--- a/tests/component/TreeTableRow.test.js
+++ b/tests/component/TreeTableRow.test.js
@@ -1,4 +1,6 @@
 import { render, screen } from "@testing-library/svelte";
+import fs from "node:fs";
+import path from "node:path";
 import { describe, expect, test } from "vitest";
 
 import TreeTableRow from "@features/tasks/components/TreeTableRow.svelte";
@@ -65,5 +67,15 @@ describe("TreeTableRow", () => {
     render(TreeTableRow, { props });
 
     expect(screen.getByText("0")).toBeInTheDocument();
+  });
+
+  test("uses border-box sizing for the selection checkbox column", () => {
+    const source = fs.readFileSync(
+      path.join(process.cwd(), "src/features/tasks/components/TreeTableRow.svelte"),
+      "utf8"
+    );
+    const checkboxCellRule = source.match(/\.CheckboxCell\s*\{[^}]+}/)?.[0] ?? "";
+
+    expect(checkboxCellRule).toContain("box-sizing: border-box;");
   });
 });


### PR DESCRIPTION
## Summary
- Align tree grid checkbox column sizing between the header and data rows.
- Centralize tree grid resizer placement so initial layout, drag updates, row resyncs, and pane resizes use the same column boundary math.
- Update architecture docs for the current tree column width behavior.

## Root Cause
The data row checkbox column did not use the same border-box sizing as the header checkbox column, so the first data boundary could drift by 1px. Resizer positions were also recalculated in several places with duplicated math, making the column boundary source of truth easier to desynchronize.

## Validation
- `vitest run tests\component\TreeTable.test.js tests\component\TreeTableRow.test.js --pool=threads`
- `svelte-check --tsconfig ./tsconfig.json`
- `eslint src\features\tasks\components\TreeTable.svelte src\features\tasks\components\TreeTableRow.svelte tests\component\TreeTableRow.test.js tests\component\TreeTable.test.js`
- Push hook: `npm run lint`, `npm run format:check`, `npm run test`