### PR TITLE
[codex] fix markdown preview image scaling

### DIFF
--- a/src/features/memos/components/MarkdownMemo.svelte
+++ b/src/features/memos/components/MarkdownMemo.svelte
@@ -78,6 +78,8 @@
   const SPLIT_MIN_PERCENT = 30;
   const SPLIT_MAX_PERCENT = 72;
   const SPLIT_KEY_STEP = 5;
+  const PREVIEW_IMAGE_MAX_WIDTH_VAR = "--memo-preview-image-max-width";
+  const measuredPreviewImages = new WeakSet<HTMLImageElement>();
 
   const EXTERNAL_LINK_PATTERN = /^(https?:\/\/|mailto:|file:\/\/)/i;
   // Quill 標準の `code` と `code-block` は同じ SVG (`<>`) で視覚的に区別できないため、
@@ -989,6 +991,24 @@
     });
   }
 
+  function syncPreviewImageNaturalWidth(image: HTMLImageElement) {
+    if (image.naturalWidth > 0) {
+      image.style.setProperty(PREVIEW_IMAGE_MAX_WIDTH_VAR, `${image.naturalWidth}px`);
+    }
+  }
+
+  function applyPreviewImageNaturalWidths(root: HTMLElement | null) {
+    if (!root) return;
+
+    root.querySelectorAll<HTMLImageElement>("img").forEach((image) => {
+      syncPreviewImageNaturalWidth(image);
+
+      if (measuredPreviewImages.has(image)) return;
+      measuredPreviewImages.add(image);
+      image.addEventListener("load", () => syncPreviewImageNaturalWidth(image), { once: true });
+    });
+  }
+
   // mermaid の初期化はテーマに依存する。最初の renderMermaidBlocks 呼び出し
   // および theme 変更時に setupMermaidTheme で再初期化する。
   let mermaidThemeApplied: "dark" | "default" | null = null;
@@ -1044,6 +1064,8 @@
     }) as string;
     renderedHtml = baseHtml;
     await tick();
+    applyPreviewImageNaturalWidths(previewEl);
+    applyPreviewImageNaturalWidths(livePreviewEl);
     injectCopyButtons(previewEl);
     injectCopyButtons(livePreviewEl);
     await renderMermaidBlocks(previewEl);
@@ -1053,6 +1075,8 @@
     if (sequence === renderSequence) {
       renderedHtml = nextHtml;
       await tick();
+      applyPreviewImageNaturalWidths(previewEl);
+      applyPreviewImageNaturalWidths(livePreviewEl);
       injectCopyButtons(previewEl);
       injectCopyButtons(livePreviewEl);
       await renderMermaidBlocks(previewEl);
@@ -2118,7 +2142,9 @@
 
   .preview :global(img) {
     display: block;
-    max-width: min(100%, 48rem);
+    box-sizing: border-box;
+    width: min(100%, var(--memo-preview-image-max-width, 100%));
+    max-width: 100%;
     height: auto;
     margin: var(--sp3) 0;
     border-radius: var(--shape-md);

--- a/tests/component/Memo.test.js
+++ b/tests/component/Memo.test.js
@@ -439,6 +439,18 @@ describe("Markdown Memo - view mode", () => {
     });
   });
 
+  test("caps markdown preview image growth at the image's natural width", async () => {
+    await renderMarkdownMemo({ saveMemo, content: "![Diagram](data:image/png;base64,AAAA)" });
+
+    const image = document.querySelector(".preview img");
+    expect(image).toBeInTheDocument();
+
+    Object.defineProperty(image, "naturalWidth", { configurable: true, value: 640 });
+    await fireEvent.load(image);
+
+    expect(image.style.getPropertyValue("--memo-preview-image-max-width")).toBe("640px");
+  }, 30000);
+
   test("converts legacy Quill Delta object to readable markdown text in workspace view", async () => {
     const delta = { ops: [{ insert: "hello" }, { insert: "\nworld" }] };
     await renderMarkdownMemo({ saveMemo, content: delta });


### PR DESCRIPTION
## Summary

- Removed the fixed `48rem` markdown preview image cap.
- Measure rendered markdown images after load and cap growth at each image's natural pixel width.
- Added a component test covering the natural-width cap behavior.

## Why

Markdown preview images were limited by an artificial max width, so they did not grow with wider preview panes in the same way users expected from Quill-rendered images.

## Validation

- `vitest run tests/component/Memo.test.js`
- `svelte-check --tsconfig .\tsconfig.json`
