### PR TITLE
fix(task-attachments): cap list height so many attachments scroll

### DIFF
--- a/src/features/tasks/components/TaskAttachments.svelte
+++ b/src/features/tasks/components/TaskAttachments.svelte
@@ -385,9 +385,11 @@
     display: grid;
     gap: var(--sp1);
     min-width: 0;
+    max-height: 12rem;
     margin: 0;
     padding: 0;
     list-style: none;
+    overflow-y: auto;
   }
   .attachment-item {
     display: flex;


### PR DESCRIPTION
## Summary
- `.attachment-list` に高さ制約がなく、添付が増えるとタスク詳細レイアウト全体が押し下げられていた。
- `max-height: 12rem` + `overflow-y: auto` でリスト内に閉じてスクロールするように変更（おおむね6件まで表示、それ以上はスクロール）。

## Test plan
- [x] `npm run check`
- [x] `npm run lint`
- [ ] 添付ファイルを7件以上付けてタスク詳細を開き、リスト内でスクロールできること
- [ ] 添付が0件のときと数件のときに従来通りの表示で、レイアウト崩れがないこと

🤖 Generated with [Claude Code](https://claude.com/claude-code)