### PR TITLE
[codex] improve task detail window UX

### DIFF
--- a/src/App.svelte
+++ b/src/App.svelte
@@ -89,12 +89,27 @@
 
         const workspaceProject = await platform.wsReadProject(detailWindowProjectDir);
         if (workspaceProject) {
+          const workspaceRootTask = Object.values(workspaceProject.tasks ?? {}).find(
+            (task) => task.parents.length === 0
+          );
+          const effectiveProjectId = workspaceRootTask?.id || detailWindowProjectId;
+
+          detailWindowProjectId = effectiveProjectId;
+          setTaskDetailWindowTarget(effectiveProjectId, detailWindowTaskId, {
+            selectedType: "WorkspaceProject",
+            projectDir: detailWindowProjectDir,
+          });
+          workspace_store.syncProjectListItem(detailWindowProjectDir, {
+            rootId: effectiveProjectId,
+            name: workspaceRootTask?.name || detailWindowTaskName,
+            order: workspaceRootTask?.order,
+          });
           workspace_tasks_cache.set(workspaceProject.tasks);
           tree_data.setFromSource(
-            workspaceToProjectData(workspaceProject.tasks, detailWindowProjectId)
+            workspaceToProjectData(workspaceProject.tasks, effectiveProjectId)
           );
           selected_type.set("WorkspaceProject");
-          selected_id.set(detailWindowProjectId);
+          selected_id.set(effectiveProjectId);
           table_selected_id.set(detailWindowTaskId);
         }
         return;

--- a/src/features/memos/components/MemoTab.svelte
+++ b/src/features/memos/components/MemoTab.svelte
@@ -506,15 +506,17 @@
     display: inline-flex;
     align-items: center;
     flex: 0 0 auto;
-    margin: 0 var(--sp1);
+    margin: 0 var(--sp2);
   }
 
   .memotab-control {
     display: flex;
     flex-direction: row;
     align-items: center;
+    gap: var(--sp2);
     flex-shrink: 0;
     margin-left: auto;
+    padding-right: var(--sp2);
   }
 
   .memotab-control :global(button) {

--- a/src/features/tasks/components/TaskDetail.svelte
+++ b/src/features/tasks/components/TaskDetail.svelte
@@ -34,18 +34,15 @@
     normalizeMemoFormat,
   } from "@features/memos/utils/memo_utils";
 
-  /**
-   * When TaskDetail is rendered inside its own dedicated window (TaskDetailPage),
-   * the card title is redundant with the OS-level title bar. Callers pass
-   * `hideDetailTitle` to suppress the local card header in that context.
-   */
-  export let hideDetailTitle = false;
+  export let titleOverride = "";
+  export let showOpenWindowAction = true;
 
   $: extraSelectedCount = Math.max(0, $selected_ids.size - 1);
   $: is_selected = $table_selected_id ? true : false;
   $: node =
     $table_selected_id && $tree_data ? getNode($table_selected_id, $tree_data.data) : undefined;
   $: name = node ? node.data["name"] : "Select Task";
+  $: cardTitle = titleOverride || name;
   $: memo = node ? node.data["memo"] : [];
   $: attachments = node ? (node.data["attachments"] ?? []) : [];
   $: isArchived = isNodeEffectivelyArchived($table_selected_id, $tree_data?.data);
@@ -69,6 +66,7 @@
   let detailPaneSize = "40%";
   let splitState = "open";
   let splitSnapping = false;
+  let memoFocusMode = false;
   let previousTaskDetailId = "";
   let snapTimer;
   let resizeStartY = 0;
@@ -76,6 +74,7 @@
   let startMemoSize = 0;
   let lastDesiredDetailSize = 0;
   let lastDesiredMemoSize = 0;
+  let lastOpenDetailSize = 0;
 
   const getEditContext = () => ({
     selectedType: $selected_type,
@@ -346,9 +345,15 @@
 
   function resetCardSplit() {
     clearTimeout(snapTimer);
-    detailPaneSize = "auto";
-    detailPanePercent = 0;
-    splitState = "open";
+    if (memoFocusMode) {
+      detailPaneSize = `${MINI_PANE_SIZE}px`;
+      detailPanePercent = 0;
+      splitState = "detail-mini";
+    } else {
+      detailPaneSize = "auto";
+      detailPanePercent = 0;
+      splitState = "open";
+    }
     splitSnapping = false;
   }
 
@@ -450,6 +455,7 @@
 
   function startCardResize(event) {
     event.preventDefault();
+    memoFocusMode = false;
     event.currentTarget.setPointerCapture?.(event.pointerId);
     clearTimeout(snapTimer);
     splitSnapping = false;
@@ -466,15 +472,53 @@
   }
 
   function setDetailPanePercent(nextPercent) {
+    memoFocusMode = false;
     detailPanePercent = Math.min(76, Math.max(24, nextPercent));
     detailPaneSize = `${detailPanePercent}%`;
     splitState = "open";
   }
 
   function snapCardSplit(nextState) {
+    memoFocusMode = nextState === "detail-mini";
     const { total } = getCurrentPaneSizes();
     const nextDetailSize = nextState === "detail-mini" ? MINI_PANE_SIZE : total - MINI_PANE_SIZE;
     applyDetailSize(nextDetailSize, total, nextState, true);
+  }
+
+  function getRestoredDetailSize(totalHeight) {
+    const safeTotal =
+      totalHeight > 0 ? totalHeight : DETAIL_MIN_HEIGHT + MEMO_MIN_HEIGHT + RESIZER_SIZE;
+    const maxDetailSize = Math.max(MINI_PANE_SIZE, safeTotal - MEMO_MIN_HEIGHT);
+    const preferredDetailSize = lastOpenDetailSize || safeTotal * 0.4;
+
+    if (maxDetailSize < DETAIL_MIN_HEIGHT) {
+      return Math.max(MINI_PANE_SIZE, safeTotal * 0.4);
+    }
+
+    return Math.min(Math.max(preferredDetailSize, DETAIL_MIN_HEIGHT), maxDetailSize);
+  }
+
+  function collapseDetailForMemo() {
+    const { total, detailHeight } = getCurrentPaneSizes();
+    if (detailHeight >= SNAP_THRESHOLD) {
+      lastOpenDetailSize = detailHeight;
+    }
+    memoFocusMode = true;
+    applyDetailSize(MINI_PANE_SIZE, total, "detail-mini", true);
+  }
+
+  function restoreDetailPane() {
+    const { total } = getCurrentPaneSizes();
+    memoFocusMode = false;
+    applyDetailSize(getRestoredDetailSize(total), total, "open", true);
+  }
+
+  function toggleMemoFocusMode() {
+    if (splitState === "detail-mini") {
+      restoreDetailPane();
+    } else {
+      collapseDetailForMemo();
+    }
   }
 
   function handleCardResizeKeydown(event) {
@@ -498,6 +542,7 @@
       case "Enter":
       case " ":
         event.preventDefault();
+        memoFocusMode = false;
         splitState = "open";
         break;
     }
@@ -526,31 +571,85 @@
 </script>
 
 {#if is_selected && node}
-  <Card
-    title={hideDetailTitle ? "" : name}
-    padded={false}
-    style={"height: 100%; width: 100%; overflow: hidden;"}
-  >
+  <Card title={cardTitle} padded={false} style={"height: 100%; width: 100%; overflow: hidden;"}>
     <svelte:fragment slot="header-actions">
-      <IconButton
-        tooltipContent="別ウィンドウで開く"
-        ariaLabel="タスク詳細を別ウィンドウで開く"
-        variant="text"
-        normalColor={"var(--theme-color-Sub-main)"}
-        activeColor={"var(--theme-color-Primary-main)"}
-        style={"width: 1.75rem; height: 1.75rem; margin: 0;"}
-        on:click={openTaskDetailInWindow}
-      >
-        <svg viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
-          <path
-            d="M14 3h7v7M21 3l-9 9M21 14v5a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2V5a2 2 0 0 1 2-2h5"
-            stroke="currentColor"
-            stroke-width="2"
-            stroke-linecap="round"
-            stroke-linejoin="round"
-          />
-        </svg>
-      </IconButton>
+      <div class="task-detail-actions">
+        <IconButton
+          tooltipContent={splitState === "detail-mini"
+            ? "詳細欄を表示"
+            : "詳細欄をたたんでメモを広げる"}
+          ariaLabel={splitState === "detail-mini" ? "詳細欄を表示" : "詳細欄をたたんでメモを広げる"}
+          ariaPressed={splitState === "detail-mini" ? "true" : "false"}
+          variant="text"
+          normalColor={splitState === "detail-mini"
+            ? "var(--theme-color-Primary-main)"
+            : "var(--theme-color-Sub-main)"}
+          activeColor={"var(--theme-color-Primary-main)"}
+          on:click={toggleMemoFocusMode}
+        >
+          {#if splitState === "detail-mini"}
+            <svg viewBox="0 0 24 24" fill="none" aria-hidden="true">
+              <rect
+                x="3"
+                y="4"
+                width="18"
+                height="16"
+                rx="2"
+                stroke="currentColor"
+                stroke-width="1.8"
+              />
+              <path d="M3 10H21" stroke="currentColor" stroke-width="1.8" />
+              <path
+                d="M8 14L12 10L16 14"
+                stroke="currentColor"
+                stroke-width="1.8"
+                stroke-linecap="round"
+                stroke-linejoin="round"
+              />
+            </svg>
+          {:else}
+            <svg viewBox="0 0 24 24" fill="none" aria-hidden="true">
+              <rect
+                x="3"
+                y="4"
+                width="18"
+                height="16"
+                rx="2"
+                stroke="currentColor"
+                stroke-width="1.8"
+              />
+              <path d="M3 10H21" stroke="currentColor" stroke-width="1.8" />
+              <path
+                d="M8 7L12 11L16 7"
+                stroke="currentColor"
+                stroke-width="1.8"
+                stroke-linecap="round"
+                stroke-linejoin="round"
+              />
+            </svg>
+          {/if}
+        </IconButton>
+        {#if showOpenWindowAction}
+          <IconButton
+            tooltipContent="別ウィンドウで開く"
+            ariaLabel="タスク詳細を別ウィンドウで開く"
+            variant="text"
+            normalColor={"var(--theme-color-Sub-main)"}
+            activeColor={"var(--theme-color-Primary-main)"}
+            on:click={openTaskDetailInWindow}
+          >
+            <svg viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
+              <path
+                d="M14 3h7v7M21 3l-9 9M21 14v5a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2V5a2 2 0 0 1 2-2h5"
+                stroke="currentColor"
+                stroke-width="2"
+                stroke-linecap="round"
+                stroke-linejoin="round"
+              />
+            </svg>
+          </IconButton>
+        {/if}
+      </div>
     </svelte:fragment>
 
     {#if extraSelectedCount > 0}
@@ -726,6 +825,12 @@
     font-size: var(--font-label-md);
     font-weight: 600;
     border-bottom: 1px solid color-mix(in srgb, var(--theme-color-Primary-main) 30%, transparent);
+  }
+  .task-detail-actions {
+    display: inline-flex;
+    align-items: center;
+    gap: var(--sp2);
+    flex: 0 0 auto;
   }
   .detail-pane {
     flex: 0 0 var(--detail-pane-size);

--- a/src/features/tasks/components/TreeTableHeader.svelte
+++ b/src/features/tasks/components/TreeTableHeader.svelte
@@ -885,7 +885,7 @@
   .HeaderUtilityButtons {
     display: flex;
     align-items: center;
-    gap: 2px;
+    gap: var(--sp1);
     flex-shrink: 0;
   }
 

--- a/src/features/workspace/utils/workspace_tree.ts
+++ b/src/features/workspace/utils/workspace_tree.ts
@@ -20,6 +20,10 @@ export function workspaceToProjectData(
   tasks: Record<string, WorkspaceTask>,
   rootId: string
 ): ProjectData {
+  const resolvedRootId =
+    tasks[rootId] !== undefined
+      ? rootId
+      : (Object.values(tasks).find((task) => task.parents.length === 0)?.id ?? rootId);
   const childrenMap = new Map<string, string[]>();
   for (const [id, task] of Object.entries(tasks)) {
     for (const parent of task.parents) {
@@ -72,7 +76,7 @@ export function workspaceToProjectData(
     return node;
   }
 
-  if (!tasks[rootId]) {
+  if (!tasks[resolvedRootId]) {
     return {
       headers: DEFAULT_HEADERS,
       data: {
@@ -89,7 +93,7 @@ export function workspaceToProjectData(
     };
   }
 
-  return { headers: DEFAULT_HEADERS, data: buildNode(rootId) };
+  return { headers: DEFAULT_HEADERS, data: buildNode(resolvedRootId) };
 }
 
 /**

--- a/src/lib/primitives/Button.svelte
+++ b/src/lib/primitives/Button.svelte
@@ -10,6 +10,7 @@
   export let variant = "filled"; // "outlined", "text"
   export let tooltipContent = undefined;
   export let ariaLabel = undefined;
+  export let type = "button";
   // tooltip
   let use_tooltip = tooltipContent === undefined ? false : true;
   let afcolor = "gray";
@@ -55,6 +56,7 @@
 </script>
 
 <button
+  {type}
   {disabled}
   aria-label={ariaLabel}
   use:ripple={{
@@ -85,7 +87,7 @@
     min-height: 2rem;
     border-radius: var(--shape-pill);
     border: 1px solid var(--borderColor);
-    margin: var(--sp1);
+    margin: var(--button-margin, 0);
     padding: var(--sp1) var(--sp4);
     font-size: var(--font-body-sm);
     font-weight: 500;

--- a/src/lib/primitives/IconButton.svelte
+++ b/src/lib/primitives/IconButton.svelte
@@ -9,6 +9,8 @@
   export let variant = "filled"; // "outlined", "text"
   export let tooltipContent = undefined;
   export let ariaLabel = undefined;
+  export let ariaPressed = undefined;
+  export let type = "button";
   // tooltip — keep reactive so a parent toggling tooltipContent (e.g. the
   // sidebar hamburger flipping its label between "open" and "close") is
   // picked up by the tooltip action's `update()` lifecycle.
@@ -62,8 +64,10 @@
 
 <button
   class="IconButton"
+  {type}
   {disabled}
   aria-label={ariaLabel}
+  aria-pressed={ariaPressed}
   use:ripple={{
     duration: 350,
     color: disabled ? "var(--theme-color-Sub-dark)" : rippleColor,
@@ -88,12 +92,12 @@
     display: flex;
     justify-content: center;
     align-items: center;
-    height: 2rem;
-    width: 2rem;
-    padding: 2px;
-    border-radius: 50%;
+    height: var(--icon-button-size, 2rem);
+    width: var(--icon-button-size, 2rem);
+    padding: var(--icon-button-padding, 2px);
+    border-radius: var(--icon-button-radius, var(--shape-sm));
     border: 1px solid var(--borderColor);
-    margin: var(--sp1);
+    margin: var(--button-margin, 0);
     cursor: pointer;
     background-color: var(--backgroundColor);
     color: var(--fontColor);

--- a/src/pages/MainPage.svelte
+++ b/src/pages/MainPage.svelte
@@ -1053,7 +1053,7 @@
     display: flex;
     flex-direction: row;
     align-items: center;
-    gap: 2px;
+    gap: var(--sp2);
     margin: 0;
     box-sizing: border-box;
     flex: 0 0 auto;

--- a/src/pages/TaskDetailPage.svelte
+++ b/src/pages/TaskDetailPage.svelte
@@ -1,7 +1,6 @@
 ﻿<script>
   import { getNode } from "@features/tasks/utils/tree_control";
   import { selected_id, tree_data } from "@stores";
-  import Button from "@lib/primitives/Button.svelte";
   import Loading from "@lib/primitives/Loading.svelte";
   import TaskDetail from "@features/tasks/components/TaskDetail.svelte";
 
@@ -10,8 +9,31 @@
   export let initialProjectId = "";
   export let ready = false;
 
+  function getNodePathName(targetId, root) {
+    const names = [];
+
+    function visit(node) {
+      names.push(node?.data?.name || "");
+      if (node?.id === targetId) return true;
+
+      for (const child of node?.children ?? []) {
+        if (visit(child)) return true;
+      }
+
+      names.pop();
+      return false;
+    }
+
+    return root && visit(root) ? names.filter(Boolean).join(" / ") : "";
+  }
+
   $: node = initialTaskId && $tree_data ? getNode(initialTaskId, $tree_data.data) : undefined;
-  $: taskName = node?.data?.name || initialTaskName;
+  $: taskPathName =
+    initialTaskId && $tree_data ? getNodePathName(initialTaskId, $tree_data.data) : "";
+  $: taskName = taskPathName || node?.data?.name || initialTaskName;
+  $: if (ready && taskName && typeof document !== "undefined") {
+    document.title = `${taskName} | Task Detail`;
+  }
   $: isProjectDeleted = ready && initialProjectId && $selected_id !== initialProjectId;
   $: isTaskDeleted =
     ready &&
@@ -23,25 +45,6 @@
 </script>
 
 <div class="detail-window">
-  <div class="detail-header">
-    <div class="detail-meta">
-      <!--
-        The dedicated TaskDetail window already shows the task name as its
-        OS-level title and as the H1 below — repeating "Task Detail" as an
-        eyebrow above it is redundant and adds vertical clutter. Keep only
-        the task name. The inner panes likewise skip their card titles
-        (see `hideDetailTitle` below).
-      -->
-      <h1>{taskName}</h1>
-    </div>
-    <Button
-      content="閉じる"
-      on:click={() => {
-        window.close();
-      }}
-    />
-  </div>
-
   <div class="detail-body">
     {#if !ready}
       <div class="empty-state">
@@ -58,7 +61,7 @@
         <p>The target task was deleted. Rename is still tracked by task ID.</p>
       </div>
     {:else}
-      <TaskDetail hideDetailTitle />
+      <TaskDetail titleOverride={taskName} showOpenWindowAction={false} />
     {/if}
   </div>
 </div>
@@ -71,23 +74,8 @@
     height: 100%;
     padding: var(--sp2);
     box-sizing: border-box;
-    gap: var(--sp2);
     background: var(--theme-color-Main-dark);
     color: var(--theme-color-Sub-main);
-  }
-
-  .detail-header {
-    display: flex;
-    justify-content: space-between;
-    align-items: flex-start;
-    gap: var(--sp2);
-    flex-shrink: 0;
-  }
-
-  .detail-meta h1 {
-    margin: 0;
-    font-size: var(--font-title-md);
-    line-height: 1.2;
   }
 
   .detail-body {

--- a/src/stores/index.ts
+++ b/src/stores/index.ts
@@ -41,9 +41,14 @@ let initStoreReady: Promise<void> | null = null;
 export function init_store(): Promise<void> {
   if (initStoreReady) return initStoreReady;
 
+  const isTaskDetailWindow =
+    typeof window !== "undefined" && window.location.hash === "#task-detail-window";
+
   tree_data.init();
   const projectIdsReady = project_ids.init();
-  selected_id.init();
+  if (!isTaskDetailWindow) {
+    selected_id.init();
+  }
   sort_state.init();
   filter.init();
   theme.init();
@@ -58,8 +63,6 @@ export function init_store(): Promise<void> {
   // 履歴記録は selected_type / selected_id への subscribe を張る。
   // タスク詳細サブウィンドウ (`#task-detail-window`) では戻る/進むの概念が
   // 不要なため、メインウィンドウのときだけ初期化する。
-  const isTaskDetailWindow =
-    typeof window !== "undefined" && window.location.hash === "#task-detail-window";
   if (!isTaskDetailWindow) {
     navigation_history.init();
   }

--- a/tests/component/AppTaskDetailWindow.test.js
+++ b/tests/component/AppTaskDetailWindow.test.js
@@ -1,0 +1,119 @@
+import { cleanup, render, screen, waitFor } from "@testing-library/svelte";
+import { get } from "svelte/store";
+import { afterEach, describe, expect, test, vi } from "vitest";
+
+vi.mock("@features/navigation/components/Header.svelte", async () => {
+  const mod = await import("../mocks/PassThroughStub.svelte");
+  return { default: mod.default };
+});
+vi.mock("@features/navigation/components/MenuList.svelte", async () => {
+  const mod = await import("../mocks/PassThroughStub.svelte");
+  return { default: mod.default };
+});
+vi.mock("@pages/MainPage.svelte", async () => {
+  const mod = await import("../mocks/TreeTableStub.svelte");
+  return { default: mod.default };
+});
+vi.mock("@features/search/components/PageSearchBox.svelte", async () => {
+  const mod = await import("../mocks/PassThroughStub.svelte");
+  return { default: mod.default };
+});
+vi.mock("@features/inbox/components/InboxPanel.svelte", async () => {
+  const mod = await import("../mocks/PassThroughStub.svelte");
+  return { default: mod.default };
+});
+vi.mock("@features/inbox/components/QuickCapture.svelte", async () => {
+  const mod = await import("../mocks/PassThroughStub.svelte");
+  return { default: mod.default };
+});
+vi.mock("@features/tasks/components/TaskDetail.svelte", async () => {
+  const mod = await import("../mocks/TaskDetailStub.svelte");
+  return { default: mod.default };
+});
+
+const taskDetailUrl =
+  "/?projectId=stale-root&taskId=task-1&taskName=Opened%20Task&selectedType=WorkspaceProject&projectDir=C%3A%2Fworkspace%2Falpha#task-detail-window";
+
+function makeElectronAPI(overrides = {}) {
+  return {
+    getProjectIDs: vi.fn().mockResolvedValue([]),
+    getMetaData: vi.fn().mockResolvedValue(null),
+    setMetaData: vi.fn(),
+    getCurrentTheme: vi.fn().mockResolvedValue("dark"),
+    onThemeChanged: vi.fn(),
+    onTreeDataUpdated: vi.fn(),
+    onProjectDeleted: vi.fn(),
+    onSaveError: vi.fn(),
+    onWorkspaceSaveStatus: vi.fn(),
+    onWorkspaceProjectUpdated: vi.fn(),
+    onWorkspaceConflict: vi.fn(),
+    onWorkspaceNotice: vi.fn(),
+    onWorkspaceFlushStart: vi.fn(),
+    onWorkspaceFlushComplete: vi.fn(),
+    wsGetWorkspaces: vi.fn().mockResolvedValue({ workspaces: [], activeWorkspace: null }),
+    wsListProjects: vi.fn().mockResolvedValue([]),
+    wsReadProject: vi.fn().mockResolvedValue({
+      tasks: {
+        "actual-root": {
+          id: "actual-root",
+          name: "Actual Project",
+          status: "Open",
+          parents: [],
+          memos: [],
+          createdAt: "2026-01-01",
+        },
+        "task-1": {
+          id: "task-1",
+          name: "Opened Task",
+          status: "Open",
+          parents: ["actual-root"],
+          memos: [],
+          createdAt: "2026-01-01",
+        },
+      },
+    }),
+    ...overrides,
+  };
+}
+
+async function importAppAtTaskDetailUrl(api = makeElectronAPI()) {
+  cleanup();
+  window.history.pushState({}, "", taskDetailUrl);
+  Object.defineProperty(window, "electronAPI", { configurable: true, value: api });
+
+  const [{ default: App }, stores] = await Promise.all([
+    import("../../src/App.svelte"),
+    import("@stores"),
+  ]);
+  return { App, stores, api };
+}
+
+describe("App - task detail window", () => {
+  afterEach(() => {
+    cleanup();
+    vi.clearAllMocks();
+    delete window.electronAPI;
+    window.history.pushState({}, "", "/");
+  });
+
+  test("opens a workspace task detail window from the real workspace root", async () => {
+    const { App, stores, api } = await importAppAtTaskDetailUrl();
+
+    render(App);
+
+    let taskDetail;
+    await waitFor(() => {
+      taskDetail = screen.getByTestId("task-detail-stub");
+      expect(taskDetail).toBeInTheDocument();
+    });
+
+    expect(screen.queryByText("Task not found.")).not.toBeInTheDocument();
+    expect(taskDetail).toHaveAttribute("data-title-override", "Actual Project / Opened Task");
+    expect(taskDetail).toHaveAttribute("data-show-open-window-action", "false");
+    expect(api.wsReadProject).toHaveBeenCalledTimes(1);
+    expect(api.wsReadProject).toHaveBeenCalledWith("C:/workspace/alpha");
+    expect(get(stores.selected_id)).toBe("actual-root");
+    expect(get(stores.table_selected_id)).toBe("task-1");
+    expect(get(stores.tree_data).data.id).toBe("actual-root");
+  }, 20000);
+});

--- a/tests/component/TaskDetail.test.js
+++ b/tests/component/TaskDetail.test.js
@@ -127,6 +127,61 @@ describe("TaskDetail", () => {
     );
   });
 
+  test("collapses task fields to keep the memo pane wide", async () => {
+    table_selected_id.set("task-1");
+    const { container } = render(TaskDetail);
+
+    const body = container.querySelector(".task-detail-card-body");
+    const collapseButton = screen.getByRole("button", {
+      name: "詳細欄をたたんでメモを広げる",
+    });
+    expect(collapseButton).toHaveAttribute("aria-pressed", "false");
+
+    await fireEvent.click(collapseButton);
+    await tick();
+
+    expect(body).toHaveClass("detail-mini");
+    expect(screen.getByRole("button", { name: "詳細欄を表示" })).toHaveAttribute(
+      "aria-pressed",
+      "true"
+    );
+
+    table_selected_id.set("task-2");
+    await tick();
+
+    expect(body).toHaveClass("detail-mini");
+
+    await fireEvent.click(screen.getByRole("button", { name: "詳細欄を表示" }));
+    await tick();
+
+    expect(body).not.toHaveClass("detail-mini");
+    expect(screen.getByRole("button", { name: "詳細欄をたたんでメモを広げる" })).toHaveAttribute(
+      "aria-pressed",
+      "false"
+    );
+  });
+
+  test("uses a path title and hides the open-window action in the dedicated detail window layout", async () => {
+    table_selected_id.set("task-1");
+    const { container } = render(TaskDetail, {
+      props: {
+        titleOverride: "Sample Project / First Task",
+        showOpenWindowAction: false,
+      },
+    });
+
+    expect(screen.getByText("Sample Project / First Task")).toBeInTheDocument();
+    expect(
+      screen.getByRole("button", { name: "詳細欄をたたんでメモを広げる" })
+    ).toBeInTheDocument();
+    expect(screen.queryByRole("button", { name: "タスク詳細を別ウィンドウで開く" })).toBeNull();
+
+    await fireEvent.click(screen.getByRole("button", { name: "詳細欄をたたんでメモを広げる" }));
+    await tick();
+
+    expect(container.querySelector(".task-detail-card-body")).toHaveClass("detail-mini");
+  });
+
   test("hydrates workspace memo bodies for the selected task", async () => {
     const project = createProjectData();
     project.data.children[1].data.memo = [

--- a/tests/e2e/app.smoke.spec.js
+++ b/tests/e2e/app.smoke.spec.js
@@ -65,9 +65,11 @@ async function openTaskDetailWindow(
   }, detailData);
 
   const detailWindow = await detailWindowPromise;
-  // The standalone TaskDetail window no longer carries a redundant
-  // "Task Detail" eyebrow above the heading — the task-name H1 is enough.
-  await expect(detailWindow.getByRole("heading", { name: detailData.taskName })).toBeVisible();
+  // The standalone TaskDetail window renders the same pure Card as the main
+  // pane, so the task name lives in the Card title rather than a separate H1.
+  await expect(
+    detailWindow.locator(".CardHeaderTitle", { hasText: detailData.taskName })
+  ).toBeVisible();
 
   return detailWindow;
 }
@@ -183,7 +185,7 @@ test("opens the task detail window for the selected task", async () => {
   }
 });
 
-test("keeps the task detail window heading in sync when the task name changes", async () => {
+test("keeps the task detail window Card title in sync when the task name changes", async () => {
   const app = await launchSeededApp();
 
   try {
@@ -195,7 +197,9 @@ test("keeps the task detail window heading in sync when the task name changes", 
       window.electronAPI.setTreeData(project);
     });
 
-    await expect(detailWindow.getByRole("heading", { name: "Renamed Task" })).toBeVisible();
+    await expect(
+      detailWindow.locator(".CardHeaderTitle", { hasText: "Renamed Task" })
+    ).toBeVisible();
   } finally {
     await closeSeededApp(app);
   }

--- a/tests/mocks/TaskDetailStub.svelte
+++ b/tests/mocks/TaskDetailStub.svelte
@@ -1,1 +1,12 @@
-<div data-testid="task-detail-stub">task detail stub</div>
+<script>
+  export let titleOverride = "";
+  export let showOpenWindowAction = true;
+</script>
+
+<div
+  data-testid="task-detail-stub"
+  data-title-override={titleOverride}
+  data-show-open-window-action={String(showOpenWindowAction)}
+>
+  task detail stub
+</div>

--- a/tests/unit/workspace_tree.test.ts
+++ b/tests/unit/workspace_tree.test.ts
@@ -151,4 +151,32 @@ describe("workspace tree conversion", () => {
 
     expect(tasks[0].attachments).toEqual([attachment]);
   });
+
+  it("uses the workspace root task when the requested root id is stale", () => {
+    const projectData = workspaceToProjectData(
+      {
+        "actual-root": {
+          id: "actual-root",
+          name: "Actual Project",
+          status: "Open",
+          parents: [],
+          memos: [],
+          createdAt: "2026-05-20",
+        },
+        "task-1": {
+          id: "task-1",
+          name: "Task One",
+          status: "Open",
+          parents: ["actual-root"],
+          memos: [],
+          createdAt: "2026-05-21",
+        },
+      },
+      "stale-root"
+    );
+
+    expect(projectData.data.id).toBe("actual-root");
+    expect(projectData.data.data.name).toBe("Actual Project");
+    expect(projectData.data.children.map((child) => child.id)).toEqual(["task-1"]);
+  });
 });


### PR DESCRIPTION
## Summary
- Improve round/icon button spacing through shared primitives and nearby toolbar layout.
- Add a TaskDetail memo-focus toggle that collapses/restores the detail pane while keeping the resizer available.
- Fix Workspace TaskDetail separate-window loading by avoiding selected_id auto-init in the window route and resolving the workspace root from loaded disk data.
- Simplify the separate TaskDetail window to render the pure card body and use a path-style task title.

## Validation
- `vitest run tests\component\TaskDetail.test.js tests\component\Card.test.js tests\component\AppTaskDetailWindow.test.js --pool=threads`
- `vitest run tests\component\TaskDetail.test.js tests\component\AppTaskDetailWindow.test.js tests\unit\workspace_tree.test.ts --pool=threads`
- `vitest run tests\component\App.test.js tests\component\AppWorkspaceProject.test.js tests\component\AppTaskDetailWindow.test.js`
- `svelte-check --tsconfig .\tsconfig.json`
- `prettier --check ...`
- `vite build`