### PR TITLE
[codex] improve memo editing and task restore UX

### DIFF
--- a/src/App.svelte
+++ b/src/App.svelte
@@ -458,7 +458,7 @@
     position: relative;
   }
   div.Header {
-    height: 3.5rem;
+    height: 2.75rem;
   }
   div.Body {
     display: flex;
@@ -466,7 +466,7 @@
     flex: 1;
     min-height: 0;
     width: 100%;
-    height: calc(100% - 3.5rem);
+    height: calc(100% - 2.75rem);
     overflow: hidden;
   }
   div.Body.DetailWindowBody {

--- a/src/features/memos/components/MarkdownMemo.svelte
+++ b/src/features/memos/components/MarkdownMemo.svelte
@@ -1,6 +1,14 @@
 ﻿<script lang="ts">
   import { tick, onDestroy } from "svelte";
-  import { EditorView, keymap, lineNumbers } from "@codemirror/view";
+  import {
+    Direction,
+    EditorView,
+    keymap,
+    layer,
+    lineNumbers,
+    type LayerMarker,
+    type ViewUpdate,
+  } from "@codemirror/view";
   import { EditorState, type Text } from "@codemirror/state";
   import {
     autocompletion,
@@ -20,7 +28,6 @@
   import mermaid from "mermaid";
   import quillIcons from "quill/ui/icons.js";
   import { toMarkdown } from "@features/memos/utils/memo_utils";
-  import SegmentedControl from "@lib/primitives/SegmentedControl.svelte";
   import * as platform from "@lib/ipc/platform";
   import { theme } from "@stores/theme";
   import "@features/memos/styles/hljs-theme.css";
@@ -63,6 +70,7 @@
   let saveTimer: ReturnType<typeof setTimeout>;
   let savedTimer: ReturnType<typeof setTimeout>;
   let isEditing = false;
+  let markdownMode: MarkdownMemoMode = "preview";
   let hasChanges = false;
   let saveState: "clean" | "dirty" | "saved" = "clean";
   let currentContent = toMarkdown(content);
@@ -71,9 +79,11 @@
   let previewEl: HTMLElement | null = null;
   let livePreviewEl: HTMLElement | null = null;
   let editBody: HTMLElement | null = null;
+  let modeDropdownEl: HTMLElement | null = null;
   let markdownSplitPercent = 55;
   let currentHeadingLevel = "normal";
   let tableActionValue = "";
+  let modeMenuOpen = false;
 
   const SPLIT_MIN_PERCENT = 30;
   const SPLIT_MAX_PERCENT = 72;
@@ -109,10 +119,25 @@
     { value: "delete-table", label: "表を削除" },
   ] as const;
   type TableAction = (typeof tableActionOptions)[number]["value"];
+  type MarkdownMemoMode = "preview" | "edit" | "split";
+  type EditableMarkdownMemoMode = Exclude<MarkdownMemoMode, "preview">;
   const memoModeOptions = [
-    { value: "read", label: "Read", className: "read-mode-btn" },
-    { value: "edit", label: "Edit", className: "edit-mode-btn" },
-  ];
+    { value: "preview", label: "Preview" },
+    { value: "edit", label: "Edit" },
+    { value: "split", label: "Split" },
+  ] satisfies Array<{
+    value: MarkdownMemoMode;
+    label: string;
+  }>;
+  const memoModeIconSvg: Record<MarkdownMemoMode, string> = {
+    preview:
+      '<svg viewBox="0 0 24 24" aria-hidden="true"><path d="M2.5 12S6 5.5 12 5.5 21.5 12 21.5 12 18 18.5 12 18.5 2.5 12 2.5 12Z"/><circle cx="12" cy="12" r="3"/></svg>',
+    edit: '<svg viewBox="0 0 24 24" aria-hidden="true"><path d="M4 20h4.5L19 9.5 14.5 5 4 15.5V20Z"/><path d="M13.5 6 18 10.5"/></svg>',
+    split:
+      '<svg viewBox="0 0 24 24" aria-hidden="true"><rect x="3.5" y="5" width="17" height="14" rx="2"/><path d="M12 5v14"/></svg>',
+  };
+  const chevronDownIconSvg =
+    '<svg viewBox="0 0 24 24" aria-hidden="true"><path d="m7 10 5 5 5-5"/></svg>';
 
   function memoLinkCompletion(context: CompletionContext): CompletionResult | null {
     const line = context.state.doc.lineAt(context.pos);
@@ -1122,6 +1147,132 @@
   const markdownSourceFontFamily =
     '"BIZ UDゴシック", "BIZ UDGothic", "Cascadia Mono", "Cascadia Code", Consolas, "Courier New", monospace';
 
+  type VisibleSpaceKind = "half" | "full";
+
+  class VisibleSpaceMarker implements LayerMarker {
+    readonly kind: VisibleSpaceKind;
+    readonly left: number;
+    readonly top: number;
+    readonly width: number;
+    readonly height: number;
+
+    constructor(kind: VisibleSpaceKind, left: number, top: number, width: number, height: number) {
+      this.kind = kind;
+      this.left = left;
+      this.top = top;
+      this.width = width;
+      this.height = height;
+    }
+
+    eq(other: LayerMarker): boolean {
+      return (
+        other instanceof VisibleSpaceMarker &&
+        other.kind === this.kind &&
+        other.left === this.left &&
+        other.top === this.top &&
+        other.width === this.width &&
+        other.height === this.height
+      );
+    }
+
+    draw(): HTMLElement {
+      const element = document.createElement("div");
+      element.className = `cm-visible-space-marker cm-visible-${this.kind}-space-marker`;
+      this.adjust(element);
+      return element;
+    }
+
+    update(element: HTMLElement, previous: LayerMarker): boolean {
+      if (!(previous instanceof VisibleSpaceMarker) || previous.kind !== this.kind) {
+        return false;
+      }
+      this.adjust(element);
+      return true;
+    }
+
+    private adjust(element: HTMLElement) {
+      element.style.left = `${this.left}px`;
+      element.style.top = `${this.top}px`;
+      element.style.width = `${this.width}px`;
+      element.style.height = `${this.height}px`;
+    }
+  }
+
+  function getLayerBase(view: EditorView) {
+    const rect = view.scrollDOM.getBoundingClientRect();
+    const left =
+      view.textDirection === Direction.LTR
+        ? rect.left
+        : rect.right - view.scrollDOM.clientWidth * view.scaleX;
+    return {
+      left: left - view.scrollDOM.scrollLeft * view.scaleX,
+      top: rect.top - view.scrollDOM.scrollTop * view.scaleY,
+    };
+  }
+
+  function createVisibleSpaceMarker(
+    view: EditorView,
+    base: { left: number; top: number },
+    pos: number,
+    kind: VisibleSpaceKind
+  ) {
+    const rect = view.coordsForChar(pos);
+    if (!rect) return null;
+
+    const charLeft = rect.left - base.left;
+    const charTop = rect.top - base.top;
+    const charWidth = rect.right - rect.left;
+    const charHeight = rect.bottom - rect.top;
+
+    if (kind === "half") {
+      const size = Math.max(2, Math.min(charWidth, charHeight) * 0.14);
+      return new VisibleSpaceMarker(
+        kind,
+        charLeft + (charWidth - size) / 2,
+        charTop + (charHeight - size) * 0.56,
+        size,
+        size
+      );
+    }
+
+    const size = Math.max(8, Math.min(charWidth, charHeight) * 0.62);
+    return new VisibleSpaceMarker(
+      kind,
+      charLeft + (charWidth - size) / 2,
+      charTop + (charHeight - size) / 2,
+      size,
+      size
+    );
+  }
+
+  const visibleSpaces = layer({
+    above: true,
+    class: "cm-visibleSpaceLayer",
+    markers(view) {
+      const markers: LayerMarker[] = [];
+      const base = getLayerBase(view);
+      for (const range of view.visibleRanges) {
+        const text = view.state.doc.sliceString(range.from, range.to);
+        for (let offset = 0; offset < text.length; offset += 1) {
+          const character = text[offset];
+          if (character !== " " && character !== "\u3000") continue;
+
+          const marker = createVisibleSpaceMarker(
+            view,
+            base,
+            range.from + offset,
+            character === " " ? "half" : "full"
+          );
+          if (marker) markers.push(marker);
+        }
+      }
+      return markers;
+    },
+    update(update: ViewUpdate) {
+      return update.docChanged || update.viewportChanged || update.geometryChanged;
+    },
+  });
+
   const editorTheme = EditorView.theme({
     "&": {
       height: "100%",
@@ -1132,13 +1283,13 @@
       overflow: "auto",
       fontFamily: markdownSourceFontFamily,
       fontSize: "var(--font-body-md)",
-      lineHeight: "1.7",
+      lineHeight: "1.5",
       fontKerning: "none",
       fontVariantLigatures: "none",
       fontFeatureSettings: '"liga" 0, "calt" 0',
     },
     ".cm-content": {
-      padding: "var(--sp3) var(--sp4)",
+      padding: "var(--sp2) var(--sp3)",
       caretColor: "var(--theme-color-Sub-light)",
       minHeight: "100%",
     },
@@ -1152,6 +1303,19 @@
     ".cm-cursor, .cm-dropCursor": {
       borderLeftColor: "var(--theme-color-Sub-light)",
     },
+    ".cm-visibleSpaceLayer": {
+      pointerEvents: "none",
+    },
+    ".cm-visible-space-marker": {
+      boxSizing: "border-box",
+    },
+    ".cm-visible-half-space-marker": {
+      borderRadius: "50%",
+      backgroundColor: "color-mix(in srgb, var(--theme-color-Sub-main) 46%, transparent)",
+    },
+    ".cm-visible-full-space-marker": {
+      border: "1px solid color-mix(in srgb, var(--theme-color-Primary-main) 42%, transparent)",
+    },
     ".cm-activeLine": {
       backgroundColor: "rgba(255, 255, 255, 0.02)",
     },
@@ -1162,7 +1326,7 @@
       userSelect: "none",
     },
     ".cm-lineNumbers .cm-gutterElement": {
-      padding: "0 var(--sp2) 0 var(--sp3)",
+      padding: "0 var(--sp1) 0 var(--sp2)",
       minWidth: "2.25rem",
       fontVariantNumeric: "tabular-nums",
     },
@@ -1200,6 +1364,7 @@
     return [
       editorTheme,
       lineNumbers(),
+      visibleSpaces,
       markdown({ base: markdownLanguage, codeLanguages: languages }),
       autocompletion({
         override: [memoLinkCompletion],
@@ -1321,20 +1486,26 @@
     ];
   }
 
-  async function startEdit() {
-    if (readOnly || isEditing) return;
-    isEditing = true;
+  async function startEdit(nextMode: EditableMarkdownMemoMode) {
+    if (readOnly) return;
+    modeMenuOpen = false;
+    markdownMode = nextMode;
     await tick();
-    if (!container || view) return;
-    view = new EditorView({
-      state: EditorState.create({ doc: currentContent, extensions: buildExtensions() }),
-      parent: container,
-    });
-    syncHeadingLevel(view);
+    if (!container) return;
+    if (!view) {
+      view = new EditorView({
+        state: EditorState.create({ doc: currentContent, extensions: buildExtensions() }),
+        parent: container,
+      });
+      syncHeadingLevel(view);
+    }
+    view.requestMeasure();
     view.focus();
   }
 
   function stopEdit() {
+    modeMenuOpen = false;
+    stopSplitResize();
     if (view) {
       clearTimeout(saveTimer);
       currentContent = view.state.doc.toString();
@@ -1344,14 +1515,71 @@
       view.destroy();
       view = null;
     }
-    isEditing = false;
+    markdownMode = "preview";
   }
 
-  function handleModeChange(event: CustomEvent<{ value: string }>) {
-    if (event.detail.value === "edit") {
-      void startEdit();
-    } else {
+  function selectMarkdownMode(nextMode: MarkdownMemoMode) {
+    modeMenuOpen = false;
+    if (nextMode === markdownMode) {
+      return;
+    }
+    if (nextMode === "preview") {
       stopEdit();
+    } else {
+      void startEdit(nextMode);
+    }
+  }
+
+  function toggleModeMenu() {
+    modeMenuOpen = !modeMenuOpen;
+  }
+
+  function closeModeMenu() {
+    modeMenuOpen = false;
+  }
+
+  function handleModeTriggerKeydown(event: KeyboardEvent) {
+    if (event.key === "Enter" || event.key === " " || event.key === "ArrowDown") {
+      event.preventDefault();
+      modeMenuOpen = true;
+      void tick().then(() => {
+        const activeOption = modeDropdownEl?.querySelector<HTMLButtonElement>(
+          ".memo-mode-option.active"
+        );
+        activeOption?.focus();
+      });
+    } else if (event.key === "Escape") {
+      closeModeMenu();
+    }
+  }
+
+  function handleModeMenuKeydown(event: KeyboardEvent) {
+    if (event.key === "Escape") {
+      event.preventDefault();
+      closeModeMenu();
+      modeDropdownEl?.querySelector<HTMLButtonElement>(".memo-mode-trigger")?.focus();
+      return;
+    }
+    if (event.key !== "ArrowDown" && event.key !== "ArrowUp") {
+      return;
+    }
+    event.preventDefault();
+    const options = Array.from(
+      modeDropdownEl?.querySelectorAll<HTMLButtonElement>(".memo-mode-option") ?? []
+    );
+    if (options.length === 0) return;
+    const currentIndex = Math.max(0, options.indexOf(document.activeElement as HTMLButtonElement));
+    const nextIndex =
+      event.key === "ArrowDown"
+        ? (currentIndex + 1) % options.length
+        : (currentIndex - 1 + options.length) % options.length;
+    options[nextIndex]?.focus();
+  }
+
+  function handleWindowClick(event: MouseEvent) {
+    if (!modeMenuOpen || !modeDropdownEl || !(event.target instanceof Node)) return;
+    if (!modeDropdownEl.contains(event.target)) {
+      closeModeMenu();
     }
   }
 
@@ -1447,6 +1675,9 @@
   }
 
   $: normalizedContent = toMarkdown(content);
+  $: isEditing = markdownMode !== "preview";
+  $: currentModeLabel =
+    memoModeOptions.find((mode) => mode.value === markdownMode)?.label ?? "Preview";
   $: hasRenderedContent = Boolean(currentContent.trim());
   $: if (!isEditing && normalizedContent !== currentContent) {
     currentContent = normalizedContent;
@@ -1464,6 +1695,8 @@
     void updateRenderedHtml(currentContent);
   }
 </script>
+
+<svelte:window on:click={handleWindowClick} />
 
 <div class="wrapper">
   {#if isEditing}
@@ -1575,50 +1808,96 @@
           <span class="save-status" aria-live="polite">
             {saveState === "dirty" ? "Unsaved" : saveState === "saved" ? "Saved" : ""}
           </span>
-          <SegmentedControl
-            options={memoModeOptions}
-            value="edit"
-            ariaLabel="Memo mode"
-            on:change={handleModeChange}
-          />
+          <!-- eslint-disable svelte/no-at-html-tags -->
+          <div class="memo-mode-dropdown" bind:this={modeDropdownEl}>
+            <button
+              type="button"
+              class="memo-mode-trigger"
+              aria-label={`Memo mode: ${currentModeLabel}`}
+              aria-haspopup="listbox"
+              aria-expanded={modeMenuOpen}
+              title={currentModeLabel}
+              on:click|stopPropagation={toggleModeMenu}
+              on:keydown={handleModeTriggerKeydown}
+            >
+              <!-- eslint-disable-next-line svelte/no-at-html-tags -->
+              <span class="memo-mode-icon" aria-hidden="true"
+                >{@html memoModeIconSvg[markdownMode]}</span
+              >
+              <span class="memo-mode-hover-label" aria-hidden="true">{currentModeLabel}</span>
+              <!-- eslint-disable-next-line svelte/no-at-html-tags -->
+              <span class="memo-mode-chevron" aria-hidden="true">{@html chevronDownIconSvg}</span>
+            </button>
+            {#if modeMenuOpen}
+              <div
+                class="memo-mode-menu"
+                role="listbox"
+                aria-label="Memo mode"
+                tabindex="-1"
+                on:keydown={handleModeMenuKeydown}
+              >
+                {#each memoModeOptions as mode}
+                  <button
+                    type="button"
+                    class="memo-mode-option"
+                    class:active={mode.value === markdownMode}
+                    data-mode={mode.value}
+                    role="option"
+                    aria-selected={mode.value === markdownMode}
+                    on:click|stopPropagation={() => selectMarkdownMode(mode.value)}
+                  >
+                    <!-- eslint-disable-next-line svelte/no-at-html-tags -->
+                    <span class="memo-mode-icon" aria-hidden="true"
+                      >{@html memoModeIconSvg[mode.value]}</span
+                    >
+                    <span class="memo-mode-option-label">{mode.label}</span>
+                  </button>
+                {/each}
+              </div>
+            {/if}
+          </div>
+          <!-- eslint-enable svelte/no-at-html-tags -->
         </div>
       </div>
       <div
         class="edit-body"
+        class:split-mode={markdownMode === "split"}
         bind:this={editBody}
         style={`--editor-pane-width: ${markdownSplitPercent}%`}
       >
         <div class="editor-pane">
           <div class="editor" bind:this={container}></div>
         </div>
-        <!-- svelte-ignore a11y_no_noninteractive_tabindex -->
-        <!-- svelte-ignore a11y_no_noninteractive_element_interactions -->
-        <div
-          class="markdown-split-resizer"
-          role="separator"
-          aria-label="Resize editor and preview"
-          aria-orientation="vertical"
-          aria-valuemin={SPLIT_MIN_PERCENT}
-          aria-valuemax={SPLIT_MAX_PERCENT}
-          aria-valuenow={Math.round(markdownSplitPercent)}
-          tabindex="0"
-          on:pointerdown={startSplitResize}
-          on:keydown={handleSplitKeydown}
-        ></div>
-        <!-- svelte-ignore a11y-no-static-element-interactions -->
-        <div
-          class="live-preview"
-          aria-label="Markdown preview"
-          on:click={handlePreviewClick}
-          on:keydown={handlePreviewKeydown}
-        >
-          {#if hasRenderedContent}
-            <!-- eslint-disable-next-line svelte/no-at-html-tags -->
-            <div class="preview" bind:this={livePreviewEl}>{@html renderedHtml}</div>
-          {:else}
-            <div class="placeholder">Preview</div>
-          {/if}
-        </div>
+        {#if markdownMode === "split"}
+          <!-- svelte-ignore a11y_no_noninteractive_tabindex -->
+          <!-- svelte-ignore a11y_no_noninteractive_element_interactions -->
+          <div
+            class="markdown-split-resizer"
+            role="separator"
+            aria-label="Resize editor and preview"
+            aria-orientation="vertical"
+            aria-valuemin={SPLIT_MIN_PERCENT}
+            aria-valuemax={SPLIT_MAX_PERCENT}
+            aria-valuenow={Math.round(markdownSplitPercent)}
+            tabindex="0"
+            on:pointerdown={startSplitResize}
+            on:keydown={handleSplitKeydown}
+          ></div>
+          <!-- svelte-ignore a11y-no-static-element-interactions -->
+          <div
+            class="live-preview"
+            aria-label="Markdown preview"
+            on:click={handlePreviewClick}
+            on:keydown={handlePreviewKeydown}
+          >
+            {#if hasRenderedContent}
+              <!-- eslint-disable-next-line svelte/no-at-html-tags -->
+              <div class="preview" bind:this={livePreviewEl}>{@html renderedHtml}</div>
+            {:else}
+              <div class="placeholder">Preview</div>
+            {/if}
+          </div>
+        {/if}
       </div>
     </div>
   {:else}
@@ -1631,12 +1910,55 @@
     >
       {#if !readOnly}
         <div class="preview-bar">
-          <SegmentedControl
-            options={memoModeOptions}
-            value="read"
-            ariaLabel="Memo mode"
-            on:change={handleModeChange}
-          />
+          <!-- eslint-disable svelte/no-at-html-tags -->
+          <div class="memo-mode-dropdown" bind:this={modeDropdownEl}>
+            <button
+              type="button"
+              class="memo-mode-trigger"
+              aria-label={`Memo mode: ${currentModeLabel}`}
+              aria-haspopup="listbox"
+              aria-expanded={modeMenuOpen}
+              title={currentModeLabel}
+              on:click|stopPropagation={toggleModeMenu}
+              on:keydown={handleModeTriggerKeydown}
+            >
+              <!-- eslint-disable-next-line svelte/no-at-html-tags -->
+              <span class="memo-mode-icon" aria-hidden="true"
+                >{@html memoModeIconSvg[markdownMode]}</span
+              >
+              <span class="memo-mode-hover-label" aria-hidden="true">{currentModeLabel}</span>
+              <!-- eslint-disable-next-line svelte/no-at-html-tags -->
+              <span class="memo-mode-chevron" aria-hidden="true">{@html chevronDownIconSvg}</span>
+            </button>
+            {#if modeMenuOpen}
+              <div
+                class="memo-mode-menu"
+                role="listbox"
+                aria-label="Memo mode"
+                tabindex="-1"
+                on:keydown={handleModeMenuKeydown}
+              >
+                {#each memoModeOptions as mode}
+                  <button
+                    type="button"
+                    class="memo-mode-option"
+                    class:active={mode.value === markdownMode}
+                    data-mode={mode.value}
+                    role="option"
+                    aria-selected={mode.value === markdownMode}
+                    on:click|stopPropagation={() => selectMarkdownMode(mode.value)}
+                  >
+                    <!-- eslint-disable-next-line svelte/no-at-html-tags -->
+                    <span class="memo-mode-icon" aria-hidden="true"
+                      >{@html memoModeIconSvg[mode.value]}</span
+                    >
+                    <span class="memo-mode-option-label">{mode.label}</span>
+                  </button>
+                {/each}
+              </div>
+            {/if}
+          </div>
+          <!-- eslint-enable svelte/no-at-html-tags -->
         </div>
       {/if}
       {#if hasRenderedContent}
@@ -1694,7 +2016,7 @@
     display: flex;
     justify-content: space-between;
     align-items: flex-start;
-    padding: var(--sp2);
+    padding: var(--sp1) var(--sp2);
     background-color: var(--theme-color-Main-dark);
     flex-shrink: 0;
     gap: var(--sp2);
@@ -1884,6 +2206,148 @@
     margin-left: auto;
   }
 
+  .memo-mode-dropdown {
+    position: relative;
+    flex: 0 0 auto;
+  }
+
+  .memo-mode-trigger {
+    position: relative;
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    gap: 4px;
+    width: 3.05rem;
+    height: var(--memo-quill-button-height);
+    padding: 0 7px;
+    margin: 0;
+    border: 1px solid color-mix(in srgb, var(--theme-color-Sub-main) 34%, transparent);
+    border-radius: var(--shape-xs);
+    color: var(--theme-color-Sub-main);
+    background-color: var(--theme-color-Main-light);
+    cursor: pointer;
+  }
+
+  .memo-mode-trigger:hover,
+  .memo-mode-trigger:focus,
+  .memo-mode-trigger[aria-expanded="true"] {
+    border-color: var(--theme-color-Primary-main);
+    color: var(--theme-color-Primary-main);
+    outline: none;
+  }
+
+  .memo-mode-trigger:focus-visible {
+    box-shadow: 0 0 0 2px color-mix(in srgb, var(--theme-color-Primary-main) 30%, transparent);
+  }
+
+  .memo-mode-icon,
+  .memo-mode-chevron {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    flex: 0 0 auto;
+    pointer-events: none;
+  }
+
+  .memo-mode-icon :global(svg) {
+    width: 15px;
+    height: 15px;
+  }
+
+  .memo-mode-chevron :global(svg) {
+    width: 12px;
+    height: 12px;
+    transition: transform 120ms ease;
+  }
+
+  .memo-mode-icon :global(svg),
+  .memo-mode-chevron :global(svg) {
+    display: block;
+    fill: none;
+    stroke: currentColor;
+    stroke-width: 2;
+    stroke-linecap: round;
+    stroke-linejoin: round;
+  }
+
+  .memo-mode-trigger[aria-expanded="true"] .memo-mode-chevron :global(svg) {
+    transform: rotate(180deg);
+  }
+
+  .memo-mode-hover-label {
+    position: absolute;
+    top: 50%;
+    right: calc(100% + var(--sp1));
+    z-index: 24;
+    padding: 4px 9px;
+    border: 1px solid color-mix(in srgb, var(--theme-color-Sub-main) 30%, transparent);
+    border-radius: var(--shape-xs);
+    color: var(--theme-color-Sub-light);
+    background-color: var(--theme-color-Main-light);
+    box-shadow: var(--shadow-sm);
+    font-size: var(--font-label-sm);
+    font-weight: 700;
+    line-height: 1;
+    white-space: nowrap;
+    opacity: 0;
+    transform: translateY(-50%) translateX(3px);
+    transition:
+      opacity 120ms ease,
+      transform 120ms ease;
+    pointer-events: none;
+  }
+
+  .memo-mode-trigger:hover .memo-mode-hover-label,
+  .memo-mode-trigger:focus-visible .memo-mode-hover-label {
+    opacity: 1;
+    transform: translateY(-50%);
+  }
+
+  .memo-mode-menu {
+    position: absolute;
+    top: calc(100% + 4px);
+    right: 0;
+    z-index: 25;
+    display: flex;
+    flex-direction: column;
+    min-width: 8rem;
+    padding: 4px;
+    border: 1px solid color-mix(in srgb, var(--theme-color-Sub-main) 28%, transparent);
+    border-radius: var(--shape-xs);
+    background-color: var(--theme-color-Main-light);
+    box-shadow: var(--shadow-md);
+  }
+
+  .memo-mode-option {
+    display: flex;
+    align-items: center;
+    gap: var(--sp1);
+    width: 100%;
+    min-height: 1.65rem;
+    padding: 0 var(--sp3);
+    border: 0;
+    border-radius: var(--shape-xs);
+    color: var(--theme-color-Sub-main);
+    background-color: transparent;
+    font-size: var(--font-label-md);
+    font-weight: 700;
+    line-height: 1;
+    text-align: left;
+    cursor: pointer;
+  }
+
+  .memo-mode-option:hover,
+  .memo-mode-option:focus,
+  .memo-mode-option.active {
+    color: var(--theme-color-Primary-main);
+    background-color: color-mix(in srgb, var(--theme-color-Primary-main) 14%, transparent);
+    outline: none;
+  }
+
+  .memo-mode-option-label {
+    white-space: nowrap;
+  }
+
   .save-status {
     min-width: 3rem;
     text-align: right;
@@ -1906,10 +2370,14 @@
 
   .editor-pane {
     display: flex;
-    flex: 0 0 var(--editor-pane-width);
+    flex: 1 1 auto;
     min-width: 0;
     min-height: 0;
     overflow: hidden;
+  }
+
+  .edit-body.split-mode .editor-pane {
+    flex: 0 0 var(--editor-pane-width);
   }
 
   .editor {
@@ -2021,7 +2489,7 @@
     z-index: 1;
     display: flex;
     justify-content: flex-end;
-    padding: var(--sp2) var(--sp2);
+    padding: 2px var(--sp2);
     border-bottom: 1px solid var(--theme-color-Shadow-main);
     background-color: color-mix(in srgb, var(--theme-color-Main-light) 94%, black);
   }
@@ -2029,7 +2497,7 @@
   .preview {
     flex: 1 1 auto;
     min-height: 0;
-    padding: var(--sp4);
+    padding: var(--sp2) var(--sp4);
     color: var(--theme-color-Sub-light);
     font-family: var(--memo-editor-font);
     font-size: var(--font-body-md);
@@ -2038,11 +2506,11 @@
     font-feature-settings:
       "liga" 0,
       "calt" 0;
-    line-height: 1.7;
+    line-height: 1.55;
   }
 
   @media (max-width: 900px) {
-    .editor-pane {
+    .edit-body.split-mode .editor-pane {
       flex-basis: 100%;
     }
 
@@ -2072,7 +2540,7 @@
     flex: 1 1 auto;
     min-height: 0;
     box-sizing: border-box;
-    padding: var(--sp4);
+    padding: var(--sp2);
     color: var(--theme-color-Sub-main);
     font-size: var(--font-body-md);
     font-style: italic;
@@ -2090,6 +2558,10 @@
     font-weight: 700;
     line-height: 1.3;
     color: var(--theme-color-Sub-light);
+  }
+
+  .preview :global(:first-child) {
+    margin-top: 0;
   }
 
   .preview :global(h1) {

--- a/src/features/memos/components/MemoTab.svelte
+++ b/src/features/memos/components/MemoTab.svelte
@@ -488,7 +488,7 @@
     display: flex;
     flex-direction: row;
     align-items: center;
-    height: var(--sp8);
+    height: 2.5rem;
     width: 100%;
   }
 
@@ -497,7 +497,7 @@
     flex-direction: row;
     align-items: center;
     height: 2rem;
-    padding: var(--sp2);
+    padding: var(--sp1);
     overflow-x: auto;
     flex: 1;
   }
@@ -515,6 +515,12 @@
     align-items: center;
     flex-shrink: 0;
     margin-left: auto;
+  }
+
+  .memotab-control :global(button) {
+    width: 1.75rem;
+    height: 1.75rem;
+    margin: 0;
   }
 
   input {
@@ -552,7 +558,7 @@
     height: 100%;
     min-width: 5rem;
     max-width: 10rem;
-    padding: var(--sp2);
+    padding: var(--sp1);
     flex: 1;
     justify-content: center;
     align-items: center;
@@ -592,10 +598,10 @@
   .tag-panel {
     display: flex;
     flex-direction: column;
-    gap: var(--sp2);
+    gap: 2px;
     box-sizing: border-box;
     min-width: 0;
-    padding: var(--sp3);
+    padding: 2px var(--sp2);
     border-bottom: 1px solid color-mix(in srgb, var(--theme-color-Sub-dark) 65%, transparent);
     background-color: transparent;
     container-type: inline-size;
@@ -605,20 +611,21 @@
   /* Tag area — 2-section layout (追加済み / 候補) */
   .tag-row {
     display: flex;
-    align-items: flex-start;
-    gap: var(--sp2);
+    align-items: center;
+    gap: var(--sp1);
     width: 100%;
     min-width: 0;
   }
 
   .tag-row-label {
     flex: 0 0 auto;
-    width: 4rem;
-    min-width: 4rem;
-    padding-top: var(--sp1);
+    width: 2.75rem;
+    min-width: 2.75rem;
+    padding-top: 0;
     color: var(--theme-color-Sub-main);
     font-size: var(--font-label-md);
     font-weight: 600;
+    line-height: 1.4;
     user-select: none;
   }
 
@@ -627,10 +634,10 @@
     flex: 1 1 auto;
     flex-wrap: wrap;
     align-items: center;
-    gap: var(--sp1);
+    gap: 2px var(--sp1);
     min-width: 0;
-    min-height: 2rem;
-    padding: var(--sp1) var(--sp2);
+    min-height: 1.5rem;
+    padding: 1px var(--sp1);
     border: 1px solid color-mix(in srgb, var(--theme-color-Sub-main) 30%, transparent);
     border-radius: var(--shape-xs);
     background-color: var(--theme-color-Main-light);
@@ -647,7 +654,7 @@
   }
 
   .tag-chips.is-empty {
-    padding-left: var(--sp2);
+    padding-left: var(--sp1);
   }
 
   .tag-chip {
@@ -656,7 +663,8 @@
     gap: var(--sp1);
     min-width: 0;
     max-width: min(14rem, 100%);
-    padding: 0.1rem var(--sp1) 0.1rem var(--sp3);
+    min-height: 1.25rem;
+    padding: 0 var(--sp1);
     border-radius: var(--shape-pill);
     border: 1px solid var(--theme-color-Primary-main);
     background-color: color-mix(in srgb, var(--theme-color-Primary-main) 18%, transparent);
@@ -677,8 +685,8 @@
     display: inline-flex;
     align-items: center;
     justify-content: center;
-    width: 1.05rem;
-    height: 1.05rem;
+    width: 1rem;
+    height: 1rem;
     padding: 0;
     margin: 0;
     border: none;
@@ -710,12 +718,15 @@
     border: none;
     color: var(--theme-color-Sub-main);
     font-size: var(--font-body-sm);
+    line-height: 1.35;
     min-width: 0;
     max-width: 100%;
-    flex: 1 1 5rem;
+    width: auto;
+    height: 1.25rem;
+    flex: 1 1 4rem;
     outline: 0;
-    padding: var(--sp1) 0;
-    margin-left: var(--sp2);
+    padding: 0;
+    margin-left: var(--sp1);
     text-align: left;
     cursor: text;
   }
@@ -730,10 +741,10 @@
     flex: 1 1 auto;
     flex-wrap: wrap;
     align-items: center;
-    gap: var(--sp1);
+    gap: 2px var(--sp1);
     min-width: 0;
-    min-height: 2rem;
-    padding: var(--sp1) var(--sp2);
+    min-height: 1.5rem;
+    padding: 1px var(--sp1);
     background-color: color-mix(in srgb, var(--theme-color-Sub-main) 6%, transparent);
     border-radius: var(--shape-sm);
   }
@@ -742,7 +753,8 @@
     display: inline-flex;
     align-items: center;
     gap: 0.2rem;
-    padding: 0.15rem var(--sp2);
+    min-height: 1.25rem;
+    padding: 0 var(--sp1);
     border: 1px solid color-mix(in srgb, var(--theme-color-Sub-main) 35%, transparent);
     border-radius: var(--shape-pill);
     background: transparent;
@@ -774,8 +786,8 @@
 
   @media (max-width: 600px) {
     .tag-row-label {
-      width: 3rem;
-      min-width: 3rem;
+      width: 2.5rem;
+      min-width: 2.5rem;
       font-size: var(--font-label-sm);
     }
   }

--- a/src/features/memos/components/QuillMemo.svelte
+++ b/src/features/memos/components/QuillMemo.svelte
@@ -17,9 +17,19 @@
   let lastSavedContent = null;
   let linkClickListener;
   let pasteListener;
+  let visibleSpaceLayer = null;
+  let visibleSpaceScrollListener = null;
+  let visibleSpaceResizeListener = null;
+  let visibleSpaceResizeObserver = null;
+  let visibleSpaceBeforeInputListener = null;
+  let visibleSpaceCompositionStartListener = null;
+  let visibleSpaceCompositionEndListener = null;
+  let visibleSpaceUpdateTimer = null;
+  let visibleSpaceAnimationFrame = null;
   let editReleaseTimer;
   let errorMessage = null;
   let isHandlingLink = false;
+  let isVisibleSpaceComposing = false;
 
   const codeBlockIconSvg =
     '<svg viewBox="0 0 18 18" aria-hidden="true" focusable="false">' +
@@ -97,15 +107,18 @@
 
     if (isEmptyContent(nextContent)) {
       quill.setContents([{ insert: "\n" }]);
+      scheduleVisibleSpaceOverlayUpdate();
       return;
     }
 
     if (typeof nextContent === "string") {
       quill.setText(nextContent);
+      scheduleVisibleSpaceOverlayUpdate();
       return;
     }
 
     quill.setContents(nextContent);
+    scheduleVisibleSpaceOverlayUpdate();
   }
 
   function openExternalLink(href) {
@@ -276,6 +289,337 @@
     quill.root.addEventListener("paste", pasteListener, true);
   }
 
+  function getVisibleTextRect(range, textNode, offset) {
+    if (typeof document.createRange !== "function") return null;
+    if (typeof range.getClientRects !== "function") return null;
+
+    range.setStart(textNode, offset);
+    range.setEnd(textNode, offset + 1);
+
+    for (const rect of Array.from(range.getClientRects())) {
+      if (rect.width > 0 && rect.height > 0) return rect;
+    }
+    const rect = range.getBoundingClientRect?.();
+    return rect && rect.width > 0 && rect.height > 0 ? rect : null;
+  }
+
+  function rectIntersectsRoot(rect, rootRect) {
+    return (
+      rect &&
+      rect.width > 0 &&
+      rect.height > 0 &&
+      rect.bottom >= rootRect.top &&
+      rect.top <= rootRect.bottom &&
+      rect.right >= rootRect.left &&
+      rect.left <= rootRect.right
+    );
+  }
+
+  function getVisibleEditorRect() {
+    const rootRect = quill.root.getBoundingClientRect();
+    const rootStyle = getComputedStyle(quill.root);
+    const paddingLeft = Number.parseFloat(rootStyle.paddingLeft) || 0;
+    const paddingRight = Number.parseFloat(rootStyle.paddingRight) || 0;
+    const paddingTop = Number.parseFloat(rootStyle.paddingTop) || 0;
+    const paddingBottom = Number.parseFloat(rootStyle.paddingBottom) || 0;
+
+    return {
+      top: rootRect.top + paddingTop,
+      right: rootRect.left + quill.root.clientWidth - paddingRight,
+      bottom: rootRect.top + quill.root.clientHeight - paddingBottom,
+      left: rootRect.left + paddingLeft,
+    };
+  }
+
+  function getElementContentRect(element) {
+    const rect = element.getBoundingClientRect();
+    const style = getComputedStyle(element);
+    const paddingLeft = Number.parseFloat(style.paddingLeft) || 0;
+    const paddingRight = Number.parseFloat(style.paddingRight) || 0;
+    const paddingTop = Number.parseFloat(style.paddingTop) || 0;
+    const paddingBottom = Number.parseFloat(style.paddingBottom) || 0;
+
+    return {
+      top: rect.top + paddingTop,
+      right: rect.left + element.clientWidth - paddingRight,
+      bottom: rect.top + element.clientHeight - paddingBottom,
+      left: rect.left + paddingLeft,
+    };
+  }
+
+  function intersectRects(a, b) {
+    const rect = {
+      top: Math.max(a.top, b.top),
+      right: Math.min(a.right, b.right),
+      bottom: Math.min(a.bottom, b.bottom),
+      left: Math.max(a.left, b.left),
+    };
+
+    return rect.right > rect.left && rect.bottom > rect.top ? rect : null;
+  }
+
+  function getVisibleClipRectForTextNode(textNode, editorRect) {
+    let clipRect = editorRect;
+    let element = textNode.parentElement;
+
+    while (element && element !== quill.root) {
+      if (element.matches?.(".ql-code-block-container, td, th")) {
+        clipRect = intersectRects(clipRect, getElementContentRect(element));
+        if (!clipRect) return null;
+      }
+      element = element.parentElement;
+    }
+
+    return clipRect;
+  }
+
+  function rectCenterFitsVisibleClip(rect, clipRect) {
+    const centerX = rect.left + rect.width / 2;
+    const centerY = rect.top + rect.height / 2;
+
+    return (
+      rect &&
+      clipRect &&
+      rect.width > 0 &&
+      rect.height > 0 &&
+      centerY >= clipRect.top &&
+      centerY <= clipRect.bottom &&
+      centerX >= clipRect.left &&
+      centerX <= clipRect.right
+    );
+  }
+
+  function textNodeIntersectsRoot(range, textNode, rootRect) {
+    range.selectNodeContents(textNode);
+
+    for (const rect of Array.from(range.getClientRects())) {
+      if (rectIntersectsRoot(rect, rootRect)) return true;
+    }
+
+    return rectIntersectsRoot(range.getBoundingClientRect?.(), rootRect);
+  }
+
+  function createVisibleSpaceMarker(character, rect, layerRect) {
+    const marker = document.createElement("div");
+    const kind = character === " " ? "half" : "full";
+    marker.className = `quill-visible-space-marker quill-visible-${kind}-space-marker`;
+
+    const charLeft = rect.left - layerRect.left;
+    const charTop = rect.top - layerRect.top;
+    const charWidth = rect.right - rect.left;
+    const charHeight = rect.bottom - rect.top;
+    const size =
+      kind === "half"
+        ? Math.max(2, Math.min(charWidth, charHeight) * 0.14)
+        : Math.max(8, Math.min(charWidth, charHeight) * 0.62);
+
+    marker.style.left = `${charLeft + (charWidth - size) / 2}px`;
+    marker.style.top =
+      kind === "half"
+        ? `${charTop + (charHeight - size) * 0.56}px`
+        : `${charTop + (charHeight - size) / 2}px`;
+    marker.style.width = `${size}px`;
+    marker.style.height = `${size}px`;
+    return marker;
+  }
+
+  function isVisibleSpaceTextNode(node) {
+    if (!node.textContent || !/[ \u3000]/.test(node.textContent)) return false;
+    const parent = node.parentElement;
+    if (!parent || parent.closest(".ql-cursor")) return false;
+    return true;
+  }
+
+  function renderVisibleSpaceOverlay() {
+    if (!quill?.root || !visibleSpaceLayer) return;
+    if (isVisibleSpaceComposing) return;
+    if (typeof document.createRange !== "function") return;
+
+    const layerRect = visibleSpaceLayer.getBoundingClientRect();
+    const rootRect = quill.root.getBoundingClientRect();
+    const visibleRect = getVisibleEditorRect();
+    if (
+      layerRect.width <= 0 ||
+      layerRect.height <= 0 ||
+      rootRect.width <= 0 ||
+      rootRect.height <= 0
+    ) {
+      return;
+    }
+
+    const range = document.createRange();
+    const fragment = document.createDocumentFragment();
+    const walker = document.createTreeWalker(quill.root, NodeFilter.SHOW_TEXT, {
+      acceptNode(node) {
+        return isVisibleSpaceTextNode(node) ? NodeFilter.FILTER_ACCEPT : NodeFilter.FILTER_REJECT;
+      },
+    });
+
+    let textNode = walker.nextNode();
+    while (textNode) {
+      const text = textNode.textContent ?? "";
+      if (!textNodeIntersectsRoot(range, textNode, rootRect)) {
+        textNode = walker.nextNode();
+        continue;
+      }
+      const clipRect = getVisibleClipRectForTextNode(textNode, visibleRect);
+      if (!clipRect) {
+        textNode = walker.nextNode();
+        continue;
+      }
+
+      for (let offset = 0; offset < text.length; offset += 1) {
+        const character = text[offset];
+        if (character !== " " && character !== "\u3000") continue;
+
+        const rect = getVisibleTextRect(range, textNode, offset);
+        if (!rectIntersectsRoot(rect, rootRect)) continue;
+        if (!rectCenterFitsVisibleClip(rect, clipRect)) continue;
+
+        fragment.appendChild(createVisibleSpaceMarker(character, rect, layerRect));
+      }
+      textNode = walker.nextNode();
+    }
+
+    range.detach?.();
+    visibleSpaceLayer.replaceChildren(fragment);
+  }
+
+  function cancelVisibleSpaceOverlayUpdate() {
+    if (visibleSpaceUpdateTimer !== null) {
+      clearTimeout(visibleSpaceUpdateTimer);
+      visibleSpaceUpdateTimer = null;
+    }
+    if (visibleSpaceAnimationFrame !== null) {
+      if (typeof cancelAnimationFrame === "function") {
+        cancelAnimationFrame(visibleSpaceAnimationFrame);
+      } else {
+        clearTimeout(visibleSpaceAnimationFrame);
+      }
+      visibleSpaceAnimationFrame = null;
+    }
+  }
+
+  function clearVisibleSpaceOverlay() {
+    visibleSpaceLayer?.replaceChildren();
+  }
+
+  function scheduleVisibleSpaceOverlayUpdate(delay = 0) {
+    if (!quill?.root || !visibleSpaceLayer) return;
+    if (isVisibleSpaceComposing) return;
+
+    if (visibleSpaceUpdateTimer !== null) {
+      clearTimeout(visibleSpaceUpdateTimer);
+      visibleSpaceUpdateTimer = null;
+    }
+
+    const requestUpdate = () => {
+      visibleSpaceUpdateTimer = null;
+      if (visibleSpaceAnimationFrame !== null) return;
+
+      const runUpdate = () => {
+        visibleSpaceAnimationFrame = null;
+        renderVisibleSpaceOverlay();
+      };
+
+      visibleSpaceAnimationFrame =
+        typeof requestAnimationFrame === "function"
+          ? requestAnimationFrame(runUpdate)
+          : setTimeout(runUpdate, 16);
+    };
+
+    if (delay > 0) {
+      visibleSpaceUpdateTimer = setTimeout(requestUpdate, delay);
+      return;
+    }
+
+    requestUpdate();
+  }
+
+  function scheduleVisibleSpaceTypingUpdate() {
+    scheduleVisibleSpaceOverlayUpdate();
+  }
+
+  function scheduleVisibleSpaceLayoutUpdate() {
+    scheduleVisibleSpaceOverlayUpdate();
+  }
+
+  function installVisibleSpaceOverlay() {
+    if (!quill?.root || visibleSpaceLayer) return;
+
+    const host = quill.root.parentElement;
+    if (!host) return;
+
+    host.classList.add("quill-visible-space-host");
+
+    visibleSpaceLayer = document.createElement("div");
+    visibleSpaceLayer.className = "quill-visible-space-layer";
+    visibleSpaceLayer.setAttribute("aria-hidden", "true");
+
+    host.appendChild(visibleSpaceLayer);
+
+    visibleSpaceScrollListener = scheduleVisibleSpaceLayoutUpdate;
+    quill.root.addEventListener("scroll", visibleSpaceScrollListener, { passive: true });
+    visibleSpaceBeforeInputListener = (event) => {
+      if (event.isComposing || event.inputType === "insertCompositionText") {
+        clearVisibleSpaceOverlay();
+      }
+    };
+    quill.root.addEventListener("beforeinput", visibleSpaceBeforeInputListener, true);
+    visibleSpaceCompositionStartListener = () => {
+      isVisibleSpaceComposing = true;
+      cancelVisibleSpaceOverlayUpdate();
+      clearVisibleSpaceOverlay();
+    };
+    quill.root.addEventListener("compositionstart", visibleSpaceCompositionStartListener, true);
+    visibleSpaceCompositionEndListener = () => {
+      isVisibleSpaceComposing = false;
+      scheduleVisibleSpaceLayoutUpdate();
+    };
+    quill.root.addEventListener("compositionend", visibleSpaceCompositionEndListener, true);
+    visibleSpaceResizeListener = scheduleVisibleSpaceLayoutUpdate;
+    window.addEventListener("resize", visibleSpaceResizeListener, { passive: true });
+    if (typeof ResizeObserver === "function") {
+      visibleSpaceResizeObserver = new ResizeObserver(scheduleVisibleSpaceLayoutUpdate);
+      visibleSpaceResizeObserver.observe(host);
+      visibleSpaceResizeObserver.observe(quill.root);
+    }
+    scheduleVisibleSpaceLayoutUpdate();
+  }
+
+  function removeVisibleSpaceOverlay() {
+    cancelVisibleSpaceOverlayUpdate();
+    if (visibleSpaceScrollListener && quill?.root) {
+      quill.root.removeEventListener("scroll", visibleSpaceScrollListener);
+    }
+    if (visibleSpaceBeforeInputListener && quill?.root) {
+      quill.root.removeEventListener("beforeinput", visibleSpaceBeforeInputListener, true);
+    }
+    if (visibleSpaceCompositionStartListener && quill?.root) {
+      quill.root.removeEventListener(
+        "compositionstart",
+        visibleSpaceCompositionStartListener,
+        true
+      );
+    }
+    if (visibleSpaceCompositionEndListener && quill?.root) {
+      quill.root.removeEventListener("compositionend", visibleSpaceCompositionEndListener, true);
+    }
+    if (visibleSpaceResizeListener) {
+      window.removeEventListener("resize", visibleSpaceResizeListener);
+    }
+    visibleSpaceResizeObserver?.disconnect();
+    visibleSpaceResizeObserver = null;
+    visibleSpaceBeforeInputListener = null;
+    visibleSpaceCompositionStartListener = null;
+    visibleSpaceCompositionEndListener = null;
+    visibleSpaceScrollListener = null;
+    visibleSpaceResizeListener = null;
+    isVisibleSpaceComposing = false;
+    visibleSpaceLayer?.remove();
+    visibleSpaceLayer = null;
+  }
+
   onMount(() => {
     quill = new Quill(editor, {
       theme: "snow",
@@ -295,6 +639,7 @@
 
     const initialContent = normalizeContent(content);
     applyContent(initialContent);
+    installVisibleSpaceOverlay();
     lastSavedContent = initialContent;
     quill.enable(!readOnly);
 
@@ -319,6 +664,7 @@
           saveMemo(contents);
         }
 
+        scheduleVisibleSpaceTypingUpdate();
         releaseEditingAfter(100);
       });
 
@@ -349,6 +695,7 @@
         clearTimeout(editReleaseTimer);
         editReleaseTimer = null;
       }
+      removeVisibleSpaceOverlay();
       isEditing = false;
       savedSelection = null;
       lastSavedContent = null;
@@ -374,6 +721,7 @@
       applyContent(normalizedContent);
       restoreSelection(savedSelection);
       lastSavedContent = normalizedContent;
+      scheduleVisibleSpaceOverlayUpdate();
       releaseEditingAfter(50);
     }
   }
@@ -398,8 +746,8 @@
 <style>
   .wrapper {
     --memo-editor-font:
-      "BIZ UDゴシック", "BIZ UDGothic", "Cascadia Mono", "Cascadia Code", Consolas, "Courier New",
-      monospace;
+      "BIZ UDゴシック", "BIZ UDGothic", "ＭＳ ゴシック", "MS Gothic", "Cascadia Mono",
+      "Cascadia Code", Consolas, "Courier New", monospace;
 
     display: flex;
     flex-direction: column;
@@ -460,8 +808,13 @@
 
   .wrapper :global(.ql-toolbar) {
     flex-shrink: 0;
+    padding: var(--sp1) var(--sp2) !important;
     border-color: var(--theme-color-Sub-dark) !important;
     background-color: var(--theme-color-Main-dark);
+  }
+
+  .wrapper :global(.ql-toolbar .ql-formats) {
+    margin-right: var(--sp1) !important;
   }
 
   .wrapper :global(.ql-toolbar .memo-table-picker) {
@@ -514,11 +867,13 @@
   }
 
   .wrapper :global(.ql-editor) {
+    position: relative;
+    z-index: 1;
     flex: 1 1 auto;
     height: auto;
     min-height: 0;
     overflow-y: auto;
-    padding: var(--sp3) var(--sp4);
+    padding: var(--sp2) var(--sp3);
     color: var(--theme-color-Sub-light);
     font-family: var(--memo-editor-font);
     font-size: var(--font-body-md);
@@ -527,7 +882,38 @@
     font-feature-settings:
       "liga" 0,
       "calt" 0;
-    line-height: 1.7;
+    line-height: 1.55;
+    white-space: break-spaces;
+    word-wrap: break-word;
+    overflow-wrap: anywhere;
+    word-break: normal;
+  }
+
+  .wrapper :global(.quill-visible-space-host) {
+    position: relative;
+  }
+
+  .wrapper :global(.quill-visible-space-layer) {
+    position: absolute;
+    inset: 0;
+    z-index: 2;
+    overflow: hidden;
+    pointer-events: none;
+  }
+
+  .wrapper :global(.quill-visible-space-marker) {
+    position: absolute;
+    box-sizing: border-box;
+    pointer-events: none;
+  }
+
+  .wrapper :global(.quill-visible-half-space-marker) {
+    border-radius: 50%;
+    background-color: color-mix(in srgb, var(--theme-color-Sub-main) 46%, transparent);
+  }
+
+  .wrapper :global(.quill-visible-full-space-marker) {
+    border: 1px solid color-mix(in srgb, var(--theme-color-Primary-main) 42%, transparent);
   }
 
   .wrapper :global(.ql-editor code),
@@ -547,15 +933,20 @@
   .wrapper :global(.ql-editor .ql-code-block-container) {
     color: var(--theme-color-Sub-light);
     background-color: var(--theme-color-Main-dark);
-    padding: var(--sp3) var(--sp4);
+    padding: var(--sp2) var(--sp3);
     border-radius: var(--shape-sm);
-    overflow-x: auto;
+    overflow-x: visible;
     margin: 0.75em 0;
     border: 1px solid color-mix(in srgb, var(--theme-color-Sub-dark) 25%, transparent);
+    white-space: break-spaces;
+    word-wrap: break-word;
+    overflow-wrap: anywhere;
+    word-break: normal;
   }
 
   .wrapper :global(.ql-editor table) {
     border-collapse: collapse;
+    table-layout: fixed;
     width: 100%;
     margin: 0.5em 0;
     color: var(--theme-color-Sub-light);
@@ -568,6 +959,17 @@
     padding: 0.3em 0.6em;
     min-width: 2.5rem;
     vertical-align: top;
+    white-space: break-spaces;
+    word-wrap: break-word;
+    overflow-wrap: anywhere;
+    word-break: normal;
+  }
+
+  .wrapper :global(.ql-editor .ql-code-block) {
+    white-space: break-spaces;
+    word-wrap: break-word;
+    overflow-wrap: anywhere;
+    word-break: normal;
   }
 
   .wrapper :global(.ql-editor table th),

--- a/src/features/navigation/components/Header.svelte
+++ b/src/features/navigation/components/Header.svelte
@@ -130,7 +130,7 @@
     use_ripple={false}
     activeColor={"transparent"}
     normalColor={"transparent"}
-    style={"box-shadow: none; height:3rem; width: 3rem"}
+    style={"box-shadow: none; height:2.5rem; width: 2.5rem; margin: 0;"}
   >
     {#if $sidebarCollapsed}
       <!-- Hamburger when the sidebar is hidden — clicking opens it. -->
@@ -455,8 +455,8 @@
 
 <style>
   h1.Title {
-    margin: 0 var(--sp4);
-    font-size: var(--font-title-lg);
+    margin: 0 var(--sp2);
+    font-size: var(--font-title-md);
     font-weight: 500;
   }
   .Container {
@@ -464,7 +464,7 @@
     flex-direction: row;
     justify-content: left;
     align-items: center;
-    gap: var(--sp3);
+    gap: var(--sp2);
     box-shadow: var(--elevation-2);
     width: 100%;
     height: 100%;
@@ -488,13 +488,13 @@
   .Menu {
     flex-shrink: 0;
     flex-grow: 0;
-    margin: var(--sp4);
+    margin: var(--sp2);
     height: 100%;
   }
   .Title {
     flex-shrink: 0;
     flex-grow: 0;
-    margin: var(--sp4);
+    margin: var(--sp2);
   }
 
   /* Browser-style back/forward navigation through the visited-page history. */
@@ -508,8 +508,8 @@
     display: inline-flex;
     align-items: center;
     justify-content: center;
-    width: 2rem;
-    height: 2rem;
+    width: 1.75rem;
+    height: 1.75rem;
     padding: 0;
     margin: 0;
     border: 1px solid rgba(255, 255, 255, 0.25);
@@ -551,7 +551,7 @@
     flex: 1 1 auto;
     max-width: 25rem;
     min-width: 8rem;
-    padding: var(--sp1) var(--sp2);
+    padding: 2px var(--sp2);
     border: 1px solid rgba(255, 255, 255, 0.25);
     border-radius: var(--shape-sm);
     background-color: rgba(255, 255, 255, 0.12);
@@ -648,8 +648,8 @@
     display: inline-flex;
     align-items: center;
     justify-content: center;
-    width: 2rem;
-    height: 2rem;
+    width: 1.75rem;
+    height: 1.75rem;
     flex-shrink: 0;
     border: 1px solid rgba(255, 255, 255, 0.25);
     border-radius: var(--shape-sm);
@@ -698,14 +698,14 @@
   .HeaderRight {
     display: flex;
     align-items: center;
-    gap: var(--sp3);
+    gap: var(--sp2);
     margin-left: auto;
   }
   .SaveIndicator {
     display: flex;
     align-items: center;
     gap: var(--sp1);
-    padding: var(--sp1) var(--sp2);
+    padding: 0 var(--sp2);
     border-radius: var(--shape-xs);
     font-size: var(--font-label-md);
     color: rgba(255, 255, 255, 0.92);
@@ -730,12 +730,18 @@
   .ToggleSwitchContainer {
     flex-shrink: 0;
   }
+  .ToggleSwitchContainer :global(> div) {
+    margin: 0;
+  }
+  .ToggleSwitchContainer :global(span) {
+    margin: 0 var(--sp1);
+  }
   .SettingsBtn {
     display: inline-flex;
     align-items: center;
     justify-content: center;
-    width: 2rem;
-    height: 2rem;
+    width: 1.75rem;
+    height: 1.75rem;
     flex-shrink: 0;
     padding: 0;
     margin: 0;
@@ -768,9 +774,9 @@
     -webkit-app-region: no-drag;
   }
   .WinCtrlBtn {
-    width: 2.75rem;
+    width: 2.5rem;
     height: 100%;
-    min-height: 2.5rem;
+    min-height: 2.25rem;
     display: inline-flex;
     align-items: center;
     justify-content: center;

--- a/src/features/tasks/components/TaskDetail.svelte
+++ b/src/features/tasks/components/TaskDetail.svelte
@@ -1,5 +1,9 @@
 ﻿<script>
-  import { getNode, updateNodeDataById } from "@features/tasks/utils/tree_control";
+  import {
+    getNode,
+    isNodeEffectivelyArchived,
+    updateNodeDataById,
+  } from "@features/tasks/utils/tree_control";
   import { uuidV4 } from "@lib/utils/uuid";
   import {
     tree_data,
@@ -44,7 +48,7 @@
   $: name = node ? node.data["name"] : "Select Task";
   $: memo = node ? node.data["memo"] : [];
   $: attachments = node ? (node.data["attachments"] ?? []) : [];
-  $: isArchived = !!node?.archived;
+  $: isArchived = isNodeEffectivelyArchived($table_selected_id, $tree_data?.data);
   $: isWorkspaceProject = $selected_type === "WorkspaceProject";
   $: workspaceProjectDir = isWorkspaceProject ? $workspace_store.activeProjectDir : null;
   $: defaultMemoFormat = isWorkspaceProject ? "markdown" : "quill";
@@ -534,6 +538,7 @@
         variant="text"
         normalColor={"var(--theme-color-Sub-main)"}
         activeColor={"var(--theme-color-Primary-main)"}
+        style={"width: 1.75rem; height: 1.75rem; margin: 0;"}
         on:click={openTaskDetailInWindow}
       >
         <svg viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
@@ -836,13 +841,13 @@
     display: grid;
     grid-template-columns: 1fr 1fr;
     align-content: start;
-    gap: var(--sp2) var(--sp4);
+    gap: var(--sp1) var(--sp3);
     flex: 1;
     width: 100%;
     height: 100%;
     min-height: 0;
     box-sizing: border-box;
-    padding: var(--sp3);
+    padding: var(--sp2);
     overflow: auto;
     container-type: inline-size;
   }
@@ -855,7 +860,7 @@
     display: flex;
     flex-direction: column;
     align-items: stretch;
-    gap: 0.2rem;
+    gap: 0.1rem;
     min-width: 0;
     color: var(--theme-color-Sub-main);
   }
@@ -888,7 +893,7 @@
     align-items: center;
     flex: 1 1 auto;
     min-width: 0;
-    height: 2rem;
+    height: 1.75rem;
     box-sizing: border-box;
     border: 1px solid color-mix(in srgb, var(--theme-color-Sub-main) 30%, transparent);
     border-radius: var(--shape-sm);
@@ -932,7 +937,7 @@
     min-height: 0;
     box-sizing: border-box;
     margin: 0;
-    padding: var(--sp3);
+    padding: var(--sp1);
     overflow: hidden;
   }
   .memotab-container > :global(.container) {

--- a/src/features/tasks/components/TreeTable.svelte
+++ b/src/features/tasks/components/TreeTable.svelte
@@ -44,6 +44,7 @@
     bulkDuplicate,
     areAllSiblings,
     isContiguousSiblingBlock,
+    isNodeEffectivelyArchived,
     getTopLevelSelection,
     archiveNode,
     restoreNode,
@@ -882,7 +883,7 @@
     for (const id of targetIds) {
       const n = getNode(id, $tree_data.data);
       if (!n) continue;
-      if (n.archived) permanentIds.push(id);
+      if (isNodeEffectivelyArchived(id, $tree_data.data)) permanentIds.push(id);
       else archiveIds.push(id);
     }
     bulkArchiveTargetIds = archiveIds;

--- a/src/features/tasks/utils/tree_control.ts
+++ b/src/features/tasks/utils/tree_control.ts
@@ -417,6 +417,42 @@ export function flattenVisibleTree(
   return rows;
 }
 
+type TreePathEntry = {
+  node: TreeData;
+  parent?: TreeData;
+};
+
+function findPathToNode(
+  target: string,
+  tree_data: TreeData | undefined
+): TreePathEntry[] | undefined {
+  if (!tree_data) return undefined;
+  const path: TreePathEntry[] = [];
+
+  function visit(node: TreeData, parent?: TreeData): boolean {
+    path.push({ node, parent });
+    if (node.id === target) return true;
+
+    for (const child of node.children) {
+      if (visit(child, node)) return true;
+    }
+
+    path.pop();
+    return false;
+  }
+
+  return visit(tree_data) ? path : undefined;
+}
+
+export function isNodeEffectivelyArchived(
+  target: string | undefined,
+  tree_data: TreeData | undefined
+): boolean {
+  if (!target) return false;
+  const path = findPathToNode(target, tree_data);
+  return !!path?.some(({ node }) => node.archived);
+}
+
 // 各行に対し、ルートから現在ノードまでの名前パス ("root / a / b / current") を返す。
 // 行は flattenVisibleTree の DFS 順 (親が子より先) なので、親のパスを引いて連結するだけで O(N)。
 export function buildNodePathMap(rows: VisibleTreeRow[]): Map<string, string> {
@@ -863,26 +899,36 @@ export function archiveNode(target: string, tree_data: TreeData): TreeData {
 /** ノードの archived を解除する。`archivedAt` も消す。 */
 export function restoreNode(target: string, tree_data: TreeData): TreeData {
   if (target === tree_data.id) return tree_data;
-  const parent = getParent(target, tree_data);
-  if (!parent) return tree_data;
-  for (const child of parent.children) {
-    if (child.id === target) {
-      if (!child.archived) return tree_data;
-      delete child.archived;
-      delete child.archivedAt;
-      // 復元時は元の親の末尾へ移動する。元親 ID をエントリに残していない
-      // 設計のため、archived 中も子は親の children 配列内にいる前提で、
-      // 末尾に詰め直す（同 parent の他の active 兄弟の後ろになるため、
-      // archived 表示時の並びと整合する）。
-      const index = parent.children.findIndex((c) => c.id === target);
-      if (index >= 0 && index !== parent.children.length - 1) {
-        const [moved] = parent.children.splice(index, 1);
-        parent.children.push(moved);
-      }
-      return tree_data;
+  const path = findPathToNode(target, tree_data);
+  if (!path) return tree_data;
+
+  for (const { node, parent } of path) {
+    if (!parent || !node.archived) continue;
+    delete node.archived;
+    delete node.archivedAt;
+    // 復元時は元の親の末尾へ移動する。元親 ID をエントリに残していない
+    // 設計のため、archived 中も子は親の children 配列内にいる前提で、
+    // 末尾に詰め直す（同 parent の他の active 兄弟の後ろになるため、
+    // archived 表示時の並びと整合する）。
+    const index = parent.children.findIndex((c) => c.id === node.id);
+    if (index >= 0 && index !== parent.children.length - 1) {
+      const [moved] = parent.children.splice(index, 1);
+      parent.children.push(moved);
     }
   }
+
   return tree_data;
+}
+
+function getRestoreNodeIds(target: string, tree_data: TreeData): Set<string> {
+  const path = findPathToNode(target, tree_data);
+  const ids = new Set<string>();
+  for (const entry of path ?? []) {
+    if (entry.parent && entry.node.archived) {
+      ids.add(entry.node.id);
+    }
+  }
+  return ids;
 }
 
 /** archived フラグを無視して、対象ノードをツリーから物理削除する。 */
@@ -910,11 +956,21 @@ export function bulkArchiveNodes(tree_data: TreeData, ids: Set<string>): TreeDat
 /** 複数まとめて restore する。 */
 export function bulkRestoreNodes(tree_data: TreeData, ids: Set<string>): TreeData {
   if (ids.size === 0) return tree_data;
+  const restoreIds = new Set<string>();
+
+  for (const id of ids) {
+    for (const restoreId of getRestoreNodeIds(id, tree_data)) {
+      restoreIds.add(restoreId);
+    }
+  }
+
+  if (restoreIds.size === 0) return tree_data;
+
   function visit(node: TreeData) {
     let i = 0;
     while (i < node.children.length) {
       const child = node.children[i];
-      if (ids.has(child.id) && child.archived) {
+      if (restoreIds.has(child.id) && child.archived) {
         delete child.archived;
         delete child.archivedAt;
         // 末尾へ移動

--- a/src/lib/primitives/Card.svelte
+++ b/src/lib/primitives/Card.svelte
@@ -41,7 +41,8 @@
     align-items: center;
     gap: var(--sp2);
     flex-shrink: 0;
-    padding: var(--sp2) var(--sp4);
+    min-height: 2.25rem;
+    padding: var(--sp1) var(--sp3);
     border-bottom: 1px solid color-mix(in srgb, var(--theme-color-Sub-main) 20%, transparent);
     background-color: color-mix(
       in srgb,
@@ -52,7 +53,7 @@
   .CardHeaderTitle {
     flex: 1 1 auto;
     min-width: 0;
-    font-size: var(--font-title-md);
+    font-size: var(--font-title-sm);
     font-weight: 600;
     color: var(--theme-color-Sub-main);
     line-height: 1.2;
@@ -60,6 +61,9 @@
     overflow: hidden;
     text-overflow: ellipsis;
     white-space: nowrap;
+  }
+  .CardHeader :global(button) {
+    margin: 0;
   }
   .CardBody {
     display: flex;

--- a/src/pages/MainPage.svelte
+++ b/src/pages/MainPage.svelte
@@ -36,6 +36,7 @@
     bulkOutdent,
     areAllSiblings,
     isContiguousSiblingBlock,
+    isNodeEffectivelyArchived,
     archiveNode,
     restoreNode,
     bulkArchiveNodes,
@@ -373,7 +374,7 @@
       for (const id of ids) {
         const n = getNode(id, $tree_data.data);
         if (!n) continue;
-        if (n.archived) permanentIds.push(id);
+        if (isNodeEffectivelyArchived(id, $tree_data.data)) permanentIds.push(id);
         else archiveIds.push(id);
       }
       archive_target_ids = archiveIds;
@@ -426,15 +427,13 @@
   // 選択中の anchor が archived かどうか（toolbar のアイコン切替に使う）
   $: anchorIsArchived = (() => {
     if (!$tree_data?.data || !$table_selected_id) return false;
-    const node = getNode($table_selected_id, $tree_data.data);
-    return !!node?.archived;
+    return isNodeEffectivelyArchived($table_selected_id, $tree_data.data);
   })();
   // 選択中のどこかに archived が含まれているか（restore ボタン表示の判定に使う）
   $: selectionHasArchived = (() => {
     if (!$tree_data?.data) return false;
     for (const id of $selected_ids) {
-      const node = getNode(id, $tree_data.data);
-      if (node?.archived) return true;
+      if (isNodeEffectivelyArchived(id, $tree_data.data)) return true;
     }
     return anchorIsArchived;
   })();
@@ -1059,12 +1058,17 @@
     box-sizing: border-box;
     flex: 0 0 auto;
   }
+  .TbGroup :global(button) {
+    width: 1.75rem;
+    height: 1.75rem;
+    margin: 0;
+  }
   .TbSearch {
     display: flex;
     flex: 1 1 auto;
     align-items: center;
     margin-left: auto;
-    height: 2rem;
+    height: 1.75rem;
     min-width: 8rem;
     max-width: 22rem;
   }
@@ -1075,7 +1079,7 @@
     gap: var(--sp2);
     width: 100%;
     min-width: 0;
-    padding: var(--sp2) var(--sp3);
+    padding: var(--sp1) var(--sp2);
     box-sizing: border-box;
     flex-wrap: wrap;
     border-bottom: 1px solid color-mix(in srgb, var(--theme-color-Sub-main) 12%, transparent);

--- a/src/pages/TaskDetailPage.svelte
+++ b/src/pages/TaskDetailPage.svelte
@@ -69,9 +69,9 @@
     flex-direction: column;
     width: 100%;
     height: 100%;
-    padding: var(--sp4);
+    padding: var(--sp2);
     box-sizing: border-box;
-    gap: var(--sp4);
+    gap: var(--sp2);
     background: var(--theme-color-Main-dark);
     color: var(--theme-color-Sub-main);
   }
@@ -80,11 +80,14 @@
     display: flex;
     justify-content: space-between;
     align-items: flex-start;
-    gap: var(--sp4);
+    gap: var(--sp2);
+    flex-shrink: 0;
   }
 
   .detail-meta h1 {
     margin: 0;
+    font-size: var(--font-title-md);
+    line-height: 1.2;
   }
 
   .detail-body {

--- a/tests/component/Memo.test.js
+++ b/tests/component/Memo.test.js
@@ -29,9 +29,15 @@ vi.mock("quill", () => {
       this.on = vi.fn((event, callback) => {
         this.handlers[event] = callback;
       });
+      this.off = vi.fn();
       this.enable = vi.fn();
-      this.setContents = vi.fn();
-      this.setText = vi.fn();
+      this.setContents = vi.fn((value) => {
+        const ops = Array.isArray(value) ? value : (value?.ops ?? []);
+        this.root.textContent = ops.map((op) => op.insert ?? "").join("");
+      });
+      this.setText = vi.fn((value) => {
+        this.root.textContent = value;
+      });
       this.getContents = vi.fn(() => ({ ops: [{ insert: "changed\n" }] }));
       this.getLength = vi.fn(() => 0);
       this._selection = null;
@@ -41,8 +47,14 @@ vi.mock("quill", () => {
       this.setSelection = vi.fn((index, length = 0) => {
         this._selection = { index, length };
       });
-      this.deleteText = vi.fn();
-      this.insertText = vi.fn();
+      this.deleteText = vi.fn((index, length) => {
+        const current = this.root.textContent ?? "";
+        this.root.textContent = `${current.slice(0, index)}${current.slice(index + length)}`;
+      });
+      this.insertText = vi.fn((index, text) => {
+        const current = this.root.textContent ?? "";
+        this.root.textContent = `${current.slice(0, index)}${text}${current.slice(index)}`;
+      });
       this.getModule = vi.fn((name) => {
         if (name === "toolbar") return { container: this.toolbarContainer };
         if (name === "table") return this.tableModule;
@@ -81,6 +93,10 @@ vi.mock("quill", () => {
       quillInstances.push(this);
     }
   }
+  MockQuill.events = {
+    SCROLL_UPDATE: "scroll-update",
+    SCROLL_OPTIMIZE: "scroll-optimize",
+  };
   return { default: MockQuill };
 });
 
@@ -116,11 +132,20 @@ async function renderMarkdownMemo(props = {}) {
 
 async function openMarkdownEditor(props = {}) {
   await renderMarkdownMemo(props);
-  await fireEvent.click(document.querySelector(".edit-mode-btn"));
+  await chooseMarkdownMode("edit");
   await waitFor(() => {
     expect(document.querySelector(".cm-editor")).toBeInTheDocument();
   });
   return EditorView.findFromDOM(document.querySelector(".cm-editor"));
+}
+
+async function chooseMarkdownMode(mode) {
+  const trigger = document.querySelector(".memo-mode-trigger");
+  expect(trigger).toBeInTheDocument();
+  await fireEvent.click(trigger);
+  const option = document.querySelector(`.memo-mode-option[data-mode="${mode}"]`);
+  expect(option).toBeInTheDocument();
+  await fireEvent.click(option);
 }
 
 function markdownToolButton(label) {
@@ -305,6 +330,65 @@ describe("Memo mode routing", () => {
     expect(select.value).toBe("");
   });
 
+  test("installs a visible-space layer without replacing Quill editor text", async () => {
+    await renderMemo({
+      saveMemo: vi.fn(),
+      content: " leading　full",
+      isWorkspaceProject: false,
+    });
+
+    expect(document.querySelector(".quill-visible-space-layer")).toBeInTheDocument();
+    expect(quillInstances[0].root.textContent).toBe(" leading　full");
+  });
+
+  test("clears stale Quill visible-space markers while composing full-width text", async () => {
+    await renderMemo({
+      saveMemo: vi.fn(),
+      content: "a 　b",
+      isWorkspaceProject: false,
+    });
+    const quill = quillInstances[0];
+    const layer = document.querySelector(".quill-visible-space-layer");
+
+    expect(layer).toBeInTheDocument();
+    layer.appendChild(document.createElement("span"));
+    expect(layer.childElementCount).toBe(1);
+
+    await fireEvent.compositionStart(quill.root);
+    expect(layer.childElementCount).toBe(0);
+  });
+
+  test("observes Quill editor resizes for visible-space placement", async () => {
+    const originalResizeObserver = globalThis.ResizeObserver;
+    const observe = vi.fn();
+    const disconnect = vi.fn();
+    globalThis.ResizeObserver = vi.fn(function MockResizeObserver() {
+      this.observe = observe;
+      this.disconnect = disconnect;
+    });
+
+    try {
+      const result = await renderMemo({
+        saveMemo: vi.fn(),
+        content: " leading　full",
+        isWorkspaceProject: false,
+      });
+      const quill = quillInstances[0];
+
+      expect(observe).toHaveBeenCalledWith(quill.root.parentElement);
+      expect(observe).toHaveBeenCalledWith(quill.root);
+
+      result.unmount();
+      expect(disconnect).toHaveBeenCalled();
+    } finally {
+      if (originalResizeObserver) {
+        globalThis.ResizeObserver = originalResizeObserver;
+      } else {
+        delete globalThis.ResizeObserver;
+      }
+    }
+  });
+
   test("adds distinct Quill inline and block code toolbar buttons", async () => {
     await renderMemo({ saveMemo: vi.fn(), content: "", isWorkspaceProject: false });
     const inlineCode = quillInstances[0].toolbarContainer.querySelector("button.ql-code");
@@ -389,6 +473,14 @@ describe("Markdown Memo - view mode", () => {
     await renderMarkdownMemo({ saveMemo, content: "" });
     expect(document.querySelector(".cm-editor")).not.toBeInTheDocument();
     expect(document.querySelector(".preview-mode")).toBeInTheDocument();
+    const modeTrigger = document.querySelector(".memo-mode-trigger");
+    expect(modeTrigger).toHaveAttribute("aria-label", "Memo mode: Preview");
+    expect(modeTrigger.querySelector(".memo-mode-icon svg")).toBeInTheDocument();
+
+    await fireEvent.click(modeTrigger);
+    expect(
+      [...document.querySelectorAll(".memo-mode-option-label")].map((node) => node.textContent)
+    ).toEqual(["Preview", "Edit", "Split"]);
   });
 
   test("shows placeholder when content is empty", async () => {
@@ -467,12 +559,35 @@ describe("Markdown Memo - edit mode", () => {
     delete window.electronAPI;
   });
 
-  test("clicking edit mode switch shows CM6 editor", async () => {
+  test("choosing edit mode shows only the CM6 editor", async () => {
     await renderMarkdownMemo({ saveMemo, content: "hello" });
-    await fireEvent.click(document.querySelector(".edit-mode-btn"));
+    await chooseMarkdownMode("edit");
     await waitFor(() => {
       expect(document.querySelector(".cm-editor")).toBeInTheDocument();
     });
+    expect(document.querySelector(".markdown-split-resizer")).not.toBeInTheDocument();
+    expect(document.querySelector(".live-preview")).not.toBeInTheDocument();
+  });
+
+  test("installs a visible-space layer without replacing Markdown editor text", async () => {
+    await openMarkdownEditor({ saveMemo, content: " leading　full" });
+
+    expect(document.querySelector(".cm-visibleSpaceLayer")).toBeInTheDocument();
+    expect(document.querySelector(".cm-content").textContent).toBe(" leading　full");
+  });
+
+  test("keeps the caret after a full-width space in the Markdown editor", async () => {
+    const view = await openMarkdownEditor({ saveMemo, content: "" });
+
+    view.dispatch({
+      changes: { from: 0, insert: "　" },
+      selection: { anchor: 1 },
+      userEvent: "input.type",
+    });
+    await tick();
+
+    expect(view.state.doc.toString()).toBe("　");
+    expect(view.state.selection.main.from).toBe(1);
   });
 
   test("inserts a Markdown table from the edit toolbar", async () => {
@@ -584,7 +699,7 @@ describe("Markdown Memo - edit mode", () => {
       content: "",
       memoTitles: ["Daily Notes", "Research Log"],
     });
-    await fireEvent.click(document.querySelector(".edit-mode-btn"));
+    await chooseMarkdownMode("edit");
     await waitFor(() => {
       expect(document.querySelector(".cm-editor")).toBeInTheDocument();
     });
@@ -611,7 +726,7 @@ describe("Markdown Memo - edit mode", () => {
       memoTitles: ["Daily Notes", "Research Log"],
       currentMemoTitle: "Daily Notes",
     });
-    await fireEvent.click(document.querySelector(".edit-mode-btn"));
+    await chooseMarkdownMode("edit");
     await waitFor(() => {
       expect(document.querySelector(".cm-editor")).toBeInTheDocument();
     });
@@ -632,17 +747,30 @@ describe("Markdown Memo - edit mode", () => {
     });
   });
 
-  test("edit mode shows read mode switch", async () => {
+  test("edit mode shows the same mode dropdown", async () => {
     await renderMarkdownMemo({ saveMemo, content: "hello" });
-    await fireEvent.click(document.querySelector(".edit-mode-btn"));
+    await chooseMarkdownMode("edit");
     await waitFor(() => {
-      expect(document.querySelector(".read-mode-btn")).toBeInTheDocument();
+      expect(document.querySelector(".memo-mode-trigger")).toHaveAttribute(
+        "aria-label",
+        "Memo mode: Edit"
+      );
+    });
+  });
+
+  test("choosing split mode shows editor and live preview", async () => {
+    await renderMarkdownMemo({ saveMemo, content: "# hello" });
+    await chooseMarkdownMode("split");
+    await waitFor(() => {
+      expect(document.querySelector(".cm-editor")).toBeInTheDocument();
+      expect(document.querySelector(".markdown-split-resizer")).toBeInTheDocument();
+      expect(document.querySelector(".live-preview .preview h1")).toHaveTextContent("hello");
     });
   });
 
   test("lets the markdown editor and preview split be resized with the keyboard", async () => {
     await renderMarkdownMemo({ saveMemo, content: "hello" });
-    await fireEvent.click(document.querySelector(".edit-mode-btn"));
+    await chooseMarkdownMode("split");
     await waitFor(() => {
       expect(document.querySelector(".markdown-split-resizer")).toBeInTheDocument();
     });
@@ -659,12 +787,17 @@ describe("Markdown Memo - edit mode", () => {
     expect(editBody.getAttribute("style")).toContain("--editor-pane-width: 72%");
   });
 
-  test("clicking read mode switch returns to view mode", async () => {
+  test("choosing preview mode returns to view mode", async () => {
     await renderMarkdownMemo({ saveMemo, content: "hello" });
-    await fireEvent.click(document.querySelector(".edit-mode-btn"));
-    await waitFor(() => expect(document.querySelector(".read-mode-btn")).toBeInTheDocument());
+    await chooseMarkdownMode("edit");
+    await waitFor(() =>
+      expect(document.querySelector(".memo-mode-trigger")).toHaveAttribute(
+        "aria-label",
+        "Memo mode: Edit"
+      )
+    );
 
-    await fireEvent.click(document.querySelector(".read-mode-btn"));
+    await chooseMarkdownMode("preview");
     await tick();
 
     expect(document.querySelector(".cm-editor")).not.toBeInTheDocument();
@@ -686,12 +819,17 @@ describe("Markdown Memo - edit mode", () => {
     vi.useRealTimers();
   });
 
-  test("switching back to read mode without changes does not call saveMemo", async () => {
+  test("switching back to preview mode without changes does not call saveMemo", async () => {
     await renderMarkdownMemo({ saveMemo, content: "hello" });
-    await fireEvent.click(document.querySelector(".edit-mode-btn"));
-    await waitFor(() => expect(document.querySelector(".read-mode-btn")).toBeInTheDocument());
+    await chooseMarkdownMode("edit");
+    await waitFor(() =>
+      expect(document.querySelector(".memo-mode-trigger")).toHaveAttribute(
+        "aria-label",
+        "Memo mode: Edit"
+      )
+    );
 
-    await fireEvent.click(document.querySelector(".read-mode-btn"));
+    await chooseMarkdownMode("preview");
     await tick();
 
     expect(saveMemo).not.toHaveBeenCalled();
@@ -712,7 +850,7 @@ describe("Markdown Memo - edit mode", () => {
       taskId: "task-1",
     });
 
-    await fireEvent.click(document.querySelector(".edit-mode-btn"));
+    await chooseMarkdownMode("edit");
     await waitFor(() => {
       expect(document.querySelector(".cm-editor")).toBeInTheDocument();
     });
@@ -809,7 +947,7 @@ describe("Markdown Memo - link handling in preview", () => {
     expect(window.electronAPI.openExternalLink).toHaveBeenCalledWith("https://example.com/");
   });
 
-  test("clicking non-link preview area stays in read mode", async () => {
+  test("clicking non-link preview area stays in preview mode", async () => {
     await renderMarkdownMemo({ saveMemo, content: "plain text" });
     await fireEvent.click(document.querySelector(".preview-mode"));
     await tick();

--- a/tests/unit/archive.test.ts
+++ b/tests/unit/archive.test.ts
@@ -4,6 +4,7 @@ import {
   bulkArchiveNodes,
   bulkRestoreNodes,
   flattenVisibleTree,
+  isNodeEffectivelyArchived,
   restoreNode,
   stripArchivedNodes,
   type TreeData,
@@ -80,6 +81,39 @@ describe("archive / restore tree helpers", () => {
     const before = tree.children.map((c) => c.id);
     restoreNode("b", tree);
     expect(tree.children.map((c) => c.id)).toEqual(before);
+  });
+
+  test("restoreNode restores archived ancestors for an effectively archived child", () => {
+    const tree = makeTree();
+    archiveNode("a", tree);
+
+    restoreNode("a1", tree);
+
+    const a = tree.children.find((c) => c.id === "a")!;
+    expect(tree.children.map((c) => c.id)).toEqual(["b", "c", "a"]);
+    expect(a.archived).toBeUndefined();
+    expect(a.archivedAt).toBeUndefined();
+    expect(a.children.map((c) => c.id)).toEqual(["a1", "a2"]);
+  });
+
+  test("bulkRestoreNodes restores archived ancestors for selected descendants", () => {
+    const tree = makeTree();
+    archiveNode("a", tree);
+
+    bulkRestoreNodes(tree, new Set(["a1"]));
+
+    const a = tree.children.find((c) => c.id === "a")!;
+    expect(tree.children.map((c) => c.id)).toEqual(["b", "c", "a"]);
+    expect(a.archived).toBeUndefined();
+  });
+
+  test("isNodeEffectivelyArchived includes archived ancestors", () => {
+    const tree = makeTree();
+    archiveNode("a", tree);
+
+    expect(isNodeEffectivelyArchived("a", tree)).toBe(true);
+    expect(isNodeEffectivelyArchived("a1", tree)).toBe(true);
+    expect(isNodeEffectivelyArchived("b", tree)).toBe(false);
   });
 
   test("bulkArchiveNodes は複数ノードに同じ archivedAt を一括で立てる", () => {


### PR DESCRIPTION
## Summary
- Restores archived child tasks together with archived ancestors so restore actions visibly recover the task path.
- Tightens the app chrome, task detail card headers, memo spacing, and tag input sizing.
- Reworks Markdown memo viewing with Preview/Edit/Split modes and improves visible whitespace handling in both Markdown and Quill editors.
- Reduces unnecessary Quill whitespace overlay redraw work while keeping resize, scroll, and composition-end updates.

## Validation
- `svelte-check --tsconfig ./tsconfig.json`
- `vitest run tests/component/Memo.test.js --pool=threads`
- `vite build`
- `npm run lint`
- `npm run format:check`
- `npm test`