### PR TITLE
[codex] Support shared memo table controls

### DIFF
--- a/electron/workspace.js
+++ b/electron/workspace.js
@@ -138,6 +138,7 @@ function deltaToLines(ops) {
 }
 
 const BLOCK_ATTR_KEYS = new Set([
+  "table",
   "header",
   "list",
   "blockquote",
@@ -154,6 +155,7 @@ function pickBlockAttrs(attrs) {
 }
 
 function getBlockType(attrs) {
+  if (attrs.table) return "table";
   if (attrs["code-block"]) return "code-block";
   if (attrs.list) return "list";
   if (attrs.blockquote) return "blockquote";
@@ -162,7 +164,7 @@ function getBlockType(attrs) {
 }
 
 function shouldGroupAdjacent(type) {
-  return type === "list" || type === "blockquote" || type === "code-block";
+  return type === "list" || type === "blockquote" || type === "code-block" || type === "table";
 }
 
 function groupBlocks(lines) {
@@ -194,6 +196,75 @@ function renderListBlock(block) {
     .join("\n");
 }
 
+function escapeTableCell(value) {
+  return String(value || "")
+    .replace(/\r?\n/g, "<br>")
+    .replace(/\|/g, "\\|");
+}
+
+function tableRowId(attrs) {
+  if (!attrs || attrs.table == null) return null;
+  return String(attrs.table);
+}
+
+function normalizeTableAlign(value) {
+  return value === "left" || value === "center" || value === "right" ? value : undefined;
+}
+
+function tableDividerCell(align) {
+  switch (normalizeTableAlign(align)) {
+    case "left":
+      return ":---";
+    case "center":
+      return ":---:";
+    case "right":
+      return "---:";
+    default:
+      return "---";
+  }
+}
+
+function renderTableRow(cells) {
+  return `| ${cells.join(" | ")} |`;
+}
+
+function renderTableBlock(block) {
+  const rows = [];
+  let currentRowId = null;
+
+  for (const line of block.lines) {
+    const rowId = tableRowId(line.attrs);
+    if (!rowId) continue;
+    if (rowId !== currentRowId) {
+      rows.push([]);
+      currentRowId = rowId;
+    }
+    rows[rows.length - 1].push(line);
+  }
+
+  if (rows.length === 0) return "";
+
+  const columnCount = Math.max(1, ...rows.map((row) => row.length));
+  const normalizedRows = rows.map((row) =>
+    Array.from({ length: columnCount }, (_, index) => row[index] || { inline: "", attrs: {} })
+  );
+  const columnAligns = Array.from({ length: columnCount }, (_, index) => {
+    for (const row of normalizedRows) {
+      const align = normalizeTableAlign(row[index].attrs.align);
+      if (align) return align;
+    }
+    return undefined;
+  });
+
+  const header = renderTableRow(normalizedRows[0].map((cell) => escapeTableCell(cell.inline)));
+  const divider = renderTableRow(columnAligns.map(tableDividerCell));
+  const body = normalizedRows
+    .slice(1)
+    .map((row) => renderTableRow(row.map((cell) => escapeTableCell(cell.inline))));
+
+  return [header, divider, ...body].join("\n");
+}
+
 function renderBlock(block) {
   switch (block.type) {
     case "heading": {
@@ -207,6 +278,8 @@ function renderBlock(block) {
       return block.lines.map(({ inline }) => `> ${inline}`).join("\n");
     case "code-block":
       return "```\n" + block.lines.map((l) => l.inline).join("\n") + "\n```";
+    case "table":
+      return renderTableBlock(block);
     case "paragraph":
     default:
       // 仕様: リスト外の Quill indent は Md に出力しない(諦める)。
@@ -383,6 +456,36 @@ function appendListToken(ops, list, level) {
   }
 }
 
+function appendTableCell(ops, cell) {
+  if (cell && cell.tokens && cell.tokens.length > 0) {
+    appendInlineMdTokens(ops, cell.tokens, {});
+    return;
+  }
+  if (typeof cell?.text === "string") {
+    pushDeltaText(ops, decodeMdEntities(cell.text), {});
+  }
+}
+
+function appendTableToken(ops, token) {
+  const header = Array.isArray(token.header) ? token.header : [];
+  const bodyRows = Array.isArray(token.rows) ? token.rows : [];
+  const rows = [header, ...bodyRows];
+  const columnCount = Math.max(1, ...rows.map((row) => row.length));
+  const align = Array.isArray(token.align) ? token.align : [];
+  const rowIdPrefix = `row-md-${ops.length + 1}`;
+
+  rows.forEach((row, rowIndex) => {
+    const rowId = `${rowIdPrefix}-${rowIndex + 1}`;
+    for (let columnIndex = 0; columnIndex < columnCount; columnIndex += 1) {
+      const cell = row[columnIndex];
+      const cellAlign = normalizeTableAlign(cell?.align ?? align[columnIndex]);
+      const attributes = cellAlign ? { table: rowId, align: cellAlign } : { table: rowId };
+      appendTableCell(ops, cell);
+      ops.push({ insert: "\n", attributes });
+    }
+  });
+}
+
 function appendBlockToken(ops, token) {
   switch (token.type) {
     case "heading":
@@ -414,6 +517,9 @@ function appendBlockToken(ops, token) {
     }
     case "list":
       appendListToken(ops, token, 0);
+      return;
+    case "table":
+      appendTableToken(ops, token);
       return;
     case "html": {
       const raw = token.raw || "";

--- a/src/features/memos/components/MarkdownMemo.svelte
+++ b/src/features/memos/components/MarkdownMemo.svelte
@@ -1,7 +1,7 @@
 ﻿<script lang="ts">
   import { tick, onDestroy } from "svelte";
   import { EditorView, keymap, lineNumbers } from "@codemirror/view";
-  import { EditorState } from "@codemirror/state";
+  import { EditorState, type Text } from "@codemirror/state";
   import {
     autocompletion,
     completionKeymap,
@@ -72,6 +72,8 @@
   let livePreviewEl: HTMLElement | null = null;
   let editBody: HTMLElement | null = null;
   let markdownSplitPercent = 55;
+  let currentHeadingLevel = "normal";
+  let tableActionValue = "";
 
   const SPLIT_MIN_PERCENT = 30;
   const SPLIT_MAX_PERCENT = 72;
@@ -91,15 +93,22 @@
     bold: quillIcons.bold,
     italic: quillIcons.italic,
     inlineCode: quillIcons.code,
-    heading1: quillIcons.header["1"],
-    heading2: quillIcons.header["2"],
-    heading3: quillIcons.header["3"],
     link: quillIcons.link,
     bulletList: quillIcons.list.bullet,
-    checklist: quillIcons.list.check,
     quote: quillIcons.blockquote,
     codeBlock: codeBlockIconSvg,
   };
+  const tableActionOptions = [
+    { value: "insert", label: "表を挿入" },
+    { value: "row-above", label: "行を上に追加" },
+    { value: "row-below", label: "行を下に追加" },
+    { value: "column-left", label: "列を左に追加" },
+    { value: "column-right", label: "列を右に追加" },
+    { value: "delete-row", label: "行を削除" },
+    { value: "delete-column", label: "列を削除" },
+    { value: "delete-table", label: "表を削除" },
+  ] as const;
+  type TableAction = (typeof tableActionOptions)[number]["value"];
   const memoModeOptions = [
     { value: "read", label: "Read", className: "read-mode-btn" },
     { value: "edit", label: "Edit", className: "edit-mode-btn" },
@@ -284,16 +293,28 @@
     wrapInline("`");
   }
 
-  function formatHeading(level: 1 | 2 | 3) {
+  function getHeadingLevelFromState(state: EditorState): string {
+    const { from } = state.selection.main;
+    const line = state.doc.lineAt(from);
+    const headingMatch = line.text.match(/^(#{1,6}) /);
+    const level = headingMatch?.[1]?.length ?? 0;
+    return level >= 1 && level <= 2 ? String(level) : "normal";
+  }
+
+  function syncHeadingLevel(editorView: EditorView | null = view) {
+    currentHeadingLevel = editorView ? getHeadingLevelFromState(editorView.state) : "normal";
+  }
+
+  function formatHeading(level: 0 | 1 | 2) {
     if (!view) return;
     const { from } = view.state.selection.main;
     const line = view.state.doc.lineAt(from);
-    const newPrefix = "#".repeat(level) + " ";
+    const newPrefix = level > 0 ? "#".repeat(level) + " " : "";
     const headingMatch = line.text.match(/^(#{1,6}) /);
-    if (headingMatch && headingMatch[0] === newPrefix) {
+    if (headingMatch && (!newPrefix || headingMatch[0] === newPrefix)) {
       view.dispatch({
-        changes: { from: line.from, to: line.from + newPrefix.length, insert: "" },
-        selection: { anchor: Math.max(line.from, from - newPrefix.length) },
+        changes: { from: line.from, to: line.from + headingMatch[0].length, insert: "" },
+        selection: { anchor: Math.max(line.from, from - headingMatch[0].length) },
       });
     } else if (headingMatch) {
       const oldLen = headingMatch[0].length;
@@ -307,26 +328,14 @@
         selection: { anchor: from + newPrefix.length },
       });
     }
+    syncHeadingLevel();
     view.focus();
   }
 
-  function formatCheckbox() {
-    if (!view) return;
-    const prefix = "- [ ] ";
-    const { from } = view.state.selection.main;
-    const line = view.state.doc.lineAt(from);
-    if (line.text.startsWith(prefix)) {
-      view.dispatch({
-        changes: { from: line.from, to: line.from + prefix.length, insert: "" },
-        selection: { anchor: Math.max(line.from, from - prefix.length) },
-      });
-    } else {
-      view.dispatch({
-        changes: { from: line.from, insert: prefix },
-        selection: { anchor: from + prefix.length },
-      });
-    }
-    view.focus();
+  function handleHeadingChange(event: Event) {
+    const value = (event.currentTarget as HTMLSelectElement).value;
+    const level = value === "normal" ? 0 : Number(value);
+    formatHeading(level === 1 || level === 2 ? level : 0);
   }
 
   function toggleLinePrefix(prefix: string) {
@@ -394,6 +403,521 @@
       });
     }
     view.focus();
+  }
+
+  type TableAlignment = "left" | "center" | "right" | undefined;
+
+  type MarkdownTable = {
+    startLineNumber: number;
+    endLineNumber: number;
+    startPos: number;
+    endPos: number;
+    rows: string[][];
+    aligns: TableAlignment[];
+    columnCount: number;
+    currentSourceLineIndex: number;
+    currentColumnIndex: number;
+  };
+
+  function isEscaped(value: string, index: number): boolean {
+    let backslashCount = 0;
+    for (let i = index - 1; i >= 0 && value[i] === "\\"; i -= 1) {
+      backslashCount += 1;
+    }
+    return backslashCount % 2 === 1;
+  }
+
+  function splitMarkdownTableCells(row: string): string[] {
+    let text = row.trim();
+    if (text.startsWith("|")) {
+      text = text.slice(1);
+    }
+    if (text.endsWith("|") && !isEscaped(text, text.length - 1)) {
+      text = text.slice(0, -1);
+    }
+
+    const cells: string[] = [];
+    let current = "";
+    for (let i = 0; i < text.length; i += 1) {
+      const char = text[i];
+      if (char === "\\" && text[i + 1] === "|") {
+        current += "|";
+        i += 1;
+        continue;
+      }
+      if (char === "|" && !isEscaped(text, i)) {
+        cells.push(current.trim());
+        current = "";
+        continue;
+      }
+      current += char;
+    }
+    cells.push(current.trim());
+    return cells;
+  }
+
+  function isPotentialTableLine(line: string): boolean {
+    return /^\s*\|/.test(line) && splitMarkdownTableCells(line).length >= 1;
+  }
+
+  function normalizeDividerCell(cell: string): TableAlignment | null {
+    const value = cell.trim();
+    if (!/^:?-{3,}:?$/.test(value)) return null;
+    const left = value.startsWith(":");
+    const right = value.endsWith(":");
+    if (left && right) return "center";
+    if (left) return "left";
+    if (right) return "right";
+    return undefined;
+  }
+
+  function isDividerRow(line: string): boolean {
+    const cells = splitMarkdownTableCells(line);
+    return cells.length >= 1 && cells.every((cell) => normalizeDividerCell(cell) !== null);
+  }
+
+  function columnIndexAtOffset(line: string, offset: number, columnCount: number): number {
+    let pipeCount = 0;
+    for (let i = 0; i < Math.min(offset, line.length); i += 1) {
+      if (line[i] === "|" && !isEscaped(line, i)) {
+        pipeCount += 1;
+      }
+    }
+
+    const hasLeadingPipe = /^\s*\|/.test(line);
+    const rawIndex = hasLeadingPipe ? pipeCount - 1 : pipeCount;
+    return Math.max(0, Math.min(columnCount - 1, rawIndex));
+  }
+
+  function findMarkdownTableAt(doc: Text, pos: number): MarkdownTable | null {
+    const currentLine = doc.lineAt(pos);
+    if (!isPotentialTableLine(currentLine.text)) return null;
+
+    let blockStart = currentLine.number;
+    while (blockStart > 1 && isPotentialTableLine(doc.line(blockStart - 1).text)) {
+      blockStart -= 1;
+    }
+
+    let blockEnd = currentLine.number;
+    while (blockEnd < doc.lines && isPotentialTableLine(doc.line(blockEnd + 1).text)) {
+      blockEnd += 1;
+    }
+
+    const blockLines = [];
+    for (let lineNumber = blockStart; lineNumber <= blockEnd; lineNumber += 1) {
+      blockLines.push(doc.line(lineNumber));
+    }
+
+    const dividerIndex = blockLines.findIndex((line) => isDividerRow(line.text));
+    if (dividerIndex <= 0) return null;
+
+    const headerIndex = dividerIndex - 1;
+    const tableLines = blockLines.slice(headerIndex);
+    const startLine = tableLines[0];
+    const endLine = tableLines[tableLines.length - 1];
+    if (currentLine.number < startLine.number || currentLine.number > endLine.number) {
+      return null;
+    }
+
+    const headerCells = splitMarkdownTableCells(tableLines[0].text);
+    const dividerCells = splitMarkdownTableCells(tableLines[1].text);
+    const bodyRows = tableLines.slice(2).map((line) => splitMarkdownTableCells(line.text));
+    const rows = [headerCells, ...bodyRows];
+    const columnCount = Math.max(1, dividerCells.length, ...rows.map((row) => row.length));
+    const aligns = Array.from({ length: columnCount }, (_, index) => {
+      const align = normalizeDividerCell(dividerCells[index] ?? "---");
+      return align === null ? undefined : align;
+    });
+
+    return {
+      startLineNumber: startLine.number,
+      endLineNumber: endLine.number,
+      startPos: startLine.from,
+      endPos: endLine.to,
+      rows,
+      aligns,
+      columnCount,
+      currentSourceLineIndex: currentLine.number - startLine.number,
+      currentColumnIndex: columnIndexAtOffset(
+        currentLine.text,
+        pos - currentLine.from,
+        columnCount
+      ),
+    };
+  }
+
+  function escapeMarkdownTableCell(value: string): string {
+    return value.replace(/\r?\n/g, "<br>").replace(/\|/g, "\\|");
+  }
+
+  function characterDisplayWidth(value: string): number {
+    const code = value.codePointAt(0) ?? 0;
+    if (
+      (code >= 0x0300 && code <= 0x036f) ||
+      (code >= 0x1ab0 && code <= 0x1aff) ||
+      (code >= 0x1dc0 && code <= 0x1dff) ||
+      (code >= 0x20d0 && code <= 0x20ff) ||
+      (code >= 0xfe20 && code <= 0xfe2f)
+    ) {
+      return 0;
+    }
+    if (
+      code >= 0x1100 &&
+      (code <= 0x115f ||
+        code === 0x2329 ||
+        code === 0x232a ||
+        (code >= 0x2e80 && code <= 0xa4cf && code !== 0x303f) ||
+        (code >= 0xac00 && code <= 0xd7a3) ||
+        (code >= 0xf900 && code <= 0xfaff) ||
+        (code >= 0xfe10 && code <= 0xfe19) ||
+        (code >= 0xfe30 && code <= 0xfe6f) ||
+        (code >= 0xff00 && code <= 0xff60) ||
+        (code >= 0xffe0 && code <= 0xffe6) ||
+        (code >= 0x1f300 && code <= 0x1f64f) ||
+        (code >= 0x1f900 && code <= 0x1f9ff) ||
+        (code >= 0x20000 && code <= 0x3fffd))
+    ) {
+      return 2;
+    }
+    return 1;
+  }
+
+  function displayWidth(value: string): number {
+    return Array.from(value).reduce((width, char) => width + characterDisplayWidth(char), 0);
+  }
+
+  function padDisplayEnd(value: string, width: number): string {
+    return value + " ".repeat(Math.max(0, width - displayWidth(value)));
+  }
+
+  function padDisplayStart(value: string, width: number): string {
+    return " ".repeat(Math.max(0, width - displayWidth(value))) + value;
+  }
+
+  function padDisplayCenter(value: string, width: number): string {
+    const space = Math.max(0, width - displayWidth(value));
+    const left = Math.floor(space / 2);
+    return " ".repeat(left) + value + " ".repeat(space - left);
+  }
+
+  function padMarkdownTableCell(value: string, width: number, align: TableAlignment): string {
+    switch (align) {
+      case "right":
+        return padDisplayStart(value, width);
+      case "center":
+        return padDisplayCenter(value, width);
+      default:
+        return padDisplayEnd(value, width);
+    }
+  }
+
+  function minimumDividerWidth(align: TableAlignment): number {
+    if (align === "center") return 5;
+    if (align === "left" || align === "right") return 4;
+    return 3;
+  }
+
+  function renderDividerCell(align: TableAlignment, width: number): string {
+    const targetWidth = Math.max(width, minimumDividerWidth(align));
+    switch (align) {
+      case "left":
+        return ":" + "-".repeat(targetWidth - 1);
+      case "center":
+        return ":" + "-".repeat(targetWidth - 2) + ":";
+      case "right":
+        return "-".repeat(targetWidth - 1) + ":";
+      default:
+        return "-".repeat(targetWidth);
+    }
+  }
+
+  function normalizeTableRow(row: string[], columnCount: number): string[] {
+    return Array.from({ length: columnCount }, (_, index) => row[index] ?? "");
+  }
+
+  function renderMarkdownTable(rows: string[][], aligns: TableAlignment[]): string {
+    const columnCount = Math.max(1, aligns.length, ...rows.map((row) => row.length));
+    const normalizedRows = rows.map((row) => normalizeTableRow(row, columnCount));
+    const normalizedAligns = Array.from({ length: columnCount }, (_, index) => aligns[index]);
+    const columnWidths = Array.from({ length: columnCount }, (_, columnIndex) =>
+      Math.max(
+        minimumDividerWidth(normalizedAligns[columnIndex]),
+        ...normalizedRows.map((row) => displayWidth(escapeMarkdownTableCell(row[columnIndex])))
+      )
+    );
+    const header = normalizedRows[0] ?? Array.from({ length: columnCount }, () => "");
+    const body = normalizedRows.slice(1);
+    const renderDataRow = (row: string[]) =>
+      `| ${row
+        .map((cell, index) =>
+          padMarkdownTableCell(
+            escapeMarkdownTableCell(cell),
+            columnWidths[index],
+            normalizedAligns[index]
+          )
+        )
+        .join(" | ")} |`;
+
+    return [
+      renderDataRow(header),
+      `| ${normalizedAligns
+        .map((align, index) => renderDividerCell(align, columnWidths[index]))
+        .join(" | ")} |`,
+      ...body.map(renderDataRow),
+    ].join("\n");
+  }
+
+  function sourceLineIndexToRowIndex(sourceLineIndex: number): number {
+    return sourceLineIndex <= 1 ? 0 : sourceLineIndex - 1;
+  }
+
+  function rowIndexToSourceLineIndex(rowIndex: number): number {
+    return rowIndex === 0 ? 0 : rowIndex + 1;
+  }
+
+  function renderedCellAnchor(markdownTable: string, sourceLineIndex: number, columnIndex: number) {
+    const lines = markdownTable.split("\n");
+    const targetLineIndex = Math.max(0, Math.min(sourceLineIndex, lines.length - 1));
+    const targetLine = lines[targetLineIndex] ?? "";
+    let offset = 0;
+    for (let i = 0; i < targetLineIndex; i += 1) {
+      offset += lines[i].length + 1;
+    }
+
+    let column = -1;
+    for (let i = 0; i < targetLine.length; i += 1) {
+      if (targetLine[i] === "|" && !isEscaped(targetLine, i)) {
+        column += 1;
+        if (column === columnIndex) {
+          return offset + Math.min(targetLine.length, i + 2);
+        }
+      }
+    }
+    return offset + targetLine.length;
+  }
+
+  function replaceMarkdownTable(
+    table: MarkdownTable,
+    rows: string[][],
+    aligns: TableAlignment[],
+    sourceLineIndex: number,
+    columnIndex: number,
+    editorView: EditorView | null = view
+  ): boolean {
+    if (!editorView) return false;
+    const nextTable = renderMarkdownTable(rows, aligns);
+    const anchor = table.startPos + renderedCellAnchor(nextTable, sourceLineIndex, columnIndex);
+    editorView.dispatch({
+      changes: { from: table.startPos, to: table.endPos, insert: nextTable },
+      selection: { anchor },
+      scrollIntoView: true,
+    });
+    editorView.focus();
+    return true;
+  }
+
+  function formatTableAndMoveCell(editorView: EditorView, direction: 1 | -1): boolean {
+    const table = findMarkdownTableAt(editorView.state.doc, editorView.state.selection.main.from);
+    if (!table) return false;
+
+    const rows = table.rows.map((row) => normalizeTableRow(row, table.columnCount));
+    let rowIndex = sourceLineIndexToRowIndex(table.currentSourceLineIndex);
+    let columnIndex = table.currentColumnIndex + direction;
+
+    if (direction > 0 && columnIndex >= table.columnCount) {
+      columnIndex = 0;
+      rowIndex += 1;
+    } else if (direction < 0 && columnIndex < 0) {
+      rowIndex -= 1;
+      columnIndex = table.columnCount - 1;
+    }
+
+    if (rowIndex >= rows.length) {
+      rows.push(Array.from({ length: table.columnCount }, () => ""));
+    }
+
+    if (rowIndex < 0) {
+      rowIndex = 0;
+      columnIndex = 0;
+    }
+
+    return replaceMarkdownTable(
+      table,
+      rows,
+      table.aligns,
+      rowIndexToSourceLineIndex(rowIndex),
+      columnIndex,
+      editorView
+    );
+  }
+
+  function formatInsertTable() {
+    if (!view) return;
+    const { from, to } = view.state.selection.main;
+    const docText = view.state.doc.toString();
+    const selected = docText.slice(from, to).replace(/\s+/g, " ").trim();
+    const rows = [
+      [selected || "Column 1", "Column 2"],
+      ["", ""],
+    ];
+    const tableMarkdown = renderMarkdownTable(rows, [undefined, undefined]);
+    const prefix = from > 0 && !docText.slice(0, from).endsWith("\n") ? "\n\n" : "";
+    const suffix = to < docText.length && !docText.slice(to).startsWith("\n") ? "\n\n" : "";
+    const insert = `${prefix}${tableMarkdown}${suffix}`;
+
+    view.dispatch({
+      changes: { from, to, insert },
+      selection: { anchor: from + prefix.length + renderedCellAnchor(tableMarkdown, 0, 0) },
+      scrollIntoView: true,
+    });
+    view.focus();
+  }
+
+  function formatInsertTableRow(position: "above" | "below") {
+    if (!view) return;
+    const table = findMarkdownTableAt(view.state.doc, view.state.selection.main.from);
+    if (!table) return;
+
+    const rows = table.rows.map((row) => normalizeTableRow(row, table.columnCount));
+    const emptyRow = Array.from({ length: table.columnCount }, () => "");
+    const currentRowIndex = sourceLineIndexToRowIndex(table.currentSourceLineIndex);
+    let insertIndex =
+      position === "above" ? currentRowIndex : Math.min(rows.length, currentRowIndex + 1);
+    if (currentRowIndex === 0) {
+      insertIndex = 1;
+    }
+
+    rows.splice(insertIndex, 0, emptyRow);
+    replaceMarkdownTable(
+      table,
+      rows,
+      table.aligns,
+      rowIndexToSourceLineIndex(insertIndex),
+      table.currentColumnIndex
+    );
+  }
+
+  function formatInsertTableColumn(side: "left" | "right") {
+    if (!view) return;
+    const table = findMarkdownTableAt(view.state.doc, view.state.selection.main.from);
+    if (!table) return;
+
+    const insertIndex = side === "left" ? table.currentColumnIndex : table.currentColumnIndex + 1;
+    const rows = table.rows.map((row) => {
+      const nextRow = normalizeTableRow(row, table.columnCount);
+      nextRow.splice(insertIndex, 0, "");
+      return nextRow;
+    });
+    const aligns = [...table.aligns];
+    aligns.splice(insertIndex, 0, undefined);
+    const sourceLineIndex = table.currentSourceLineIndex === 1 ? 0 : table.currentSourceLineIndex;
+
+    replaceMarkdownTable(table, rows, aligns, sourceLineIndex, insertIndex);
+  }
+
+  function formatDeleteTableRow() {
+    if (!view) return;
+    const table = findMarkdownTableAt(view.state.doc, view.state.selection.main.from);
+    if (!table) return;
+
+    const rows = table.rows.map((row) => normalizeTableRow(row, table.columnCount));
+    const rowIndex = sourceLineIndexToRowIndex(table.currentSourceLineIndex);
+    if (rows.length <= 1) {
+      formatDeleteTable();
+      return;
+    }
+
+    rows.splice(rowIndex, 1);
+    const nextRowIndex = Math.max(0, Math.min(rowIndex, rows.length - 1));
+    replaceMarkdownTable(
+      table,
+      rows,
+      table.aligns,
+      rowIndexToSourceLineIndex(nextRowIndex),
+      table.currentColumnIndex
+    );
+  }
+
+  function formatDeleteTableColumn() {
+    if (!view) return;
+    const table = findMarkdownTableAt(view.state.doc, view.state.selection.main.from);
+    if (!table) return;
+
+    if (table.columnCount <= 1) {
+      formatDeleteTable();
+      return;
+    }
+
+    const rows = table.rows.map((row) => {
+      const nextRow = normalizeTableRow(row, table.columnCount);
+      nextRow.splice(table.currentColumnIndex, 1);
+      return nextRow;
+    });
+    const aligns = [...table.aligns];
+    aligns.splice(table.currentColumnIndex, 1);
+    const nextColumnIndex = Math.max(0, Math.min(table.currentColumnIndex, table.columnCount - 2));
+    const sourceLineIndex = table.currentSourceLineIndex === 1 ? 0 : table.currentSourceLineIndex;
+
+    replaceMarkdownTable(table, rows, aligns, sourceLineIndex, nextColumnIndex);
+  }
+
+  function formatDeleteTable() {
+    if (!view) return;
+    const table = findMarkdownTableAt(view.state.doc, view.state.selection.main.from);
+    if (!table) return;
+
+    const doc = view.state.doc;
+    let from = table.startPos;
+    let to = table.endPos;
+    if (table.endLineNumber < doc.lines) {
+      to = doc.line(table.endLineNumber + 1).from;
+    } else if (table.startLineNumber > 1) {
+      from = doc.line(table.startLineNumber - 1).to;
+    }
+
+    view.dispatch({
+      changes: { from, to, insert: "" },
+      selection: { anchor: from },
+      scrollIntoView: true,
+    });
+    view.focus();
+  }
+
+  function runTableAction(action: TableAction) {
+    switch (action) {
+      case "insert":
+        formatInsertTable();
+        return;
+      case "row-above":
+        formatInsertTableRow("above");
+        return;
+      case "row-below":
+        formatInsertTableRow("below");
+        return;
+      case "column-left":
+        formatInsertTableColumn("left");
+        return;
+      case "column-right":
+        formatInsertTableColumn("right");
+        return;
+      case "delete-row":
+        formatDeleteTableRow();
+        return;
+      case "delete-column":
+        formatDeleteTableColumn();
+        return;
+      case "delete-table":
+        formatDeleteTable();
+        return;
+      default:
+    }
+  }
+
+  function handleTableActionChange(event: Event) {
+    const value = (event.currentTarget as HTMLSelectElement).value as TableAction | "";
+    if (!value) return;
+    runTableAction(value);
+    tableActionValue = "";
   }
 
   async function resolveImageSources(html: string): Promise<string> {
@@ -595,6 +1119,9 @@
     }
   }
 
+  const markdownSourceFontFamily =
+    '"BIZ UDゴシック", "BIZ UDGothic", "Cascadia Mono", "Cascadia Code", Consolas, "Courier New", monospace';
+
   const editorTheme = EditorView.theme({
     "&": {
       height: "100%",
@@ -603,9 +1130,12 @@
     },
     ".cm-scroller": {
       overflow: "auto",
-      fontFamily: "inherit",
+      fontFamily: markdownSourceFontFamily,
       fontSize: "var(--font-body-md)",
       lineHeight: "1.7",
+      fontKerning: "none",
+      fontVariantLigatures: "none",
+      fontFeatureSettings: '"liga" 0, "calt" 0',
     },
     ".cm-content": {
       padding: "var(--sp3) var(--sp4)",
@@ -699,6 +1229,14 @@
             return true;
           },
         },
+        {
+          key: "Tab",
+          run: (editorView) => formatTableAndMoveCell(editorView, 1),
+        },
+        {
+          key: "Shift-Tab",
+          run: (editorView) => formatTableAndMoveCell(editorView, -1),
+        },
         ...completionKeymap,
         ...defaultKeymap,
         ...searchKeymap,
@@ -765,6 +1303,9 @@
         },
       }),
       EditorView.updateListener.of((update) => {
+        if (update.selectionSet || update.docChanged) {
+          syncHeadingLevel(update.view);
+        }
         if (update.docChanged) {
           hasChanges = true;
           saveState = "dirty";
@@ -789,6 +1330,7 @@
       state: EditorState.create({ doc: currentContent, extensions: buildExtensions() }),
       parent: container,
     });
+    syncHeadingLevel(view);
     view.focus();
   }
 
@@ -929,6 +1471,19 @@
       <div class="edit-bar">
         <div class="toolbar">
           <!-- eslint-disable svelte/no-at-html-tags -->
+          <span class="heading-picker toolbar-picker">
+            <select
+              aria-label="Heading"
+              title="Heading"
+              bind:value={currentHeadingLevel}
+              on:change={handleHeadingChange}
+            >
+              <option value="normal">Normal</option>
+              <option value="1">Heading 1</option>
+              <option value="2">Heading 2</option>
+            </select>
+          </span>
+          <span class="tool-sep"></span>
           <button
             type="button"
             class="tool-btn tool-bold"
@@ -963,37 +1518,6 @@
           <button
             type="button"
             class="tool-btn"
-            aria-label="Heading 1"
-            title="Heading 1"
-            on:mousedown|preventDefault
-            on:click={() => formatHeading(1)}
-          >
-            <span class="tool-icon" aria-hidden="true">{@html toolbarIcons.heading1}</span>
-          </button>
-          <button
-            type="button"
-            class="tool-btn"
-            aria-label="Heading 2"
-            title="Heading 2"
-            on:mousedown|preventDefault
-            on:click={() => formatHeading(2)}
-          >
-            <span class="tool-icon" aria-hidden="true">{@html toolbarIcons.heading2}</span>
-          </button>
-          <button
-            type="button"
-            class="tool-btn"
-            aria-label="Heading 3"
-            title="Heading 3"
-            on:mousedown|preventDefault
-            on:click={() => formatHeading(3)}
-          >
-            <span class="tool-icon" aria-hidden="true">{@html toolbarIcons.heading3}</span>
-          </button>
-          <span class="tool-sep"></span>
-          <button
-            type="button"
-            class="tool-btn"
             aria-label="Link"
             title="Link (Ctrl+K)"
             on:mousedown|preventDefault
@@ -1010,16 +1534,6 @@
             on:click={formatBulletList}
           >
             <span class="tool-icon" aria-hidden="true">{@html toolbarIcons.bulletList}</span>
-          </button>
-          <button
-            type="button"
-            class="tool-btn"
-            aria-label="Checklist"
-            title="Checklist"
-            on:mousedown|preventDefault
-            on:click={formatCheckbox}
-          >
-            <span class="tool-icon" aria-hidden="true">{@html toolbarIcons.checklist}</span>
           </button>
           <button
             type="button"
@@ -1041,6 +1555,20 @@
           >
             <span class="tool-icon" aria-hidden="true">{@html toolbarIcons.codeBlock}</span>
           </button>
+          <span class="tool-sep"></span>
+          <span class="table-picker toolbar-picker">
+            <select
+              aria-label="Table"
+              title="Table"
+              bind:value={tableActionValue}
+              on:change={handleTableActionChange}
+            >
+              <option value="" disabled>Table</option>
+              {#each tableActionOptions as action}
+                <option value={action.value}>{action.label}</option>
+              {/each}
+            </select>
+          </span>
           <!-- eslint-enable svelte/no-at-html-tags -->
         </div>
         <div class="edit-bar-end">
@@ -1123,10 +1651,13 @@
 
 <style>
   .wrapper {
+    --memo-editor-font:
+      "BIZ UDゴシック", "BIZ UDGothic", "Cascadia Mono", "Cascadia Code", Consolas, "Courier New",
+      monospace;
     --memo-quill-button-color: var(--theme-color-Sub-light);
     --memo-quill-button-active-color: #06c;
-    --memo-quill-button-height: 28px;
-    --memo-quill-button-width: 30px;
+    --memo-quill-button-height: 24px;
+    --memo-quill-button-width: 28px;
 
     display: flex;
     flex-direction: column;
@@ -1162,7 +1693,7 @@
   .edit-bar {
     display: flex;
     justify-content: space-between;
-    align-items: center;
+    align-items: flex-start;
     padding: var(--sp2);
     background-color: var(--theme-color-Main-dark);
     flex-shrink: 0;
@@ -1174,11 +1705,11 @@
     display: flex;
     align-items: center;
     gap: 0;
-    flex-wrap: nowrap;
+    flex-wrap: wrap;
     flex: 1 1 auto;
     min-width: 0;
-    overflow-x: auto;
-    overflow-y: hidden;
+    row-gap: var(--sp1);
+    overflow: visible;
     scrollbar-width: none;
   }
 
@@ -1192,17 +1723,16 @@
     justify-content: center;
     flex: 0 0 auto;
     height: var(--memo-quill-button-height);
-    width: auto;
-    padding: var(--sp1) calc(var(--sp2) + 2px);
+    width: var(--memo-quill-button-width);
+    padding: 3px 5px;
     margin: 0;
-    font-size: var(--font-label-md);
+    font-size: 14px;
     background: none;
     border: none;
-    border-radius: var(--shape-xs);
+    border-radius: 0;
     color: var(--memo-quill-button-color);
     cursor: pointer;
     line-height: 1;
-    min-width: var(--memo-quill-button-width);
     text-align: center;
     transition:
       color 0.1s ease,
@@ -1223,15 +1753,15 @@
     display: inline-flex;
     align-items: center;
     justify-content: center;
-    width: 20px;
-    height: 20px;
+    width: 18px;
+    height: 18px;
     pointer-events: none;
   }
 
   .tool-icon :global(svg) {
     display: block;
-    width: 20px;
-    height: 20px;
+    width: 18px;
+    height: 18px;
   }
 
   .tool-icon :global(.ql-stroke) {
@@ -1278,6 +1808,64 @@
   .tool-code-inline,
   .tool-code-block {
     min-width: var(--memo-quill-button-width);
+  }
+
+  .toolbar-picker {
+    position: relative;
+    display: inline-block;
+    flex: 0 0 auto;
+    height: var(--memo-quill-button-height);
+    color: var(--memo-quill-button-color);
+    font-size: 14px;
+    font-weight: 500;
+    vertical-align: middle;
+  }
+
+  .heading-picker {
+    width: 98px;
+  }
+
+  .table-picker {
+    width: 112px;
+  }
+
+  .toolbar-picker select {
+    appearance: none;
+    width: 100%;
+    height: 100%;
+    padding: 0 20px 0 8px;
+    margin: 0;
+    border: none;
+    border-radius: 0;
+    outline: none;
+    color: inherit;
+    background: transparent;
+    cursor: pointer;
+    font: inherit;
+    line-height: 22px;
+  }
+
+  .toolbar-picker::after {
+    content: "";
+    position: absolute;
+    top: 50%;
+    right: 6px;
+    width: 6px;
+    height: 6px;
+    border-right: 1.5px solid currentColor;
+    border-bottom: 1.5px solid currentColor;
+    transform: translateY(-65%) rotate(45deg);
+    pointer-events: none;
+  }
+
+  .toolbar-picker:hover,
+  .toolbar-picker:focus-within {
+    color: var(--memo-quill-button-active-color);
+  }
+
+  .toolbar-picker select option {
+    color: var(--theme-color-Sub-light);
+    background-color: var(--theme-color-Main-light);
   }
 
   .tool-sep {
@@ -1443,7 +2031,13 @@
     min-height: 0;
     padding: var(--sp4);
     color: var(--theme-color-Sub-light);
+    font-family: var(--memo-editor-font);
     font-size: var(--font-body-md);
+    font-kerning: none;
+    font-variant-ligatures: none;
+    font-feature-settings:
+      "liga" 0,
+      "calt" 0;
     line-height: 1.7;
   }
 
@@ -1568,7 +2162,7 @@
   }
 
   .preview :global(code) {
-    font-family: monospace;
+    font-family: var(--memo-editor-font);
     font-size: 0.85em;
     background-color: var(--theme-color-Main-dark);
     padding: 0.1em 0.35em;
@@ -1673,7 +2267,7 @@
     color: var(--theme-color-Error-main);
     background-color: color-mix(in srgb, var(--theme-color-Error-main) 8%, transparent);
     border-color: color-mix(in srgb, var(--theme-color-Error-main) 35%, transparent);
-    font-family: monospace;
+    font-family: var(--memo-editor-font);
     font-size: var(--font-body-sm);
     white-space: pre-wrap;
   }

--- a/src/features/memos/components/QuillMemo.svelte
+++ b/src/features/memos/components/QuillMemo.svelte
@@ -1,6 +1,7 @@
 ﻿<script>
   import { onMount } from "svelte";
   import Quill from "quill";
+  import quillIcons from "quill/ui/icons.js";
   import "quill/dist/quill.snow.css";
   import { isEqual } from "lodash";
   import { memoContentForCompare } from "@features/memos/utils/memo_utils";
@@ -16,20 +17,44 @@
   let lastSavedContent = null;
   let linkClickListener;
   let pasteListener;
+  let editReleaseTimer;
   let errorMessage = null;
   let isHandlingLink = false;
 
+  const codeBlockIconSvg =
+    '<svg viewBox="0 0 18 18" aria-hidden="true" focusable="false">' +
+    '<rect class="ql-stroke" x="2.5" y="3.5" width="13" height="11" rx="1.5" ry="1.5" fill="none"/>' +
+    '<polyline class="ql-even ql-stroke" points="7 8 5.5 9.5 7 11"/>' +
+    '<polyline class="ql-even ql-stroke" points="11 8 12.5 9.5 11 11"/>' +
+    "</svg>";
+
+  const formatToolbarLabels = {
+    code: "インラインコード",
+    "code-block": "コードブロック",
+  };
+
+  const formatToolbarIcons = {
+    code: quillIcons.code,
+    "code-block": codeBlockIconSvg,
+  };
+
+  const tableToolbarLabels = {
+    insert: "表を挿入",
+    "row-above": "行を上に追加",
+    "row-below": "行を下に追加",
+    "column-left": "列を左に追加",
+    "column-right": "列を右に追加",
+    "delete-row": "行を削除",
+    "delete-column": "列を削除",
+    "delete-table": "表を削除",
+  };
+
+  const tableToolbarActions = Object.keys(tableToolbarLabels);
+
   const toolbarOptions = [
-    [{ font: [] }],
     [{ header: [1, 2, false] }],
-    [{ color: [] }, { background: [] }],
-    ["bold", "italic", "underline", "strike"],
-    ["blockquote", "code-block", { list: "ordered" }, { list: "bullet" }],
-    [{ script: "sub" }, { script: "super" }],
-    [{ indent: "-1" }, { indent: "+1" }],
-    [{ align: [] }],
-    ["link", "image"],
-    ["clean"],
+    ["bold", "italic", "code"],
+    ["link", { list: "bullet" }, "blockquote", "code-block"],
   ];
 
   function isEmptyContent(value) {
@@ -40,6 +65,31 @@
       (value.ops.length === 0 ||
         (value.ops.length === 1 && (value.ops[0].insert === "\n" || value.ops[0].insert === "")))
     );
+  }
+
+  function normalizeContent(value) {
+    if (value && typeof value === "object" && Array.isArray(value.ops)) {
+      return JSON.parse(JSON.stringify({ ops: value.ops }));
+    }
+    return value;
+  }
+
+  function releaseEditingAfter(delay) {
+    if (editReleaseTimer) {
+      clearTimeout(editReleaseTimer);
+    }
+    editReleaseTimer = setTimeout(() => {
+      isEditing = false;
+      editReleaseTimer = null;
+    }, delay);
+  }
+
+  function restoreSelection(range) {
+    if (!quill || !range || !quill.hasFocus()) return;
+
+    const index = Math.max(0, Math.min(range.index, quill.getLength()));
+    const length = Math.max(0, Math.min(range.length ?? 0, quill.getLength() - index));
+    quill.setSelection(index, length, "silent");
   }
 
   function applyContent(nextContent) {
@@ -60,6 +110,91 @@
 
   function openExternalLink(href) {
     return window.electronAPI?.openExternalLink?.(href);
+  }
+
+  function runTableAction(value) {
+    const table = quill?.getModule?.("table");
+    if (!table) return;
+
+    switch (value) {
+      case "insert":
+        table.insertTable(2, 2);
+        return;
+      case "row-above":
+        table.insertRowAbove();
+        return;
+      case "row-below":
+        table.insertRowBelow();
+        return;
+      case "column-left":
+        table.insertColumnLeft();
+        return;
+      case "column-right":
+        table.insertColumnRight();
+        return;
+      case "delete-row":
+        table.deleteRow();
+        return;
+      case "delete-column":
+        table.deleteColumn();
+        return;
+      case "delete-table":
+        table.deleteTable();
+        return;
+      default:
+    }
+  }
+
+  function installTableToolbarSelect() {
+    const toolbar = quill?.getModule?.("toolbar")?.container;
+    if (!toolbar || toolbar.querySelector(".memo-table-picker")) return;
+
+    const group = document.createElement("span");
+    group.className = "ql-formats memo-table-picker";
+
+    const select = document.createElement("select");
+    select.className = "memo-toolbar-select memo-table-select";
+    select.setAttribute("aria-label", "Table");
+    select.setAttribute("title", "Table");
+
+    const placeholder = document.createElement("option");
+    placeholder.value = "";
+    placeholder.textContent = "Table";
+    placeholder.disabled = true;
+    placeholder.selected = true;
+    select.appendChild(placeholder);
+
+    for (const value of tableToolbarActions) {
+      const option = document.createElement("option");
+      option.value = value;
+      option.textContent = tableToolbarLabels[value];
+      select.appendChild(option);
+    }
+
+    select.addEventListener("change", () => {
+      if (!select.value) return;
+      runTableAction(select.value);
+      select.value = "";
+    });
+
+    group.appendChild(select);
+    toolbar.appendChild(group);
+  }
+
+  function labelToolbarButtons() {
+    const toolbar = quill?.getModule?.("toolbar")?.container;
+    if (!toolbar) return;
+
+    for (const [value, label] of Object.entries(formatToolbarLabels)) {
+      const button = toolbar.querySelector(`button.ql-${value}`);
+      button?.setAttribute("aria-label", label);
+      button?.setAttribute("title", label);
+      if (button && formatToolbarIcons[value]) {
+        button.innerHTML = formatToolbarIcons[value];
+      }
+    }
+
+    installTableToolbarSelect();
   }
 
   function handleLinkTooltips() {
@@ -130,15 +265,22 @@
     quill = new Quill(editor, {
       theme: "snow",
       modules: {
-        toolbar: readOnly ? false : toolbarOptions,
+        table: true,
+        toolbar: readOnly
+          ? false
+          : {
+              container: toolbarOptions,
+            },
         clipboard: {
           matchVisual: false,
         },
       },
     });
+    labelToolbarButtons();
 
-    applyContent(content);
-    lastSavedContent = content;
+    const initialContent = normalizeContent(content);
+    applyContent(initialContent);
+    lastSavedContent = initialContent;
     quill.enable(!readOnly);
 
     if (!readOnly) {
@@ -147,8 +289,14 @@
 
         isEditing = true;
         const currentSelection = quill.hasFocus() ? quill.getSelection() : null;
-        const contents = quill.getContents();
+        const contents = normalizeContent(quill.getContents());
         lastSavedContent = contents;
+        if (currentSelection) {
+          savedSelection = {
+            index: currentSelection.index,
+            length: currentSelection.length,
+          };
+        }
 
         if (currentSelection) {
           saveMemo(contents, currentSelection);
@@ -156,9 +304,7 @@
           saveMemo(contents);
         }
 
-        setTimeout(() => {
-          isEditing = false;
-        }, 100);
+        releaseEditingAfter(100);
       });
 
       quill.on("selection-change", (range, _oldRange, source) => {
@@ -184,6 +330,10 @@
         pasteListener = null;
       }
 
+      if (editReleaseTimer) {
+        clearTimeout(editReleaseTimer);
+        editReleaseTimer = null;
+      }
       isEditing = false;
       savedSelection = null;
       lastSavedContent = null;
@@ -192,20 +342,24 @@
   });
 
   $: if (quill && !isEditing) {
-    const contentIsEmpty = isEmptyContent(content);
-    const lastSavedIsEmpty = isEmptyContent(lastSavedContent);
+    const normalizedContent = normalizeContent(content);
+    const normalizedLastSavedContent = normalizeContent(lastSavedContent);
+    const contentIsEmpty = isEmptyContent(normalizedContent);
+    const lastSavedIsEmpty = isEmptyContent(normalizedLastSavedContent);
     const needsUpdate =
       contentIsEmpty !== lastSavedIsEmpty ||
       (!contentIsEmpty &&
-        !isEqual(memoContentForCompare(content), memoContentForCompare(lastSavedContent)));
+        !isEqual(
+          memoContentForCompare(normalizedContent),
+          memoContentForCompare(normalizedLastSavedContent)
+        ));
 
     if (needsUpdate) {
       isEditing = true;
-      applyContent(content);
-      lastSavedContent = content;
-      setTimeout(() => {
-        isEditing = false;
-      }, 50);
+      applyContent(normalizedContent);
+      restoreSelection(savedSelection);
+      lastSavedContent = normalizedContent;
+      releaseEditingAfter(50);
     }
   }
 
@@ -228,6 +382,10 @@
 
 <style>
   .wrapper {
+    --memo-editor-font:
+      "BIZ UDゴシック", "BIZ UDGothic", "Cascadia Mono", "Cascadia Code", Consolas, "Courier New",
+      monospace;
+
     display: flex;
     flex-direction: column;
     flex: 1;
@@ -282,13 +440,62 @@
     border-color: var(--theme-color-Sub-dark) !important;
     border-top: 0 !important;
     color: var(--theme-color-Sub-light);
-    font-family: inherit;
+    font-family: var(--memo-editor-font);
   }
 
   .wrapper :global(.ql-toolbar) {
     flex-shrink: 0;
     border-color: var(--theme-color-Sub-dark) !important;
     background-color: var(--theme-color-Main-dark);
+  }
+
+  .wrapper :global(.ql-toolbar .memo-table-picker) {
+    position: relative;
+    display: inline-block;
+    height: 24px;
+    color: var(--theme-color-Sub-light);
+    vertical-align: middle;
+  }
+
+  .wrapper :global(.ql-toolbar .memo-table-picker::after) {
+    content: "";
+    position: absolute;
+    top: 50%;
+    right: 6px;
+    width: 6px;
+    height: 6px;
+    border-right: 1.5px solid currentColor;
+    border-bottom: 1.5px solid currentColor;
+    transform: translateY(-65%) rotate(45deg);
+    pointer-events: none;
+  }
+
+  .wrapper :global(.ql-toolbar .memo-toolbar-select) {
+    appearance: none;
+    width: 112px;
+    height: 24px;
+    padding: 0 20px 0 8px;
+    margin: 0;
+    border: none;
+    border-radius: 0;
+    outline: none;
+    color: inherit;
+    background: transparent;
+    cursor: pointer;
+    font-family: inherit;
+    font-size: 14px;
+    font-weight: 500;
+    line-height: 24px;
+  }
+
+  .wrapper :global(.ql-toolbar .memo-table-picker:hover),
+  .wrapper :global(.ql-toolbar .memo-table-picker:focus-within) {
+    color: #06c;
+  }
+
+  .wrapper :global(.ql-toolbar .memo-toolbar-select option) {
+    color: var(--theme-color-Sub-light);
+    background-color: var(--theme-color-Main-light);
   }
 
   .wrapper :global(.ql-editor) {
@@ -298,8 +505,64 @@
     overflow-y: auto;
     padding: var(--sp3) var(--sp4);
     color: var(--theme-color-Sub-light);
+    font-family: var(--memo-editor-font);
     font-size: var(--font-body-md);
+    font-kerning: none;
+    font-variant-ligatures: none;
+    font-feature-settings:
+      "liga" 0,
+      "calt" 0;
     line-height: 1.7;
+  }
+
+  .wrapper :global(.ql-editor code),
+  .wrapper :global(.ql-editor .ql-code-block-container) {
+    font-family: var(--memo-editor-font);
+  }
+
+  .wrapper :global(.ql-editor code) {
+    font-size: 0.85em;
+    color: var(--theme-color-Sub-light);
+    background-color: var(--theme-color-Main-dark);
+    padding: 0.1em 0.35em;
+    border-radius: var(--shape-xs);
+    border: 1px solid color-mix(in srgb, var(--theme-color-Sub-dark) 20%, transparent);
+  }
+
+  .wrapper :global(.ql-editor .ql-code-block-container) {
+    color: var(--theme-color-Sub-light);
+    background-color: var(--theme-color-Main-dark);
+    padding: var(--sp3) var(--sp4);
+    border-radius: var(--shape-sm);
+    overflow-x: auto;
+    margin: 0.75em 0;
+    border: 1px solid color-mix(in srgb, var(--theme-color-Sub-dark) 25%, transparent);
+  }
+
+  .wrapper :global(.ql-editor table) {
+    border-collapse: collapse;
+    width: 100%;
+    margin: 0.5em 0;
+    color: var(--theme-color-Sub-light);
+    font-size: var(--font-body-md);
+  }
+
+  .wrapper :global(.ql-editor table th),
+  .wrapper :global(.ql-editor table td) {
+    border: 1px solid var(--theme-color-Sub-dark);
+    padding: 0.3em 0.6em;
+    min-width: 2.5rem;
+    vertical-align: top;
+  }
+
+  .wrapper :global(.ql-editor table th),
+  .wrapper :global(.ql-editor table tr:first-child td) {
+    background-color: var(--theme-color-Main-dark);
+    font-weight: 700;
+  }
+
+  .wrapper :global(.ql-editor table p) {
+    margin: 0;
   }
 
   :global(.ql-picker :not(.ql-active, :hover)) {

--- a/src/features/memos/utils/memo_utils.ts
+++ b/src/features/memos/utils/memo_utils.ts
@@ -110,6 +110,7 @@ function deltaToLines(ops: QuillDelta["ops"]): DeltaLine[] {
 }
 
 const BLOCK_ATTR_KEYS = new Set([
+  "table",
   "header",
   "list",
   "blockquote",
@@ -125,7 +126,7 @@ function pickBlockAttrs(attrs: QuillAttrs): QuillAttrs {
   return out;
 }
 
-type BlockType = "heading" | "paragraph" | "list" | "blockquote" | "code-block";
+type BlockType = "heading" | "paragraph" | "list" | "blockquote" | "code-block" | "table";
 
 type Block = {
   type: BlockType;
@@ -133,6 +134,7 @@ type Block = {
 };
 
 function getBlockType(attrs: QuillAttrs): BlockType {
+  if (attrs.table) return "table";
   if (attrs["code-block"]) return "code-block";
   if (attrs.list) return "list";
   if (attrs.blockquote) return "blockquote";
@@ -143,7 +145,7 @@ function getBlockType(attrs: QuillAttrs): BlockType {
 // listとblockquoteとcode-blockは隣接する同種行を1つのMdブロックにまとめる。
 // heading/paragraphはMd上で空行区切りが必要なので、行ごとに別ブロックに分ける。
 function shouldGroupAdjacent(type: BlockType): boolean {
-  return type === "list" || type === "blockquote" || type === "code-block";
+  return type === "list" || type === "blockquote" || type === "code-block" || type === "table";
 }
 
 function groupBlocks(lines: DeltaLine[]): Block[] {
@@ -175,6 +177,74 @@ function renderListBlock(block: Block): string {
     .join("\n");
 }
 
+function escapeTableCell(value: string): string {
+  return value.replace(/\r?\n/g, "<br>").replace(/\|/g, "\\|");
+}
+
+function tableRowId(attrs: QuillAttrs): string | null {
+  if (attrs.table == null) return null;
+  return String(attrs.table);
+}
+
+function normalizeTableAlign(value: unknown): "left" | "center" | "right" | undefined {
+  if (value === "left" || value === "center" || value === "right") return value;
+  return undefined;
+}
+
+function tableDividerCell(align: unknown): string {
+  switch (normalizeTableAlign(align)) {
+    case "left":
+      return ":---";
+    case "center":
+      return ":---:";
+    case "right":
+      return "---:";
+    default:
+      return "---";
+  }
+}
+
+function renderTableRow(cells: string[]): string {
+  return `| ${cells.join(" | ")} |`;
+}
+
+function renderTableBlock(block: Block): string {
+  const rows: Array<Array<{ inline: string; attrs: QuillAttrs }>> = [];
+  let currentRowId: string | null = null;
+
+  for (const line of block.lines) {
+    const rowId = tableRowId(line.attrs);
+    if (!rowId) continue;
+    if (rowId !== currentRowId) {
+      rows.push([]);
+      currentRowId = rowId;
+    }
+    rows[rows.length - 1].push(line);
+  }
+
+  if (rows.length === 0) return "";
+
+  const columnCount = Math.max(1, ...rows.map((row) => row.length));
+  const normalizedRows = rows.map((row) =>
+    Array.from({ length: columnCount }, (_, index) => row[index] ?? { inline: "", attrs: {} })
+  );
+  const columnAligns = Array.from({ length: columnCount }, (_, index) => {
+    for (const row of normalizedRows) {
+      const align = normalizeTableAlign(row[index].attrs.align);
+      if (align) return align;
+    }
+    return undefined;
+  });
+
+  const header = renderTableRow(normalizedRows[0].map((cell) => escapeTableCell(cell.inline)));
+  const divider = renderTableRow(columnAligns.map(tableDividerCell));
+  const body = normalizedRows
+    .slice(1)
+    .map((row) => renderTableRow(row.map((cell) => escapeTableCell(cell.inline))));
+
+  return [header, divider, ...body].join("\n");
+}
+
 function renderBlock(block: Block): string {
   switch (block.type) {
     case "heading": {
@@ -188,6 +258,8 @@ function renderBlock(block: Block): string {
       return block.lines.map(({ inline }) => `> ${inline}`).join("\n");
     case "code-block":
       return "```\n" + block.lines.map((l) => l.inline).join("\n") + "\n```";
+    case "table":
+      return renderTableBlock(block);
     case "paragraph":
     default: {
       // 仕様: リスト外の Quill indent は Md に出力しない(諦める)。
@@ -361,6 +433,50 @@ function appendListToken(ops: QuillOp[], list: Tokens.List, level: number): void
   }
 }
 
+type MarkedTableCell = {
+  text?: string;
+  tokens?: Tokens.Generic[];
+  align?: string | null;
+};
+
+type MarkedTableToken = Tokens.Generic & {
+  header?: MarkedTableCell[];
+  rows?: MarkedTableCell[][];
+  align?: Array<string | null>;
+};
+
+function appendTableCell(ops: QuillOp[], cell: MarkedTableCell | undefined): void {
+  if (cell?.tokens && cell.tokens.length > 0) {
+    appendInlineTokens(ops, cell.tokens, {});
+    return;
+  }
+  if (typeof cell?.text === "string") {
+    pushText(ops, decodeEntities(cell.text), {});
+  }
+}
+
+function appendTableToken(ops: QuillOp[], token: MarkedTableToken): void {
+  const header = Array.isArray(token.header) ? token.header : [];
+  const bodyRows = Array.isArray(token.rows) ? token.rows : [];
+  const rows = [header, ...bodyRows];
+  const columnCount = Math.max(1, ...rows.map((row) => row.length));
+  const align = Array.isArray(token.align) ? token.align : [];
+  const rowIdPrefix = `row-md-${ops.length + 1}`;
+
+  rows.forEach((row, rowIndex) => {
+    const rowId = `${rowIdPrefix}-${rowIndex + 1}`;
+    for (let columnIndex = 0; columnIndex < columnCount; columnIndex += 1) {
+      const cell = row[columnIndex];
+      const cellAlign = normalizeTableAlign(cell?.align ?? align[columnIndex]);
+      const attributes: QuillAttrs = cellAlign
+        ? { table: rowId, align: cellAlign }
+        : { table: rowId };
+      appendTableCell(ops, cell);
+      ops.push({ insert: "\n", attributes });
+    }
+  });
+}
+
 function appendBlockToken(ops: QuillOp[], token: Tokens.Generic): void {
   switch (token.type) {
     case "heading": {
@@ -401,6 +517,9 @@ function appendBlockToken(ops: QuillOp[], token: Tokens.Generic): void {
     }
     case "list":
       appendListToken(ops, token as Tokens.List, 0);
+      return;
+    case "table":
+      appendTableToken(ops, token as MarkedTableToken);
       return;
     case "html": {
       // 仕様外の HTML ブロックは生テキストとして取り込む。<u> はインラインで underline 化されるためここでは扱わない。

--- a/tests/component/Memo.test.js
+++ b/tests/component/Memo.test.js
@@ -13,8 +13,19 @@ vi.mock("quill", () => {
       this.options = options;
       this.root = document.createElement("div");
       this.root.className = "ql-editor";
+      this.toolbarContainer = document.createElement("div");
       this.theme = { tooltip: { hide: vi.fn() } };
       this.handlers = {};
+      this.tableModule = {
+        insertTable: vi.fn(),
+        insertRowAbove: vi.fn(),
+        insertRowBelow: vi.fn(),
+        insertColumnLeft: vi.fn(),
+        insertColumnRight: vi.fn(),
+        deleteRow: vi.fn(),
+        deleteColumn: vi.fn(),
+        deleteTable: vi.fn(),
+      };
       this.on = vi.fn((event, callback) => {
         this.handlers[event] = callback;
       });
@@ -28,7 +39,41 @@ vi.mock("quill", () => {
       this.setSelection = vi.fn();
       this.deleteText = vi.fn();
       this.insertText = vi.fn();
+      this.getModule = vi.fn((name) => {
+        if (name === "toolbar") return { container: this.toolbarContainer };
+        if (name === "table") return this.tableModule;
+        return null;
+      });
+      this.element?.appendChild(this.toolbarContainer);
       this.element?.appendChild(this.root);
+      for (const group of options.modules?.toolbar?.container ?? []) {
+        for (const control of Array.isArray(group) ? group : [group]) {
+          if (typeof control === "string") {
+            const button = document.createElement("button");
+            button.className = `ql-${control}`;
+            this.toolbarContainer.appendChild(button);
+            continue;
+          }
+          if (!control || typeof control !== "object") continue;
+          const [[format, value] = []] = Object.entries(control);
+          if (!format) continue;
+          if (Array.isArray(value)) {
+            const select = document.createElement("select");
+            select.className = `ql-${format}`;
+            for (const optionValue of value) {
+              const option = document.createElement("option");
+              option.value = optionValue === false ? "" : String(optionValue);
+              select.appendChild(option);
+            }
+            this.toolbarContainer.appendChild(select);
+            continue;
+          }
+          const button = document.createElement("button");
+          button.className = `ql-${format}`;
+          button.setAttribute("value", String(value));
+          this.toolbarContainer.appendChild(button);
+        }
+      }
       quillInstances.push(this);
     }
   }
@@ -63,6 +108,27 @@ async function renderMarkdownMemo(props = {}) {
   });
   await waitForMemoComponent();
   return result;
+}
+
+async function openMarkdownEditor(props = {}) {
+  await renderMarkdownMemo(props);
+  await fireEvent.click(document.querySelector(".edit-mode-btn"));
+  await waitFor(() => {
+    expect(document.querySelector(".cm-editor")).toBeInTheDocument();
+  });
+  return EditorView.findFromDOM(document.querySelector(".cm-editor"));
+}
+
+function markdownToolButton(label) {
+  return document.querySelector(`button[aria-label="${label}"]`);
+}
+
+async function chooseMarkdownTableAction(label) {
+  const select = document.querySelector('select[aria-label="Table"]');
+  expect(select).toBeInTheDocument();
+  const option = [...select.options].find((candidate) => candidate.textContent === label);
+  expect(option).toBeTruthy();
+  await fireEvent.change(select, { target: { value: option.value } });
 }
 
 describe("Memo mode routing", () => {
@@ -110,6 +176,47 @@ describe("Memo mode routing", () => {
     expect(document.querySelector(".preview h1")).toHaveTextContent("Markdown in db");
   });
 
+  test("uses a monospace-friendly font stack in the Markdown editor", async () => {
+    await openMarkdownEditor({ content: "| A | B |\n| --- | --- |\n| 1 | 2 |" });
+    const scroller = document.querySelector(".cm-scroller");
+
+    expect(getComputedStyle(scroller).fontFamily).toContain("BIZ UD");
+    expect(getComputedStyle(scroller).fontFamily).toContain("Consolas");
+  });
+
+  test("uses a Quill-like heading picker in the Markdown toolbar", async () => {
+    const view = await openMarkdownEditor({ content: "Title" });
+    const headingPicker = document.querySelector('select[aria-label="Heading"]');
+
+    expect(headingPicker).toBeInTheDocument();
+    expect(
+      [...document.querySelector(".toolbar").querySelectorAll("select, button")].map((control) =>
+        control.getAttribute("aria-label")
+      )
+    ).toEqual([
+      "Heading",
+      "Bold",
+      "Italic",
+      "Inline code",
+      "Link",
+      "Bullet list",
+      "Quote",
+      "Code block",
+      "Table",
+    ]);
+    expect(markdownToolButton("Heading 1")).not.toBeInTheDocument();
+    expect([...headingPicker.options].map((option) => option.value)).toEqual(["normal", "1", "2"]);
+    expect(markdownToolButton("Checklist")).not.toBeInTheDocument();
+    expect(markdownToolButton("表を挿入")).not.toBeInTheDocument();
+
+    await fireEvent.change(headingPicker, { target: { value: "2" } });
+    expect(view.state.doc.toString()).toBe("## Title");
+    expect(headingPicker.value).toBe("2");
+
+    await fireEvent.change(headingPicker, { target: { value: "normal" } });
+    expect(view.state.doc.toString()).toBe("Title");
+  });
+
   test("uses Quill editor for workspace memo when its format is quill", async () => {
     await renderMemo({
       saveMemo: vi.fn(),
@@ -120,6 +227,82 @@ describe("Memo mode routing", () => {
 
     expect(quillInstances).toHaveLength(1);
     expect(document.querySelector(".cm-editor")).not.toBeInTheDocument();
+    expect(quillInstances[0].options.modules.table).toBe(true);
+    expect(quillInstances[0].options.modules.toolbar.container).toEqual([
+      [{ header: [1, 2, false] }],
+      ["bold", "italic", "code"],
+      ["link", { list: "bullet" }, "blockquote", "code-block"],
+    ]);
+    expect(
+      quillInstances[0].toolbarContainer.querySelector('select[aria-label="Table"]')
+    ).toBeInTheDocument();
+  });
+
+  test("limits the Quill toolbar to shared Markdown-compatible controls", async () => {
+    await renderMemo({ saveMemo: vi.fn(), content: "", isWorkspaceProject: false });
+    const toolbar = JSON.stringify(quillInstances[0].options.modules.toolbar.container);
+
+    for (const unsupported of [
+      "font",
+      "color",
+      "background",
+      "underline",
+      "strike",
+      "script",
+      "indent",
+      "align",
+      "image",
+      "ordered",
+      "clean",
+    ]) {
+      expect(toolbar).not.toContain(unsupported);
+    }
+
+    expect(toolbar).toContain("header");
+    expect(toolbar).toContain("bold");
+    expect(toolbar).toContain("italic");
+    expect(toolbar).toContain("code");
+    expect(toolbar).toContain("blockquote");
+    expect(toolbar).toContain("bullet");
+    expect(toolbar).toContain("link");
+    expect(quillInstances[0].toolbarContainer.querySelectorAll("button.ql-table")).toHaveLength(0);
+    expect(
+      quillInstances[0].toolbarContainer.querySelector('select[aria-label="Table"]')
+    ).toBeInTheDocument();
+  });
+
+  test("uses a Quill table dropdown with all table actions", async () => {
+    await renderMemo({ saveMemo: vi.fn(), content: "", isWorkspaceProject: false });
+    const select = quillInstances[0].toolbarContainer.querySelector('select[aria-label="Table"]');
+
+    expect(select).toBeInTheDocument();
+    expect([...select.options].map((option) => option.textContent)).toEqual([
+      "Table",
+      "表を挿入",
+      "行を上に追加",
+      "行を下に追加",
+      "列を左に追加",
+      "列を右に追加",
+      "行を削除",
+      "列を削除",
+      "表を削除",
+    ]);
+    expect(quillInstances[0].toolbarContainer.querySelectorAll("button.ql-table")).toHaveLength(0);
+
+    await fireEvent.change(select, { target: { value: "delete-column" } });
+
+    expect(quillInstances[0].tableModule.deleteColumn).toHaveBeenCalledTimes(1);
+    expect(select.value).toBe("");
+  });
+
+  test("adds distinct Quill inline and block code toolbar buttons", async () => {
+    await renderMemo({ saveMemo: vi.fn(), content: "", isWorkspaceProject: false });
+    const inlineCode = quillInstances[0].toolbarContainer.querySelector("button.ql-code");
+    const codeBlock = quillInstances[0].toolbarContainer.querySelector("button.ql-code-block");
+
+    expect(inlineCode).toHaveAttribute("title", "インラインコード");
+    expect(codeBlock).toHaveAttribute("title", "コードブロック");
+    expect(inlineCode.innerHTML).not.toBe(codeBlock.innerHTML);
   });
 
   test("db.json Projects save Quill Delta content", async () => {
@@ -131,6 +314,51 @@ describe("Memo mode routing", () => {
     await tick();
 
     expect(saveMemo).toHaveBeenCalledWith({ ops: [{ insert: "changed\n" }] });
+  });
+
+  test("does not reapply matching Quill Delta after a user edit", async () => {
+    const saveMemo = vi.fn();
+    const result = await renderMemo({
+      saveMemo,
+      content: { ops: [{ insert: "before\n" }] },
+      isWorkspaceProject: false,
+    });
+    const quill = quillInstances.at(-1);
+
+    try {
+      vi.useFakeTimers();
+      class MockDelta {
+        constructor(ops) {
+          this.ops = ops;
+        }
+      }
+
+      quill.setContents.mockClear();
+      quill.setSelection.mockClear();
+      quill.hasFocus = vi.fn(() => true);
+      quill.getSelection = vi.fn(() => ({ index: 8, length: 0 }));
+      quill.getLength = vi.fn(() => 9);
+      quill.getContents = vi.fn(() => new MockDelta([{ insert: "changed\n" }]));
+
+      quill.handlers["text-change"]({}, {}, "user");
+      await tick();
+
+      expect(saveMemo).toHaveBeenCalledWith({ ops: [{ insert: "changed\n" }] });
+
+      await result.rerender({
+        saveMemo,
+        content: { ops: [{ insert: "changed\n" }] },
+        isWorkspaceProject: false,
+      });
+      await tick();
+      vi.advanceTimersByTime(150);
+      await tick();
+
+      expect(quill.setContents).not.toHaveBeenCalled();
+      expect(quill.setSelection).not.toHaveBeenCalled();
+    } finally {
+      vi.useRealTimers();
+    }
   });
 });
 
@@ -235,6 +463,109 @@ describe("Markdown Memo - edit mode", () => {
     await waitFor(() => {
       expect(document.querySelector(".cm-editor")).toBeInTheDocument();
     });
+  });
+
+  test("inserts a Markdown table from the edit toolbar", async () => {
+    const view = await openMarkdownEditor({ saveMemo, content: "" });
+
+    await chooseMarkdownTableAction("表を挿入");
+    await tick();
+
+    expect(view.state.doc.toString()).toBe(
+      "| Column 1 | Column 2 |\n| -------- | -------- |\n|          |          |"
+    );
+  });
+
+  test("edits Markdown table rows and columns from the edit toolbar", async () => {
+    const initialTable = "| A | B |\n| --- | --- |\n| 1 | 2 |";
+    const view = await openMarkdownEditor({ saveMemo, content: initialTable });
+
+    view.dispatch({ selection: { anchor: initialTable.indexOf("2") } });
+    await chooseMarkdownTableAction("列を右に追加");
+    await tick();
+    expect(view.state.doc.toString()).toBe(
+      "| A   | B   |     |\n| --- | --- | --- |\n| 1   | 2   |     |"
+    );
+
+    await chooseMarkdownTableAction("列を削除");
+    await tick();
+    expect(view.state.doc.toString()).toBe("| A   | B   |\n| --- | --- |\n| 1   | 2   |");
+
+    await chooseMarkdownTableAction("行を下に追加");
+    await tick();
+    expect(view.state.doc.toString()).toBe(
+      "| A   | B   |\n| --- | --- |\n| 1   | 2   |\n|     |     |"
+    );
+
+    await chooseMarkdownTableAction("行を削除");
+    await tick();
+    expect(view.state.doc.toString()).toBe("| A   | B   |\n| --- | --- |\n| 1   | 2   |");
+
+    await chooseMarkdownTableAction("表を削除");
+    await tick();
+    expect(view.state.doc.toString()).toBe("");
+  });
+
+  test("inserts Markdown table rows above and columns left from the edit toolbar", async () => {
+    const initialTable = "| A | B |\n| --- | --- |\n| 1 | 2 |";
+    const view = await openMarkdownEditor({ saveMemo, content: initialTable });
+
+    view.dispatch({ selection: { anchor: initialTable.indexOf("2") } });
+    await chooseMarkdownTableAction("行を上に追加");
+    await tick();
+    expect(view.state.doc.toString()).toBe(
+      "| A   | B   |\n| --- | --- |\n|     |     |\n| 1   | 2   |"
+    );
+
+    await chooseMarkdownTableAction("列を左に追加");
+    await tick();
+    expect(view.state.doc.toString()).toBe(
+      "| A   |     | B   |\n| --- | --- | --- |\n|     |     |     |\n| 1   |     | 2   |"
+    );
+  });
+
+  test("keeps Markdown table controls working for one-column tables", async () => {
+    const initialTable = "| A |\n| --- |\n| 1 |";
+    const view = await openMarkdownEditor({ saveMemo, content: initialTable });
+
+    view.dispatch({ selection: { anchor: initialTable.indexOf("1") } });
+    await chooseMarkdownTableAction("行を下に追加");
+    await tick();
+    expect(view.state.doc.toString()).toBe("| A   |\n| --- |\n| 1   |\n|     |");
+
+    await chooseMarkdownTableAction("列を右に追加");
+    await tick();
+    expect(view.state.doc.toString()).toBe(
+      "| A   |     |\n| --- | --- |\n| 1   |     |\n|     |     |"
+    );
+
+    await chooseMarkdownTableAction("列を削除");
+    await tick();
+    expect(view.state.doc.toString()).toBe("| A   |\n| --- |\n| 1   |\n|     |");
+
+    await chooseMarkdownTableAction("行を削除");
+    await tick();
+    expect(view.state.doc.toString()).toBe("| A   |\n| --- |\n| 1   |");
+
+    await chooseMarkdownTableAction("表を削除");
+    await tick();
+    expect(view.state.doc.toString()).toBe("");
+  });
+
+  test("formats Markdown tables and moves cells with Tab", async () => {
+    const initialTable = "| Name | 値 |\n| --- | --- |\n| A | 12 |";
+    const view = await openMarkdownEditor({ saveMemo, content: initialTable });
+
+    view.dispatch({ selection: { anchor: initialTable.indexOf("12") } });
+    await fireEvent.keyDown(view.contentDOM, { key: "Tab" });
+    await tick();
+
+    expect(view.state.doc.toString()).toBe(
+      "| Name | 値  |\n| ---- | --- |\n| A    | 12  |\n|      |     |"
+    );
+
+    const newRowCellPosition = view.state.doc.toString().lastIndexOf("|      |");
+    expect(view.state.selection.main.from).toBeGreaterThan(newRowCellPosition);
   });
 
   test("suggests memo titles after a wiki-link opener", async () => {

--- a/tests/unit/memo_conversion.test.ts
+++ b/tests/unit/memo_conversion.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect } from "vitest";
 import {
+  convertMemoContent,
   markdownToQuillDelta,
   quillDeltaToMarkdown,
   type QuillDelta,
@@ -105,6 +106,15 @@ describe("Markdown ↔ Quill Delta — inline formatting", () => {
     const d = markdownToQuillDelta(md);
     expect(ops(d)).toEqual([{ insert: "code", attributes: { code: true } }, { insert: "\n" }]);
     expect(quillDeltaToMarkdown(d)).toBe(md);
+  });
+
+  it("convertMemoContent preserves inline code and fenced code blocks", () => {
+    const md = "`code`\n\n```\nline\n```";
+    const delta = convertMemoContent(md, "markdown", "quill") as QuillDelta;
+
+    expect(delta.ops).toContainEqual({ insert: "code", attributes: { code: true } });
+    expect(delta.ops).toContainEqual({ insert: "\n", attributes: { "code-block": true } });
+    expect(convertMemoContent(delta, "quill", "markdown")).toBe(md);
   });
 
   it("link", () => {
@@ -254,6 +264,55 @@ describe("Markdown ↔ Quill Delta — combined", () => {
   it("blockquote then list", () => {
     const md = "> quote\n\n- A\n- B";
     expect(roundTripMd(md)).toBe(md);
+  });
+});
+
+describe("Markdown <-> Quill Delta - table", () => {
+  it("converts a GFM table into Quill table rows", () => {
+    const md = "| Name | Count |\n| --- | ---: |\n| **A** | 1 |\n| B | 2 |";
+    const d = markdownToQuillDelta(md);
+
+    expect(ops(d)).toEqual([
+      { insert: "Name" },
+      { insert: "\n", attributes: { table: "row-md-1-1" } },
+      { insert: "Count" },
+      { insert: "\n", attributes: { table: "row-md-1-1", align: "right" } },
+      { insert: "A", attributes: { bold: true } },
+      { insert: "\n", attributes: { table: "row-md-1-2" } },
+      { insert: "1" },
+      { insert: "\n", attributes: { table: "row-md-1-2", align: "right" } },
+      { insert: "B" },
+      { insert: "\n", attributes: { table: "row-md-1-3" } },
+      { insert: "2" },
+      { insert: "\n", attributes: { table: "row-md-1-3", align: "right" } },
+    ]);
+    expect(quillDeltaToMarkdown(d)).toBe(md);
+  });
+
+  it("converts native Quill table attributes to GFM table Markdown", () => {
+    const d: QuillDelta = {
+      ops: [
+        { insert: "Task" },
+        { insert: "\n", attributes: { table: "row-a" } },
+        { insert: "Done" },
+        { insert: "\n", attributes: { table: "row-a", align: "center" } },
+        { insert: "One" },
+        { insert: "\n", attributes: { table: "row-b" } },
+        { insert: "Yes" },
+        { insert: "\n", attributes: { table: "row-b", align: "center" } },
+      ],
+    };
+
+    expect(quillDeltaToMarkdown(d)).toBe("| Task | Done |\n| --- | :---: |\n| One | Yes |");
+    expectDeltaSemEqual(roundTripDelta(d), d);
+  });
+
+  it("convertMemoContent preserves GFM tables between Markdown and Quill formats", () => {
+    const md = "| Name | Count |\n| --- | ---: |\n| A | 1 |";
+    const delta = convertMemoContent(md, "markdown", "quill") as QuillDelta;
+
+    expect(delta.ops.some((op) => op.attributes?.table)).toBe(true);
+    expect(convertMemoContent(delta, "quill", "markdown")).toBe(md);
   });
 });
 

--- a/tests/unit/workspace.test.js
+++ b/tests/unit/workspace.test.js
@@ -1228,6 +1228,25 @@ describe("migrateProjectData", () => {
     expect(memoFile).not.toContain('"ops"');
   });
 
+  it("exports Quill table Delta content as GFM Markdown table", () => {
+    const delta = {
+      ops: [
+        { insert: "Task" },
+        { insert: "\n", attributes: { table: "row-a" } },
+        { insert: "Done" },
+        { insert: "\n", attributes: { table: "row-a", align: "center" } },
+        { insert: "One" },
+        { insert: "\n", attributes: { table: "row-b" } },
+        { insert: "Yes" },
+        { insert: "\n", attributes: { table: "row-b", align: "center" } },
+      ],
+    };
+
+    expect(legacyMemoContentToMarkdown(delta, "Table")).toBe(
+      "| Task | Done |\n| --- | :---: |\n| One | Yes |"
+    );
+  });
+
   it("exports memo format unchanged by default", () => {
     const delta = { ops: [{ insert: "Keep rich\n", attributes: { italic: true } }] };
     const projectData = {


### PR DESCRIPTION
## Summary

- Align the Markdown and Quill memo toolbars to the shared Markdown-compatible formatting set and ordering.
- Move table operations into a single Table dropdown in both editors.
- Add Markdown table editing/formatting behavior and Markdown <-> Quill table conversion support, including workspace export coverage.

## Validation

- `svelte-check --tsconfig .\tsconfig.json`
- `vitest run tests\component\Memo.test.js tests\unit\memo_conversion.test.ts tests\unit\workspace.test.js --pool=threads`
- `prettier --check electron\workspace.js src\features\memos\components\MarkdownMemo.svelte src\features\memos\components\QuillMemo.svelte src\features\memos\utils\memo_utils.ts tests\component\Memo.test.js tests\unit\memo_conversion.test.ts tests\unit\workspace.test.js`
- `git diff --check --cached`
- `vite build`
- push pre-hook: `npm run lint`, `npm run format:check`, `npm run test` (454 passed, 7 skipped)

## Notes

This branch is based directly on the latest `origin/main` and contains one commit for easier rebase/review.