### PR TITLE
fix(quill): keep cursor stable when workspace save round-trips

### DIFF
--- a/src/features/memos/components/QuillMemo.svelte
+++ b/src/features/memos/components/QuillMemo.svelte
@@ -3,6 +3,7 @@
   import Quill from "quill";
   import "quill/dist/quill.snow.css";
   import { isEqual } from "lodash";
+  import { memoContentForCompare } from "@features/memos/utils/memo_utils";
 
   export let saveMemo;
   export let content = "";
@@ -195,7 +196,8 @@
     const lastSavedIsEmpty = isEmptyContent(lastSavedContent);
     const needsUpdate =
       contentIsEmpty !== lastSavedIsEmpty ||
-      (!contentIsEmpty && !isEqual(content, lastSavedContent));
+      (!contentIsEmpty &&
+        !isEqual(memoContentForCompare(content), memoContentForCompare(lastSavedContent)));
 
     if (needsUpdate) {
       isEditing = true;

--- a/src/features/memos/utils/memo_utils.ts
+++ b/src/features/memos/utils/memo_utils.ts
@@ -506,6 +506,18 @@ export function memoContentForSearch(val: unknown): string {
   return toMarkdown(val).replace(/data:[^)]+/g, "");
 }
 
+// lodash の isEqual は constructor を比較するため、Quill の Delta インスタンスと
+// IPC 越しに受け取ったプレーンな `{ops}` を「異なる」と判定する。
+// Quill エディタの編集中に workspace の保存→反映ラウンドトリップが走るたびに
+// 比較が false 化して `setContents` が呼び直され、カーソルが先頭に飛んでいた。
+// 中身 (ops) が一致しているかだけ知りたい比較は、必ずこのヘルパで正規化してから渡す。
+export function memoContentForCompare(value: unknown): unknown {
+  if (isQuillDelta(value)) {
+    return { ops: value.ops };
+  }
+  return value;
+}
+
 // 将来 elasticlunr 等のインデックス型エンジンに差し替え可能な検索ポイント
 export function searchMemoEntries(memos: Array<{ content: unknown }>, keywords: string[]): boolean {
   return memos.some((entry) =>

--- a/src/features/tasks/stores/tree.ts
+++ b/src/features/tasks/stores/tree.ts
@@ -8,6 +8,7 @@ import {
   workspaceToProjectData,
 } from "@features/workspace/utils/workspace_tree";
 import { filter } from "@features/search/stores/search";
+import { memoContentForCompare } from "@features/memos/utils/memo_utils";
 import { project_ids } from "@features/projects/stores/project";
 import {
   selected_type,
@@ -133,7 +134,7 @@ function comparableWorkspaceTask(task: WorkspaceTask) {
     memos: (task.memos ?? []).map((memo) => ({
       id: memo.id,
       title: memo.title,
-      content: memo.content,
+      content: memoContentForCompare(memo.content),
       tags: memo.tags ?? [],
       format: memo.format ?? "markdown",
       order: memo.order ?? null,


### PR DESCRIPTION
## Summary
Quill メモで入力中、約1〜2秒おきにカーソルが先頭行に飛ぶ事象を修正。

### 原因
- `quill.getContents()` は `Delta` クラスのインスタンスを返すが、Workspace 保存の往復後に IPC を通って戻ってくる同じ内容は **プレーンな `{ops:[...]}`** になる。
- lodash `isEqual` は constructor を比較するため、内容 (ops) が完全一致でも Delta vs plain は `false` 判定。
- 結果として [QuillMemo.svelte:193-208](src/features/memos/components/QuillMemo.svelte) のリアクティブが「内容が変わった」と誤判定し `quill.setContents(...)` を呼び直し、カーソルが0に戻っていた。
- 同じ問題が永続化側 [tree.ts `comparableWorkspaceTask`](src/features/tasks/stores/tree.ts) にも存在。内容未変更でも dirty 扱いになり、無駄な書き込み→workspace event→カーソル飛びの増幅ループになっていた。

### 修正
- `memo_utils.ts` に共有ヘルパ `memoContentForCompare(value)` を追加。Delta インスタンスを `{ops}` プレーンに正規化する（string 等はそのまま）。
- QuillMemo の `isEqual` 比較と `comparableWorkspaceTask` の `memo.content` をどちらも本ヘルパ経由に。
- Markdown メモは内容が常に string で `===` が正しく動くため修正不要だが、将来 Markdown が AST 等になった場合に同じ罠を踏まないよう、共有ヘルパに集約。

### 検証
Delta vs plain の `isEqual` 挙動を node で実測し、4種類 (plain text / 装飾 / リスト / 画像) のラウンドトリップで修正後はすべて `true`、本当に内容が違うケースは `false` を確認。

## Test plan
- [x] `npm run check`（svelte-check 0 errors）
- [x] `npm run lint`
- [x] `npm run test:unit`（290/290 pass）
- [x] `npm run test:component`（126/126 pass）
- [x] `npm run build`
- [ ] Workspace プロジェクトの Quill メモを数分間連続入力してもカーソルが先頭に飛ばないこと
- [ ] 外部ファイル更新 (workspace-reconciler の external-update) のときは従来通り内容が反映されること

🤖 Generated with [Claude Code](https://claude.com/claude-code)