### PR TITLE
feat(startup): auto-select top project (Workspace > InApp) and its root

### DIFF
--- a/src/App.svelte
+++ b/src/App.svelte
@@ -6,6 +6,7 @@
     tree_data,
     setTaskDetailWindowTarget,
     init_store,
+    autoSelectInitialProject,
     showPageSearch,
     theme,
     undoHistory,
@@ -214,6 +215,9 @@
       await initTaskDetailWindow();
     } else {
       detailWindowReady = true;
+      // 起動時の自動選択: Workspace を優先、なければ InApp の先頭プロジェクト。
+      // 既に何か選択されている (例: タスク詳細ウィンドウ) 場合は no-op。
+      autoSelectInitialProject();
     }
 
     // テーマ初期化

--- a/src/features/projects/stores/project.ts
+++ b/src/features/projects/stores/project.ts
@@ -13,7 +13,7 @@ import {
 } from "@stores/ui";
 
 export interface ProjectIdsStore extends Writable<ProjectListItem[] | undefined> {
-  init: () => void;
+  init: () => Promise<void>;
   addProject: () => void;
   deleteProject: (projectId: string) => void;
   setProjectOrder: (projects: ProjectListItem[]) => void;
@@ -53,9 +53,11 @@ function createProjectIds(initialValue: ProjectListItem[] | undefined): ProjectI
         });
       }
 
+      let initialLoad: Promise<void> = Promise.resolve();
+
       subscribe((current) => {
         if (current === undefined) {
-          platform.getProjectIDs().then((result) => {
+          initialLoad = platform.getProjectIDs().then((result) => {
             set(result);
           });
         }
@@ -66,6 +68,8 @@ function createProjectIds(initialValue: ProjectListItem[] | undefined): ProjectI
           closed_node_ids.update(() => new Set());
         }
       });
+
+      return initialLoad;
     },
     addProject: () => {
       const newProject = getDefaultProject();

--- a/src/features/tasks/stores/tree.ts
+++ b/src/features/tasks/stores/tree.ts
@@ -431,14 +431,11 @@ function createTreeData(initialValue: ProjectData | undefined): TreeDataStore {
             if (pendingTaskDetailSelection.taskId) {
               table_selected_id.set(pendingTaskDetailSelection.taskId);
             }
-          } else {
-            platform.getInitialTreeData().then((result) => {
-              selected_type.set("Projects");
-              if (result !== undefined) {
-                selected_id.set(result.data.id);
-              }
-            });
           }
+          // 起動時のデフォルト選択は autoSelectInitialProject() で行う。
+          // 以前ここで getInitialTreeData() 経由で "Projects" 型を
+          // 不条件に設定していたが、Workspace 優先のロジックと競合して
+          // InApp が選ばれてしまっていたため削除。
         }
 
         syncWorkspaceProjectSummaryFromTree(

--- a/src/features/workspace/stores/workspace.ts
+++ b/src/features/workspace/stores/workspace.ts
@@ -13,7 +13,7 @@ export interface WorkspaceState {
 }
 
 export interface WorkspaceStore extends Writable<WorkspaceState> {
-  init: () => void;
+  init: () => Promise<void>;
   selectDirectory: () => Promise<platform.WsSelectDirectoryResult>;
   addWorkspace: (path: string, label: string) => void;
   removeWorkspace: (path: string) => void;
@@ -76,7 +76,7 @@ function createWorkspaceStore(): WorkspaceStore {
     update,
 
     init() {
-      (async () => {
+      return (async () => {
         const { workspaces, activeWorkspace } = await platform.wsGetWorkspaces();
         const projects = activeWorkspace ? await loadProjects(activeWorkspace) : [];
         const current = get({ subscribe } as WorkspaceStore);

--- a/src/stores/index.ts
+++ b/src/stores/index.ts
@@ -19,9 +19,10 @@ export * from "@features/projects/stores/project";
 export * from "@features/search/stores/search";
 export * from "@features/inbox/stores/inbox";
 
+import { get } from "svelte/store";
 import { tree_data } from "@features/tasks/stores/tree";
 import { project_ids } from "@features/projects/stores/project";
-import { selected_id, closed_node_ids } from "./ui";
+import { selected_id, selected_type, closed_node_ids } from "./ui";
 import { filter } from "@features/search/stores/search";
 import { theme } from "./theme";
 import { column_settings } from "@features/tasks/stores/column_settings";
@@ -31,16 +32,20 @@ import { active_tag } from "@features/memos/stores/tags";
 import { sort_state } from "@features/tasks/stores/sort";
 import { inbox_store } from "@features/inbox/stores/inbox";
 
-export function init_store() {
+let initStoreReady: Promise<void> | null = null;
+
+export function init_store(): Promise<void> {
+  if (initStoreReady) return initStoreReady;
+
   tree_data.init();
-  project_ids.init();
+  const projectIdsReady = project_ids.init();
   selected_id.init();
   sort_state.init();
   filter.init();
   theme.init();
   closed_node_ids.init();
   column_settings.init();
-  workspace_store.init();
+  const workspaceReady = workspace_store.init();
   workspace_conflict_policy.init();
   inbox_store.init();
 
@@ -55,4 +60,33 @@ export function init_store() {
       return next;
     });
   });
+
+  initStoreReady = Promise.all([projectIdsReady, workspaceReady]).then(() => undefined);
+  return initStoreReady;
+}
+
+/**
+ * After init_store() resolves, pick the top-most project to land on:
+ * Workspace projects take precedence over InApp (db.json) projects.
+ * No-op when a project is already selected (e.g. task-detail window).
+ */
+export async function autoSelectInitialProject(): Promise<void> {
+  await init_store();
+
+  if (get(selected_type) !== undefined) return;
+
+  const workspaceProjects = get(workspace_store).projects ?? [];
+  if (workspaceProjects.length > 0) {
+    const first = workspaceProjects[0];
+    workspace_store.setActiveProject(first.projectDir);
+    selected_type.set("WorkspaceProject");
+    selected_id.set(first.rootId);
+    return;
+  }
+
+  const inAppProjects = get(project_ids) ?? [];
+  if (inAppProjects.length > 0) {
+    selected_type.set("Projects");
+    selected_id.set(inAppProjects[0].id);
+  }
 }

--- a/src/stores/ui.ts
+++ b/src/stores/ui.ts
@@ -129,13 +129,15 @@ function createSelectedID(initialValue: string | undefined): SelectedIdStore {
               pendingTaskDetailSelection.taskId
             ) {
               if (getNode(pendingTaskDetailSelection.taskId, result.data)) {
-                table_selected_id.set(pendingTaskDetailSelection.taskId);
+                selectOnly(pendingTaskDetailSelection.taskId);
               } else {
                 clearPendingTaskDetailSelection();
-                table_selected_id.set(undefined);
+                selectOnly(result.data.id);
               }
             } else {
-              table_selected_id.set(undefined);
+              // プロジェクト選択時は、ツリーのルート (= プロジェクト名)
+              // を自動選択する。
+              selectOnly(result.data.id);
             }
             finishLoad(version);
           },
@@ -178,9 +180,11 @@ function createSelectedID(initialValue: string | undefined): SelectedIdStore {
               pendingTaskDetailSelection.taskId &&
               getNode(pendingTaskDetailSelection.taskId, converted.data)
             ) {
-              table_selected_id.set(pendingTaskDetailSelection.taskId);
+              selectOnly(pendingTaskDetailSelection.taskId);
             } else {
-              table_selected_id.set(undefined);
+              // プロジェクト選択時は、ツリーのルート (= プロジェクト名)
+              // を自動選択する。
+              selectOnly(converted.data.id);
             }
             finishLoad(version);
           },


### PR DESCRIPTION
## Summary
- 起動時に一番上の Project を自動選択する。Workspace Projects を優先し、無ければ InApp (db.json) Projects から先頭を選ぶ。
- Project が選ばれた時点で、タスクツリーのルート (= プロジェクト名) を自動的に行選択状態にする。
- 旧 `getInitialTreeData()` 経由の暗黙のデフォルト選択を削除（Workspace 選択を後追いで `Projects` に上書きしてしまう race condition の原因だった）。

## Details
- `workspace_store.init()` / `project_ids.init()` が初期ロード完了の `Promise<void>` を返すよう変更。
- `init_store()` がそれらを束ねた Promise を返し、`autoSelectInitialProject()` から `await` する。既に選択がある場合（タスク詳細ウィンドウ等）は no-op。
- `loadProjectsData` / `loadWorkspaceData` で、保留中のタスク詳細ターゲットが無いときは `selectOnly(rootId)` でルートノードを選択。

## Test plan
- [x] `npm run check` — 0 errors
- [x] `npm run test` — 396 passed / 7 skipped
- [x] `npm run lint` / `npm run format:check`
- [ ] 起動時に Workspace Projects がある状態で先頭の Workspace Project が選ばれ、ツリーのルート行がハイライトされることを目視確認
- [ ] Workspace Projects が空 / 未設定で InApp Projects がある場合、先頭の InApp Project が選ばれることを目視確認
- [ ] タスク詳細ウィンドウ (`#task-detail-window`) を開いたとき、自動選択ロジックに上書きされず指定タスクが選択されたままになることを目視確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)