### PR TITLE
perf(tree): cache resizer content height instead of remeasuring on every scroll

### DIFF
--- a/src/features/tasks/components/TreeTable.svelte
+++ b/src/features/tasks/components/TreeTable.svelte
@@ -248,16 +248,31 @@
     if (taskFolderOpenErrorTimer) clearTimeout(taskFolderOpenErrorTimer);
   });
 
-  const syncResizerBounds = (targetResizers = resizers) => {
+  // Cached total height of all table rows. Measuring it walks every row with
+  // getBoundingClientRect (O(rows) forced reflow), so we only re-measure when
+  // rows or the container actually change — not on every scroll tick.
+  let cachedResizerContentHeight = 0;
+
+  const measureResizerContentHeight = () => {
+    if (!table_root) return 0;
+    const tableRows = Array.from(table_root.querySelectorAll(".TableRow"));
+    cachedResizerContentHeight = tableRows.reduce(
+      (height, row) => height + row.getBoundingClientRect().height,
+      0
+    );
+    return cachedResizerContentHeight;
+  };
+
+  // `remeasure` defaults to true so structural callers (createResizers, the
+  // ResizeObserver, column/row mutations) always reflect the latest layout.
+  // The scroll handler passes `false`: scrolling changes only the resizers'
+  // top/height derived from scrollTop, never the content height itself.
+  const syncResizerBounds = (targetResizers = resizers, { remeasure = true } = {}) => {
     if (!table_root) {
       return;
     }
 
-    const tableRows = Array.from(table_root.querySelectorAll(".TableRow"));
-    const contentHeight = tableRows.reduce(
-      (height, row) => height + row.getBoundingClientRect().height,
-      0
-    );
+    const contentHeight = remeasure ? measureResizerContentHeight() : cachedResizerContentHeight;
     const top = table_root.scrollTop;
     const height = Math.max(0, Math.min(table_root.clientHeight, contentHeight - top));
 
@@ -551,7 +566,9 @@
   function handleScroll(event) {
     scrollTop = event.currentTarget.scrollTop;
     $ganttScrollTop = scrollTop;
-    syncResizerBounds(resizers);
+    // Scrolling only shifts the resizers vertically; the content height is
+    // unchanged, so reuse the cached measurement instead of re-walking rows.
+    syncResizerBounds(resizers, { remeasure: false });
   }
 
   function handleToggleRow(event) {


### PR DESCRIPTION
## 概要

「無駄に高頻度に重い計算をしている箇所」の調査で見つかった 1 件を修正します。

`TreeTable.svelte` の `handleScroll` は**スクロールのたびに** `syncResizerBounds` を呼んでおり、その中で `querySelectorAll('.TableRow')` + 全行に対する `getBoundingClientRect()` を実行して全行の高さ合計（`contentHeight`）を算出していました。これは **スクロール 1 ティックごとに O(行数) の強制レイアウト（reflow）** を発生させます。

しかしスクロールでは `contentHeight` は変化せず、変わるのは `scrollTop` から導かれる各リサイザ（列の縦仕切りガイド）の `top` / `height` だけです。つまり毎回の全行再計測は完全に無駄でした。

## 変更内容

- `contentHeight` をキャッシュ（`cachedResizerContentHeight`）し、計測を `measureResizerContentHeight()` に分離
- `syncResizerBounds(targetResizers, { remeasure = true })` を導入
  - **構造が変わる呼び出し元**（`createResizers`、`ResizeObserver`、列/行変更を捕捉する `MutationObserver` 経由）は既定の `remeasure: true` で従来どおり再計測
  - **`handleScroll` のみ `remeasure: false`** とし、キャッシュ済み高さを再利用（reflow なし）

`contentHeight` が実際に変わる契機（行の増減・展開折りたたみ・フィルタ・列増減・コンテナリサイズ）はすべて `MutationObserver`（`childList: true, subtree: true`）と `ResizeObserver` 経由で `createResizers → syncResizerBounds(remeasure)` を通るため、スクロール経路だけをキャッシュ化しても表示は従来と一致します。

## 調査メモ（誤検出を除外）

あわせて他の高頻度ハンドラも確認しましたが、いずれも**既に対策済み**で変更不要でした。
- Gantt `updateDragFromPointer`: 非 create ドラッグは `if (delta === dragState.lastDelta) return` でガード済み
- SplitPanes の resize `mousemove`: rect/サイズは mousedown 時に取得済みで、move 中は算術＋直接 style 書き込みのみ（reflow なし）
- tooltip の `sweepTooltips`（scroll/wheel/mousedown 登録）: `if (activeTooltips.size === 0) return` で未表示時は即 return 済み
- tooltip `handleMouseMove`: スタイル 2 プロパティ更新のみ
- TreeTable の sticky パンくず: PR #209 でメモ化済み

## テスト

このパスは DOM レイアウト（jsdom では `getBoundingClientRect` が 0 を返す）に依存し、振る舞いは「スクロール時にキャッシュを使う」という内部最適化で出力は不変のため、専用ユニットテストは追加していません。既存の component / unit テスト（TreeTable 含む）が全て通過することで回帰がないことを担保しています。

## 検証

- `svelte-check`: 0 errors / 0 warnings、ESLint: 指摘なし
- unit 333 passed / component 137 passed（7 skip）

https://claude.ai/code/session_013inbiQ8fTE7YS4wa4nVAeo

---
_Generated by [Claude Code](https://claude.ai/code/session_013inbiQ8fTE7YS4wa4nVAeo)_