### PR TITLE
perf(workspace): async read paths so slow disk can't freeze the whole UI

### DIFF
--- a/electron/index.js
+++ b/electron/index.js
@@ -278,6 +278,22 @@ app.on("ready", () => {
     return workspace.readProject(projectDir, { includeMemoContent: false });
   }
 
+  // Async mirror used by interactive IPC handlers so a slow disk does not block
+  // the main event loop (which would freeze ALL IPC, window controls included).
+  function readProjectSummaryAsync(projectDir) {
+    return workspace.readProjectAsync(projectDir, { includeMemoContent: false });
+  }
+
+  async function ensureWorkspaceCacheAsync(projectDir) {
+    let cached = wsCache.get(projectDir);
+    if (!cached) {
+      const { tasks, taskDirs } = await readProjectSummaryAsync(projectDir);
+      cached = { tasks, taskDirs };
+      wsCache.set(projectDir, cached);
+    }
+    return cached;
+  }
+
   function ensureWorkspaceCache(projectDir) {
     let cached = wsCache.get(projectDir);
     if (!cached) {
@@ -381,7 +397,7 @@ app.on("ready", () => {
     return nextCached;
   }
 
-  function readWorkspaceProjectForRenderer(projectDir) {
+  async function readWorkspaceProjectForRendererAsync(projectDir) {
     const cached = wsCache.get(projectDir);
     if (
       cached &&
@@ -390,7 +406,7 @@ app.on("ready", () => {
       return cached;
     }
 
-    const { tasks, taskDirs } = readProjectSummary(projectDir);
+    const { tasks, taskDirs } = await readProjectSummaryAsync(projectDir);
     const fresh = { tasks, taskDirs };
     wsCache.set(projectDir, fresh);
     optimisticWorkspaceProjectDirs.delete(projectDir);
@@ -1056,7 +1072,7 @@ app.on("ready", () => {
 
   ipcMain.handle("ws:list-projects", async (event, { workspacePath }) => {
     try {
-      return workspace.listProjects(workspacePath);
+      return await workspace.listProjectsAsync(workspacePath);
     } catch (err) {
       log.error("ws:list-projects error:", err.message);
       return [];
@@ -1107,9 +1123,9 @@ app.on("ready", () => {
         await workspaceWriteQueue.flush();
       }
 
-      let cached = ensureWorkspaceCache(projectDir);
+      let cached = await ensureWorkspaceCacheAsync(projectDir);
       if (!cached.taskDirs?.has(taskId)) {
-        const { tasks, taskDirs } = readProjectSummary(projectDir);
+        const { tasks, taskDirs } = await readProjectSummaryAsync(projectDir);
         cached = { tasks, taskDirs };
         wsCache.set(projectDir, cached);
       }
@@ -1161,7 +1177,7 @@ app.on("ready", () => {
 
   ipcMain.handle("ws:read-project", async (event, { projectDir }) => {
     try {
-      const { tasks } = readWorkspaceProjectForRenderer(projectDir);
+      const { tasks } = await readWorkspaceProjectForRendererAsync(projectDir);
       // Map 竊・plain object for IPC serialisation
       return { tasks: Object.fromEntries(tasks) };
     } catch (err) {
@@ -1172,8 +1188,8 @@ app.on("ready", () => {
 
   ipcMain.handle("ws:read-task-memos", async (event, { projectDir, taskId }) => {
     try {
-      const cached = ensureWorkspaceCache(projectDir);
-      const memos = workspace.readTaskMemos(projectDir, taskId, cached.taskDirs);
+      const cached = await ensureWorkspaceCacheAsync(projectDir);
+      const memos = await workspace.readTaskMemosAsync(projectDir, taskId, cached.taskDirs);
       const task = cached.tasks.get(taskId);
       if (task) {
         task.memos = memos;
@@ -1187,16 +1203,22 @@ app.on("ready", () => {
 
   ipcMain.handle("ws:read-project-memos", async (event, { projectDir }) => {
     try {
-      const cached = ensureWorkspaceCache(projectDir);
+      const cached = await ensureWorkspaceCacheAsync(projectDir);
       const memosByTaskId = {};
-      for (const taskId of cached.taskDirs.keys()) {
-        const memos = workspace.readTaskMemos(projectDir, taskId, cached.taskDirs);
+      // Read every task's memos concurrently so per-file disk latency overlaps
+      // instead of serializing on the main event loop.
+      const taskIds = [...cached.taskDirs.keys()];
+      const memosList = await Promise.all(
+        taskIds.map((taskId) => workspace.readTaskMemosAsync(projectDir, taskId, cached.taskDirs))
+      );
+      taskIds.forEach((taskId, index) => {
+        const memos = memosList[index];
         memosByTaskId[taskId] = memos;
         const task = cached.tasks.get(taskId);
         if (task) {
           task.memos = memos;
         }
-      }
+      });
       return { memosByTaskId };
     } catch (err) {
       log.error("ws:read-project-memos error:", err.message);
@@ -1458,7 +1480,7 @@ app.on("ready", () => {
       }
 
       workspaceWriteQueue.discard(projectDir);
-      const { tasks, taskDirs } = workspace.readProject(projectDir);
+      const { tasks, taskDirs } = await workspace.readProjectAsync(projectDir);
       wsCache.set(projectDir, { tasks, taskDirs });
       optimisticWorkspaceProjectDirs.delete(projectDir);
       sendWorkspaceProjectUpdated({
@@ -1484,7 +1506,7 @@ app.on("ready", () => {
     const selected = result.filePaths[0];
     let entries;
     try {
-      entries = fs.readdirSync(selected, { withFileTypes: true });
+      entries = await fs.promises.readdir(selected, { withFileTypes: true });
     } catch (err) {
       log.error("ws:select-directory readdir error:", err.message);
       return {
@@ -1494,7 +1516,7 @@ app.on("ready", () => {
     }
 
     const isEmpty = entries.length === 0;
-    const hasProjects = workspace.listProjects(selected).length > 0;
+    const hasProjects = (await workspace.listProjectsAsync(selected)).length > 0;
 
     if (!isEmpty && !hasProjects) {
       return {

--- a/electron/workspace.js
+++ b/electron/workspace.js
@@ -950,6 +950,224 @@ function readTaskMemos(projectDir, taskId, taskDirs) {
   });
 }
 
+// ── Async read mirrors ───────────────────────────────────────────────────
+// The sync readers above stay for batch/export, the reconciler, inbox helpers
+// and tests. The async mirrors below are used by the interactive IPC handlers
+// so that slow disks (e.g. OneDrive) cannot block the main process event loop —
+// which would otherwise stall *all* IPC, including window controls, and freeze
+// the whole UI. They use fs.promises and read sibling files concurrently.
+
+async function readFilePrefixAsync(filePath, maxBytes = 16 * 1024) {
+  const fh = await fs.promises.open(filePath, "r");
+  try {
+    const buffer = Buffer.alloc(maxBytes);
+    const { bytesRead } = await fh.read(buffer, 0, maxBytes, 0);
+    return buffer.subarray(0, bytesRead).toString("utf8");
+  } finally {
+    await fh.close();
+  }
+}
+
+function buildMemoEntry(file, fileIndex, raw, includeMemoContent) {
+  const { data, body } = parseFrontmatter(raw);
+  const id = data.id || crypto.randomUUID();
+  const headingMatch = body.match(/^#\s+(.+)/m);
+  const fileTitle = file.replace(/\.md$/, "");
+  let title = data.title;
+  if (!title) {
+    if (headingMatch) {
+      title = headingMatch[1].trim();
+    } else {
+      title = data.id === fileTitle ? "memo" : fileTitle;
+    }
+  }
+  const tags = Array.isArray(data.tags) ? data.tags.map(String) : [];
+  const format = normalizeMemoFormat(data.format, "markdown");
+  const content = includeMemoContent
+    ? format === "quill"
+      ? parseQuillMemoBody(body)
+      : body.trim()
+    : "";
+  return {
+    id,
+    title,
+    content,
+    tags,
+    format,
+    order: parseOrderValue(data.order),
+    bodyLoaded: includeMemoContent,
+    fileIndex,
+  };
+}
+
+function sortMemoEntries(memos) {
+  return memos
+    .sort((a, b) => {
+      const aHasOrder = typeof a.order === "number";
+      const bHasOrder = typeof b.order === "number";
+      if (aHasOrder && bHasOrder && a.order !== b.order) return a.order - b.order;
+      if (aHasOrder !== bHasOrder) return aHasOrder ? -1 : 1;
+      return a.fileIndex - b.fileIndex;
+    })
+    .map(({ fileIndex: _fileIndex, ...memo }) => memo);
+}
+
+async function readMemosAsync(taskDir, reservedFiles = ["_index.md"], options = {}) {
+  const includeMemoContent = options.includeMemoContent !== false;
+  const reserved = new Set(reservedFiles);
+  const files = (await fs.promises.readdir(taskDir))
+    .filter((f) => f.endsWith(".md") && !reserved.has(f))
+    .sort();
+  const memos = await Promise.all(
+    files.map(async (file, fileIndex) => {
+      const filePath = path.join(taskDir, file);
+      const raw = includeMemoContent
+        ? await fs.promises.readFile(filePath, "utf8")
+        : await readFilePrefixAsync(filePath);
+      return buildMemoEntry(file, fileIndex, raw, includeMemoContent);
+    })
+  );
+  return sortMemoEntries(memos);
+}
+
+async function readAttachmentsAsync(taskDir) {
+  const attachmentsDir = path.join(taskDir, "attachments");
+  let entries;
+  try {
+    entries = await fs.promises.readdir(attachmentsDir, { withFileTypes: true });
+  } catch (err) {
+    if (err.code === "ENOENT") return [];
+    throw err;
+  }
+
+  const fileNames = entries
+    .filter((entry) => entry.isFile())
+    .map((entry) => entry.name)
+    .sort((a, b) => a.localeCompare(b, undefined, { numeric: true, sensitivity: "base" }));
+
+  return Promise.all(
+    fileNames.map(async (fileName) => {
+      const filePath = path.join(attachmentsDir, fileName);
+      const stats = await fs.promises.stat(filePath);
+      return {
+        id: `./attachments/${fileName}`,
+        name: fileName,
+        relativePath: `./attachments/${fileName}`,
+        size: stats.size,
+        modifiedAt: stats.mtime.toISOString(),
+      };
+    })
+  );
+}
+
+function buildTaskFromFrontmatter(data, extra) {
+  const task = {
+    id: data.id,
+    name: data.name || "",
+    status: data.status || "Open",
+    startDate: data.start || undefined,
+    dueDate: data.due || undefined,
+    createdAt: data.created || "",
+    order: parseOrderValue(data.order),
+    ...extra,
+  };
+  if (parseArchivedValue(data.archived)) {
+    task.archived = true;
+    if (data.archived_at) task.archivedAt = String(data.archived_at);
+  }
+  return task;
+}
+
+async function readRootTaskAsync(projectDir, options = {}) {
+  const content = await fs.promises.readFile(path.join(projectDir, "_project.md"), "utf8");
+  const { data } = parseFrontmatter(content);
+  const [memos, attachments] = await Promise.all([
+    readMemosAsync(projectDir, ["_project.md"], options),
+    readAttachmentsAsync(projectDir),
+  ]);
+  return buildTaskFromFrontmatter(data, { parents: [], memos, attachments });
+}
+
+async function readTaskDirAsync(taskDir, options = {}) {
+  const content = await fs.promises.readFile(path.join(taskDir, "_index.md"), "utf8");
+  const { data } = parseFrontmatter(content);
+  const parents = Array.isArray(data.parents) ? data.parents : data.parents ? [data.parents] : [];
+  const [memos, attachments] = await Promise.all([
+    readMemosAsync(taskDir, ["_index.md"], options),
+    readAttachmentsAsync(taskDir),
+  ]);
+  return buildTaskFromFrontmatter(data, { parents, memos, attachments });
+}
+
+/**
+ * Async mirror of readProject. Returns { tasks: Map, taskDirs: Map }.
+ * Task directories are read concurrently so per-file disk latency overlaps
+ * instead of summing.
+ */
+async function readProjectAsync(projectDir, options = {}) {
+  const tasks = new Map();
+  const taskDirs = new Map();
+
+  let entries;
+  try {
+    entries = await fs.promises.readdir(projectDir, { withFileTypes: true });
+  } catch (err) {
+    if (err.code === "ENOENT") return { tasks, taskDirs };
+    throw err;
+  }
+
+  const hasRootFile = entries.some((entry) => entry.isFile() && entry.name === "_project.md");
+
+  const taskDirNames = entries
+    .filter((entry) => entry.isDirectory() && !entry.name.startsWith("_"))
+    .map((entry) => entry.name);
+
+  const [root, regularTasks] = await Promise.all([
+    hasRootFile ? readRootTaskAsync(projectDir, options).catch(() => null) : Promise.resolve(null),
+    Promise.all(
+      taskDirNames.map(async (name) => {
+        const taskDir = path.join(projectDir, name);
+        try {
+          await fs.promises.access(path.join(taskDir, "_index.md"));
+        } catch {
+          return null;
+        }
+        try {
+          const task = await readTaskDirAsync(taskDir, options);
+          return task.id ? { name, task } : null;
+        } catch {
+          // Skip malformed task directories (parity with sync readProject).
+          return null;
+        }
+      })
+    ),
+  ]);
+
+  if (root?.id) {
+    tasks.set(root.id, root);
+    taskDirs.set(root.id, "_project");
+  }
+
+  for (const entry of regularTasks) {
+    if (!entry) continue;
+    tasks.set(entry.task.id, entry.task);
+    taskDirs.set(entry.task.id, entry.name);
+  }
+
+  return { tasks, taskDirs };
+}
+
+async function readTaskMemosAsync(projectDir, taskId, taskDirs) {
+  const dirName = taskDirs.get(taskId);
+  if (!dirName) {
+    throw new Error("Task directory was not found");
+  }
+  const taskDir = dirName === "_project" ? projectDir : path.join(projectDir, dirName);
+  return readMemosAsync(taskDir, dirName === "_project" ? ["_project.md"] : ["_index.md"], {
+    includeMemoContent: true,
+  });
+}
+
 function writeMemoFiles(taskDir, indexFileName, memos) {
   const existing = fs.readdirSync(taskDir).filter((f) => f.endsWith(".md") && f !== indexFileName);
   for (const f of existing) fs.unlinkSync(path.join(taskDir, f));
@@ -1368,6 +1586,53 @@ function listProjects(workspacePath) {
   return projects.sort(compareProjectListItems);
 }
 
+/**
+ * Async mirror of listProjects. Reads every `_project.md` concurrently so a
+ * slow disk does not serialize one stat+read per project on the main event
+ * loop.
+ */
+async function listProjectsAsync(workspacePath) {
+  let entries;
+  try {
+    entries = await fs.promises.readdir(workspacePath, { withFileTypes: true });
+  } catch (err) {
+    if (err.code === "ENOENT") return [];
+    throw err;
+  }
+
+  const dirNames = entries
+    .filter((entry) => entry.isDirectory() && !entry.name.startsWith("_"))
+    .map((entry) => entry.name);
+
+  const projects = await Promise.all(
+    dirNames.map(async (dirName) => {
+      const projectFile = path.join(workspacePath, dirName, "_project.md");
+      let content;
+      try {
+        content = await fs.promises.readFile(projectFile, "utf8");
+      } catch {
+        // Missing _project.md (not a project dir) or unreadable — skip.
+        return null;
+      }
+      try {
+        const { data } = parseFrontmatter(content);
+        if (data.kind === "inbox") return null;
+        return {
+          name: data.name || dirName,
+          rootId: data.id,
+          dirName,
+          projectDir: path.join(workspacePath, dirName),
+          order: parseOrderValue(data.order),
+        };
+      } catch {
+        return null;
+      }
+    })
+  );
+
+  return projects.filter(Boolean).sort(compareProjectListItems);
+}
+
 function projectListIdentity(project) {
   return project?.rootId || project?.id || project?.dirName || project?.projectDir || null;
 }
@@ -1610,7 +1875,9 @@ module.exports = {
   writeFileIfChanged,
   retryFileOperation,
   readProject,
+  readProjectAsync,
   readTaskMemos,
+  readTaskMemosAsync,
   writeTask,
   writeTaskAsync,
   writeProjectAsync,
@@ -1628,6 +1895,7 @@ module.exports = {
   deleteProject,
   deleteProjectAsync,
   listProjects,
+  listProjectsAsync,
   setProjectOrderAsync,
   wouldCreateCycle,
   bfsFromRoot,

--- a/tests/unit/workspace.test.js
+++ b/tests/unit/workspace.test.js
@@ -15,7 +15,9 @@ import {
   createProject,
   createProjectAsync,
   readProject,
+  readProjectAsync,
   readTaskMemos,
+  readTaskMemosAsync,
   writeTask,
   writeTaskAsync,
   writeProjectAsync,
@@ -31,6 +33,7 @@ import {
   deleteProject,
   deleteProjectAsync,
   listProjects,
+  listProjectsAsync,
   setProjectOrderAsync,
   exportProjectData,
   legacyMemoContentToMarkdown,
@@ -347,6 +350,101 @@ describe("file system operations", () => {
     expect(loaded.memos[0].id).toBe("root-memo");
     expect(loaded.memos[0].title).toBe("Root Notes");
     expect(loaded.memos[0].content).toContain("Stored here");
+  });
+
+  it("readProjectAsync matches readProject for a multi-task project with memos", async () => {
+    const { projectDir } = createProject(tmpDir, "Proj", "root-id");
+    const taskDirs = new Map([["root-id", "_project"]]);
+    writeTask(
+      projectDir,
+      {
+        id: "root-id",
+        name: "Proj",
+        status: "Open",
+        parents: [],
+        memos: [{ id: "root-memo", title: "Root Notes", content: "# Root Notes\n\nbody" }],
+        createdAt: "2026-04-24",
+      },
+      taskDirs
+    );
+    writeTask(
+      projectDir,
+      {
+        id: "child-a",
+        name: "Child A",
+        status: "Open",
+        parents: ["root-id"],
+        memos: [{ id: "memo-a", title: "A", content: "alpha" }],
+        createdAt: "2026-04-24",
+      },
+      taskDirs
+    );
+    writeTask(
+      projectDir,
+      {
+        id: "child-b",
+        name: "Child B",
+        status: "Open",
+        parents: ["root-id"],
+        memos: [],
+        createdAt: "2026-04-24",
+      },
+      taskDirs
+    );
+
+    const sync = readProject(projectDir);
+    const asyncResult = await readProjectAsync(projectDir);
+
+    expect([...asyncResult.taskDirs.entries()].sort()).toEqual([...sync.taskDirs.entries()].sort());
+    expect([...asyncResult.tasks.keys()].sort()).toEqual([...sync.tasks.keys()].sort());
+    for (const [id, task] of sync.tasks) {
+      expect(asyncResult.tasks.get(id)).toEqual(task);
+    }
+  });
+
+  it("readProjectAsync returns empty maps for a missing project dir", async () => {
+    const result = await readProjectAsync(path.join(tmpDir, "does-not-exist"));
+    expect(result.tasks.size).toBe(0);
+    expect(result.taskDirs.size).toBe(0);
+  });
+
+  it("readTaskMemosAsync matches readTaskMemos", async () => {
+    const { projectDir } = createProject(tmpDir, "Proj", "root-id");
+    const taskDirs = new Map([["root-id", "_project"]]);
+    writeTask(
+      projectDir,
+      {
+        id: "child-a",
+        name: "Child A",
+        status: "Open",
+        parents: ["root-id"],
+        memos: [
+          { id: "m1", title: "One", content: "first" },
+          { id: "m2", title: "Two", content: "second" },
+        ],
+        createdAt: "2026-04-24",
+      },
+      taskDirs
+    );
+
+    const sync = readTaskMemos(projectDir, "child-a", taskDirs);
+    const asyncResult = await readTaskMemosAsync(projectDir, "child-a", taskDirs);
+    expect(asyncResult).toEqual(sync);
+  });
+
+  it("listProjectsAsync matches listProjects including order", async () => {
+    createProject(tmpDir, "Alpha", "alpha-id", 1);
+    createProject(tmpDir, "Beta", "beta-id", 0);
+    createProject(tmpDir, "Gamma", "gamma-id", 2);
+
+    const sync = listProjects(tmpDir);
+    const asyncResult = await listProjectsAsync(tmpDir);
+    expect(asyncResult).toEqual(sync);
+  });
+
+  it("listProjectsAsync returns [] for a missing workspace dir", async () => {
+    const result = await listProjectsAsync(path.join(tmpDir, "nope"));
+    expect(result).toEqual([]);
   });
 
   it("writeTask + readProject preserves memo order independently of filenames", () => {


### PR DESCRIPTION
## 概要

「IO が遅い前提」での UI カクつき要因として、**main プロセスのイベントループが同期 fs でブロックされる**問題を修正します。

`workspace.js` の読み取り系（`readProject` / `readTaskMemos` / `listProjects`）はすべて同期で、タスクディレクトリを `readFileSync` / `readdirSync` で総なめします。これらがインタラクティブな IPC ハンドラから呼ばれるため、遅いディスク（OneDrive 同期フォルダなど）では **main のイベントループ全体がブロック**され、待っている操作だけでなく**全 IPC（ウィンドウ操作・別ウィンドウの読み込みを含む）が stall** → アプリ全体がフリーズしていました。

## 変更内容

`fs.promises` ベースの async ミラーを追加し、兄弟ファイルを並行読み込みするようにしたうえで、インタラクティブな読み取りハンドラを切り替えました。

**`electron/workspace.js`（追加）**
- `readProjectAsync` … タスクディレクトリを `Promise.all` で並行読込（per-file レイテンシが加算でなく重なる）
- `readTaskMemosAsync` / `readMemosAsync` / `readAttachmentsAsync` / `readRootTaskAsync` / `readTaskDirAsync` / `readFilePrefixAsync`
- `listProjectsAsync` … 各 `_project.md` を並行読込
- 同期版は **batch/export・reconciler・inbox・テスト**用にそのまま残置

**`electron/index.js`（ハンドラ切替）**
- `ws:read-project` / `ws:read-task-memos` / `ws:read-project-memos`（全タスクのメモを直列ループ → `Promise.all` 並行化）
- `ws:list-projects` / `ws:select-directory` / `ws:open-task-folder`
- `ws:resolve-conflict` の reload 経路
- `ensureWorkspaceCacheAsync` / `readProjectSummaryAsync` / `readWorkspaceProjectForRendererAsync` を追加（content mode は元の挙動を維持：summary は `includeMemoContent:false`、conflict-reload は本文込み）

## スコープ外（follow-up）

書き込み系ハンドラ（write queue / `ws:write-task` / 添付）が使う同期 `ensureWorkspaceCache` / `withLoadedMemoBodies` は、楽観的書き込みキャッシュと絡むため本 PR では触れず、別途対応とします。reconciler が使う同期 `readProject` も既存契約のため維持。

## テスト

`tests/unit/workspace.test.js` に async/sync の**等価性テスト**を追加：
- `readProjectAsync` がマルチタスク+メモ構成で `readProject` と一致
- `readTaskMemosAsync` / `listProjectsAsync`（順序含む）が同期版と一致
- 存在しないディレクトリのケース（空 Map / `[]`）

## 検証

- `node --check`（両ファイル）/ `svelte-check` 0 errors / ESLint 指摘なし
- unit 338 passed（+5）/ component 137 passed（7 skip）

https://claude.ai/code/session_013inbiQ8fTE7YS4wa4nVAeo

---
_Generated by [Claude Code](https://claude.ai/code/session_013inbiQ8fTE7YS4wa4nVAeo)_