### PR TITLE
perf(workspace): avoid full-tree re-hash on each reconcile

### DIFF
--- a/electron/workspace-reconciler.js
+++ b/electron/workspace-reconciler.js
@@ -48,35 +48,6 @@ async function collectFileHashes(rootDir) {
   return result;
 }
 
-function collectFileHashesSync(rootDir) {
-  const result = new Map();
-
-  function walk(dir) {
-    let entries = [];
-    try {
-      entries = fs.readdirSync(dir, { withFileTypes: true });
-    } catch {
-      return;
-    }
-
-    for (const entry of entries) {
-      const fullPath = path.join(dir, entry.name);
-      if (entry.isDirectory()) {
-        walk(fullPath);
-      } else if (entry.isFile() && !entry.name.includes(".tmp")) {
-        try {
-          result.set(fullPath, hashBuffer(fs.readFileSync(fullPath)));
-        } catch {
-          // Ignore files that disappear during a scan.
-        }
-      }
-    }
-  }
-
-  walk(rootDir);
-  return result;
-}
-
 function isFileWithinDir(filePath, dirPath) {
   const dir = path.resolve(dirPath);
   const file = path.resolve(filePath);
@@ -115,6 +86,11 @@ class WorkspaceReconciler {
     // "external update" / "conflict" notifications.
     this.knownFileHashes = new Map();
     this.projectTimers = new Map();
+    // projectDir -> Set<resolvedPath>. The files whose watcher events have
+    // accumulated since the last reconcile for that project. Consumed (and
+    // cleared) when the debounced reconcile fires; used to re-verify only the
+    // paths that actually changed instead of re-hashing the whole project.
+    this.pendingChangedPaths = new Map();
     this.workspacePath = null;
     this.watcher = null;
   }
@@ -147,6 +123,7 @@ class WorkspaceReconciler {
       clearTimeout(timer);
     }
     this.projectTimers.clear();
+    this.pendingChangedPaths.clear();
 
     if (this.watcher) {
       await this.watcher.close();
@@ -259,7 +236,17 @@ class WorkspaceReconciler {
     const projectDir = this.resolveProjectDir(resolvedPath);
     if (!projectDir) return;
 
+    this.trackPendingChange(projectDir, resolvedPath);
     this.scheduleProjectReconcile(projectDir);
+  }
+
+  trackPendingChange(projectDir, resolvedPath) {
+    let paths = this.pendingChangedPaths.get(projectDir);
+    if (!paths) {
+      paths = new Set();
+      this.pendingChangedPaths.set(projectDir, paths);
+    }
+    paths.add(resolvedPath);
   }
 
   scheduleProjectReconcile(projectDir) {
@@ -277,12 +264,18 @@ class WorkspaceReconciler {
   }
 
   async reconcileProject(projectDir) {
-    // Re-check at reconcile time: if everything matches knownFileHashes by
-    // now, the triggering event was stale (e.g. raced with our own write
-    // batch that has since completed and called markProjectWritten). This
-    // check is intentionally synchronous so the subsequent side effects
+    const changedPaths = this.pendingChangedPaths.get(projectDir);
+    this.pendingChangedPaths.delete(projectDir);
+
+    // Re-check at reconcile time: if every path that triggered this reconcile
+    // now matches knownFileHashes, the triggering events were stale (e.g. they
+    // raced with our own write batch that has since completed and called
+    // markProjectWritten). Only the changed paths can have diverged, so we
+    // verify just those instead of re-hashing the whole project on the main
+    // thread — keeping large workspaces from janking the UI on every event.
+    // This check is intentionally synchronous so the subsequent side effects
     // (onConflict / onProjectUpdated) run before any await yields control.
-    if (this.projectMatchesKnown(projectDir)) {
+    if (changedPaths && changedPaths.size > 0 && this.changedPathsMatchKnown(changedPaths)) {
       return;
     }
 
@@ -332,33 +325,29 @@ class WorkspaceReconciler {
     }
   }
 
-  projectMatchesKnown(projectDir) {
-    const resolvedProject = path.resolve(projectDir);
-    let currentHashes;
-    try {
-      currentHashes = collectFileHashesSync(projectDir);
-    } catch {
-      return false;
-    }
-
-    if (currentHashes.size !== this.countKnownFilesIn(resolvedProject)) {
-      return false;
-    }
-
-    for (const [filePath, hash] of currentHashes) {
-      if (this.knownFileHashes.get(path.resolve(filePath)) !== hash) {
+  /**
+   * Return true iff every changed path matches its recorded hash (treating a
+   * missing file and an untracked file as equal "absent" states). A mismatch —
+   * a modified file, a deleted file we knew about, a newly added file, or a
+   * read error — returns false so the caller proceeds to reconcile. Reads only
+   * the handful of files that triggered the reconcile; no full-tree walk.
+   */
+  changedPathsMatchKnown(changedPaths) {
+    for (const filePath of changedPaths) {
+      const resolved = path.resolve(filePath);
+      const known = this.knownFileHashes.get(resolved) ?? null;
+      let current = null;
+      try {
+        if (fs.existsSync(resolved)) {
+          current = hashBuffer(fs.readFileSync(resolved));
+        }
+      } catch {
+        // Cannot read it right now — treat as divergence and reconcile.
         return false;
       }
+      if (current !== known) return false;
     }
     return true;
-  }
-
-  countKnownFilesIn(resolvedProjectDir) {
-    let count = 0;
-    for (const filePath of this.knownFileHashes.keys()) {
-      if (isFileWithinDir(filePath, resolvedProjectDir)) count += 1;
-    }
-    return count;
   }
 
   resolveProjectDir(filePath) {

--- a/tests/unit/workspace-reconciler.test.js
+++ b/tests/unit/workspace-reconciler.test.js
@@ -234,6 +234,46 @@ describe("WorkspaceReconciler", () => {
     await reconciler.stop();
   });
 
+  test("skips reconcile when the changed file matches known by the time the debounced reconcile fires", async () => {
+    // Race scenario covered by the targeted re-check: at event time the file
+    // diverged from known (so a reconcile is scheduled), but before the
+    // debounced timer fires our own write records the new hash, so the changed
+    // path now matches known. The reconcile must bail out without reading the
+    // project (and without re-hashing the whole tree).
+    const { projectDir } = createProject(tmpDir, "Proj", "root-id");
+    const projectFile = path.join(projectDir, "_project.md");
+    const updates = [];
+    const conflicts = [];
+    const notices = [];
+    const reconciler = new WorkspaceReconciler({
+      readProject: () => {
+        throw new Error("should not read when the changed path matches known");
+      },
+      hasPendingWrite: () => true,
+      onProjectUpdated: (event) => updates.push(event),
+      onConflict: (event) => conflicts.push(event),
+      onNotice: (event) => notices.push(event),
+      stateRootDir: stateDir,
+      watchFactory: () => makeWatcher(),
+    });
+    await reconciler.start(tmpDir);
+
+    // Diverge on disk so handleFileEvent schedules a reconcile (known still
+    // holds the original baseline at this point).
+    const updated = stringifyFrontmatter({ id: "root-id", name: "Updated" });
+    fs.writeFileSync(projectFile, updated);
+    await reconciler.handleFileEvent("change", projectFile);
+
+    // Before the debounced reconcile fires, our own write records the new hash.
+    reconciler.recordWrite(projectFile, updated);
+    await vi.runAllTimersAsync();
+
+    expect(updates).toEqual([]);
+    expect(conflicts).toEqual([]);
+    expect(notices.map((event) => event.kind)).not.toContain("error");
+    await reconciler.stop();
+  });
+
   test("markProjectWritten clears entries for files that no longer exist", async () => {
     const { projectDir } = createProject(tmpDir, "Proj", "root-id");
     const projectFile = path.join(projectDir, "_project.md");


### PR DESCRIPTION
## 概要

`WorkspaceReconciler.reconcileProject` が、変更イベントが stale かどうかを判定するためだけに、プロジェクト配下の**全ファイルを同期的に再ハッシュ**していました（`collectFileHashesSync`）。大規模プロジェクト + 同期フォルダ（OneDrive 等）の頻繁な touch では、イベントのたびに main プロセスがブロックし UI がカクつく原因になっていました。

## 変更内容

「実際に reconcile を起こしたファイルだけを再検証する」方式へ変更しました。

- `handleFileEvent` が genuine と判定したパスを `pendingChangedPaths`（`projectDir → Set<path>`）に蓄積
- `reconcileProject` 発火時に、その蓄積パスだけを `changedPathsMatchKnown` で同期検証する。変更があったファイルだけが known と乖離し得るため、これで十分かつ正確
- 全走査用の `projectMatchesKnown` / `countKnownFilesIn` / `collectFileHashesSync`（いずれも内部専用・未エクスポート）を撤去

## 保たれている性質

- 「`await` の前に同期で stale/real を確定する」レース回避の設計はそのまま維持
- ファイル削除（known にあったが消えた）・新規追加・内容変更・自前書込による一致（stale）の各ケースを、「不在 ⇔ 不在は一致」とみなす比較で正しく判定
- `recordWrite` による `knownFileHashes` 同期更新と偽陽性抑止も従来どおり機能

## テスト

- 新規テスト「イベント発火時は差分があったが、reconcile 発火までに自分の書込が記録され一致した場合は reconcile をスキップする」を追加
- 既存 reconciler テスト全パス、workspace 系 90 件、全体 468 passed / 7 skipped、lint クリーン

https://claude.ai/code/session_013inbiQ8fTE7YS4wa4nVAeo

---
_Generated by [Claude Code](https://claude.ai/code/session_013inbiQ8fTE7YS4wa4nVAeo)_