### PR TITLE
fix: treat children of archived tasks as archived in show-archived view

### DIFF
--- a/src/features/tasks/components/TreeTableRow.svelte
+++ b/src/features/tasks/components/TreeTableRow.svelte
@@ -44,6 +44,11 @@
   $: data = node.data;
   $: hasChildren = row.hasChildren;
   $: expanded = row.expanded;
+  // A row is treated as archived if it is archived itself OR sits under an
+  // archived ancestor (computed by flattenVisibleTree). Children of an archived
+  // task don't carry their own `archived` flag, so relying on node.archived
+  // alone would wrongly let them be edited in the show-archived view.
+  $: isArchived = row.effectivelyArchived ?? !!node.archived;
 
   // When this row is part of an active multi-selection, the right-click menu
   // routes actions to the bulk handlers. Use bulk capability flags so the menu
@@ -105,8 +110,8 @@
 
   function commitData(key, value) {
     // archived 行は読み取り専用（仕様）。subscribe 経路で誤って入った
-    // commit を捨て、データ層を変えない。
-    if (node.archived) return;
+    // commit を捨て、データ層を変えない。archived 配下の子も対象に含める。
+    if (isArchived) return;
     dispatch("commit", {
       id,
       patch: {
@@ -218,7 +223,7 @@
   class:DragOverBelow={dragOverType === "DragOverBelow"}
   class:OverdueRow={dueDateUrgency === "overdue"}
   class:DueSoonRow={dueDateUrgency === "due-soon"}
-  class:ArchivedRow={!!node.archived}
+  class:ArchivedRow={isArchived}
   use:ripple
   tabindex="0"
   draggable="true"
@@ -310,7 +315,7 @@
           {canOpenTaskFolder}
           selectionCount={selectionCountForMenu}
           {nodePath}
-          archived={!!node.archived}
+          archived={isArchived}
           on:commit={(e) => {
             commitData("name", e.detail.value);
           }}
@@ -360,7 +365,7 @@
       {:else if header.name == "status"}
         <StatusSelect
           status={data[header.name]}
-          disabled={!!node.archived}
+          disabled={isArchived}
           on:change={(e) => {
             commitData("status", e.detail.value);
           }}
@@ -371,7 +376,7 @@
           id="start-date"
           backgroundColor={"var(--backgroundColor)"}
           value={data[header.name]}
-          disabled={!!node.archived}
+          disabled={isArchived}
           on:change={(e) => {
             commitData("start date", e.target.value);
           }}
@@ -383,7 +388,7 @@
           backgroundColor={"var(--backgroundColor)"}
           value={data[header.name]}
           inheritedDate={inheritedDueDate}
-          disabled={!!node.archived}
+          disabled={isArchived}
           on:change={(e) => {
             commitData("due date", e.target.value);
           }}

--- a/src/features/tasks/utils/tree_control.ts
+++ b/src/features/tasks/utils/tree_control.ts
@@ -68,6 +68,14 @@ export interface VisibleTreeRow {
   node: TreeData;
   hasChildren: boolean;
   expanded: boolean;
+  /**
+   * True when this row is archived OR sits under an archived ancestor. Only
+   * meaningful in the show-archived view (includeArchived=true); in the normal
+   * view archived subtrees are skipped entirely. Rows use this — not the row's
+   * own `node.archived` — to drive read-only / muted-row behaviour so children
+   * of an archived task are treated as archived too.
+   */
+  effectivelyArchived: boolean;
   canMoveUp: boolean;
   canMoveDown: boolean;
   canIndent: boolean;
@@ -387,6 +395,7 @@ export function flattenVisibleTree(
       node,
       hasChildren,
       expanded,
+      effectivelyArchived,
       canMoveUp: siblingIndex > 0,
       canMoveDown: siblingIndex < siblingCount - 1,
       canIndent: siblingIndex > 0,

--- a/tests/unit/archive.test.ts
+++ b/tests/unit/archive.test.ts
@@ -117,6 +117,26 @@ describe("archive / restore tree helpers", () => {
     expect(rows.map((r) => r.id)).toEqual(["root", "a", "a1", "a2", "b", "c"]);
   });
 
+  test("includeArchived=true で archived ノードの子孫も effectivelyArchived になる", () => {
+    const tree = makeTree();
+    // a だけを archive。a1/a2 は自身の archived フラグを持たない。
+    archiveNode("a", tree);
+    const rows = flattenVisibleTree(tree, new Set(), true);
+    const archivedFlag = Object.fromEntries(rows.map((r) => [r.id, r.effectivelyArchived]));
+    // a とその子孫はすべて effectivelyArchived。子は node.archived を持たないが、
+    // 祖先が archived なので連動して archived 扱いになる（これが回帰対象）。
+    expect(archivedFlag.a).toBe(true);
+    expect(archivedFlag.a1).toBe(true);
+    expect(archivedFlag.a2).toBe(true);
+    // 非 archived の枝は false のまま。
+    expect(archivedFlag.root).toBe(false);
+    expect(archivedFlag.b).toBe(false);
+    expect(archivedFlag.c).toBe(false);
+    // 子は自身の archived フラグは持っていないことも確認（連動表示であることの裏付け）。
+    const a1Node = rows.find((r) => r.id === "a1")!.node;
+    expect(a1Node.archived).toBeUndefined();
+  });
+
   test("stripArchivedNodes は archived の子孫を完全に取り除いた新ツリーを返す", () => {
     const tree = makeTree();
     archiveNode("a", tree);


### PR DESCRIPTION
## 概要

アーカイブ済みタスクの**子タスク**が、アーカイブを含めて表示する（show-archived）ときに**アーカイブ済み扱いになっていない**バグを修正します。

子タスクは表示はされるものの、以下が効いていませんでした：
- ステータス／日付入力が**編集可能**なまま（本来はアーカイブ行は読み取り専用）
- 名前の commit が**通ってしまう**
- グレーアウト（`ArchivedRow` スタイル）が**当たらない**
- 右クリックメニューが「復元／完全に削除」ではなく通常メニュー

## 原因

`flattenVisibleTree` は `effectivelyArchived`（自身が archived **または** archived な祖先配下）を計算していたのに、**その結果を行に持たせず捨てて**いました。一方 `TreeTableRow` はアーカイブ判定をすべて行自身の `node.archived` で行っていましたが、**子タスクは自分の `archived` フラグを持たない**（親だけが archived）ため、判定が漏れていました。

## 修正

- `VisibleTreeRow` に `effectivelyArchived` を追加し、`flattenVisibleTree` で設定
- `TreeTableRow` のアーカイブ関連挙動（読み取り専用化・`ArchivedRow` スタイル・メニューの restore/delete 切替・各入力の `disabled`）を `node.archived` ではなく `row.effectivelyArchived` で駆動

`isArchived = row.effectivelyArchived ?? !!node.archived` とし、手動で行を組み立てる既存テスト等との後方互換も維持しています。

## テスト

`tests/unit/archive.test.ts` に回帰テストを追加：
- `a` のみを archive（子 `a1`/`a2` は自身の archived フラグなし）した状態で show-archived 表示
- `a`/`a1`/`a2` が `effectivelyArchived=true`、非アーカイブ枝（root/b/c）は `false`
- 子は自身の `archived` フラグを持たないことも確認（連動表示であることの裏付け）

## 検証

- `svelte-check` 0 errors / ESLint 指摘なし
- unit 339 passed（+1）/ component 137 passed（7 skip）

https://claude.ai/code/session_013inbiQ8fTE7YS4wa4nVAeo

---
_Generated by [Claude Code](https://claude.ai/code/session_013inbiQ8fTE7YS4wa4nVAeo)_