### PR TITLE
fix: tree resizers showing over modals, and Quill table actions doing nothing

### DIFF
--- a/src/features/memos/components/QuillMemo.svelte
+++ b/src/features/memos/components/QuillMemo.svelte
@@ -116,6 +116,21 @@
     const table = quill?.getModule?.("table");
     if (!table) return;
 
+    // Interacting with the toolbar <select> blurs the editor, so
+    // quill.getSelection() returns null at this point. Every table module
+    // method (insertTable / insertRow* / deleteTable …) early-returns when the
+    // selection is null, so the action would silently do nothing. Refocus the
+    // editor and restore the last known caret position (falling back to the
+    // end of the document) so the table module has a range to act on.
+    quill.focus?.();
+    if (!quill.getSelection()) {
+      const fallback = savedSelection ?? { index: quill.getLength(), length: 0 };
+      const index = Math.max(0, Math.min(fallback.index, quill.getLength()));
+      const length = Math.max(0, Math.min(fallback.length ?? 0, quill.getLength() - index));
+      quill.setSelection(index, length, "silent");
+    }
+    if (!quill.getSelection()) return;
+
     switch (value) {
       case "insert":
         table.insertTable(2, 2);

--- a/src/features/tasks/components/TreeTable.svelte
+++ b/src/features/tasks/components/TreeTable.svelte
@@ -1223,6 +1223,14 @@
     min-width: var(--minWidth);
     overflow-y: auto;
     position: relative;
+    /* Establish a stacking context so the absolutely-positioned column
+       resizers (z-index: 10000) and the sticky header/trail are scoped to
+       this subtree. Without it those high z-indexes compete globally and the
+       resizer lines render ABOVE a Modal's body-level mask (z-index: 9999),
+       making the column dividers show through an open modal. A low z-index
+       keeps the whole tree below modals/overlays while preserving the
+       internal ordering of header > resizer > rows. */
+    z-index: 0;
   }
   .StickyTrail {
     /* Pinned breadcrumb sits flush under the 3rem tree header. No margin,

--- a/tests/component/Memo.test.js
+++ b/tests/component/Memo.test.js
@@ -34,9 +34,13 @@ vi.mock("quill", () => {
       this.setText = vi.fn();
       this.getContents = vi.fn(() => ({ ops: [{ insert: "changed\n" }] }));
       this.getLength = vi.fn(() => 0);
-      this.getSelection = vi.fn(() => null);
+      this._selection = null;
+      this.getSelection = vi.fn(() => this._selection);
       this.hasFocus = vi.fn(() => false);
-      this.setSelection = vi.fn();
+      this.focus = vi.fn();
+      this.setSelection = vi.fn((index, length = 0) => {
+        this._selection = { index, length };
+      });
       this.deleteText = vi.fn();
       this.insertText = vi.fn();
       this.getModule = vi.fn((name) => {
@@ -289,8 +293,14 @@ describe("Memo mode routing", () => {
     ]);
     expect(quillInstances[0].toolbarContainer.querySelectorAll("button.ql-table")).toHaveLength(0);
 
+    // Regression: interacting with the dropdown blurs the editor, so
+    // getSelection() is null. The action must refocus + restore a selection so
+    // the table module (which no-ops on a null range) still runs.
+    expect(quillInstances[0].getSelection()).toBeNull();
     await fireEvent.change(select, { target: { value: "delete-column" } });
 
+    expect(quillInstances[0].focus).toHaveBeenCalled();
+    expect(quillInstances[0].setSelection).toHaveBeenCalled();
     expect(quillInstances[0].tableModule.deleteColumn).toHaveBeenCalledTimes(1);
     expect(select.value).toBe("");
   });


### PR DESCRIPTION
2 件の UI バグ修正です。

## ① ツリーグリッドのカラム（リサイザ線）がモーダルより上に出る

**原因**: `.TableRoot` は `position: relative` だが `z-index` を持たず、**スタッキングコンテキストを生成していなかった**。そのため子要素である列リサイザ（絶対配置・`z-index: 10000`）が祖先に閉じ込められず、`body` 直下に追加される Modal の Mask（`z-index: 9999`）と**グローバルに比較**され、リサイザ線がモーダルの暗幕より上に描画されていた。

**修正**: `.TableRoot` に `z-index: 0` を付与してスタッキングコンテキストを生成。これでツリー内部の高 z-index（10000 等）はコンテキスト内ローカル値になり、ツリー全体がモーダル（99999）より下に収まる。ツリー内部の重なり順（ヘッダー > リサイザ > 行）は維持。

## ② Quill で表が使えない（ボタンを押しても出てこない）

**原因**: Quill 2 の table モジュールの各メソッド（`insertTable` / `insertRow*` / `deleteTable` …）は、内部で `const range = this.quill.getSelection(); if (range == null) return;` と**選択範囲が null だと即 return** する実装。ツールバーの `<select>` ドロップダウンを操作するとエディタが**フォーカスを失う**ため、アクション実行時には常に `getSelection()` が null になり、何も起きなかった。

**修正**: `runTableAction` で table モジュールを呼ぶ前に、エディタを再フォーカスし、直近のキャレット位置（`savedSelection`、無ければ文末）を復元してから実行する。これで table モジュールが有効な range を得られる。

## テスト

- `tests/component/Memo.test.js` の table ドロップダウンテストを拡張：
  - 選択範囲が null の状態から開始することを確認（実際のバグ条件）
  - アクションが `focus()` と `setSelection()`（選択復元）を呼んでから table メソッドを実行することを assert
  - mock Quill を実 Quill 同様に `setSelection` → `getSelection` が連動するよう更新

## 検証

- `svelte-check` 0 errors / ESLint 指摘なし
- unit + component: 475 passed / 7 skipped

https://claude.ai/code/session_013inbiQ8fTE7YS4wa4nVAeo

---
_Generated by [Claude Code](https://claude.ai/code/session_013inbiQ8fTE7YS4wa4nVAeo)_