### PR TITLE
[codex] prioritize selected memo text for shortcuts

### DIFF
--- a/src/features/tasks/components/TreeTable.svelte
+++ b/src/features/tasks/components/TreeTable.svelte
@@ -65,6 +65,11 @@
     show_archived,
   } from "@stores/ui";
   import { navigation_history } from "@stores/navigation_history";
+  import {
+    hasSelectedDocumentText,
+    hasSelectedMemoText,
+    isTextEditingTarget,
+  } from "@lib/utils/hotkey_priority";
 
   let table_root; // Bind
 
@@ -896,12 +901,19 @@
   }
 
   function isEditingText() {
-    const el = document.activeElement;
-    return el && (el.tagName === "INPUT" || el.tagName === "TEXTAREA" || el.isContentEditable);
+    return isTextEditingTarget(document.activeElement);
+  }
+
+  function shouldPrioritizeSelectedText(e) {
+    if (!hasSelectedDocumentText()) return false;
+    if (hasSelectedMemoText()) return true;
+    return (
+      (e.ctrlKey || e.metaKey) && (e.key === "c" || e.key === "C" || e.key === "a" || e.key === "A")
+    );
   }
 
   function handleGlobalKeydown(e) {
-    if (isEditingText()) return;
+    if (isEditingText() || isTextEditingTarget(e.target) || shouldPrioritizeSelectedText(e)) return;
     // Selection-aware shortcuts (Esc / Ctrl+A / Delete) act on the multi-selection.
     if (e.key === "Escape") {
       if (selectionSize > 0) {

--- a/src/lib/utils/hotkey_priority.ts
+++ b/src/lib/utils/hotkey_priority.ts
@@ -1,0 +1,33 @@
+function elementFromNode(node: Node | null): Element | null {
+  if (!node) return null;
+  if (node instanceof Element) return node;
+  return node.parentElement;
+}
+
+export function isTextEditingTarget(target: EventTarget | null): boolean {
+  if (!(target instanceof Element)) return false;
+  if (target.closest(".cm-editor")) return true;
+  if (target.closest(".ql-editor")) return true;
+  if (target.closest('[contenteditable=""], [contenteditable="true"]')) return true;
+  const tag = target.tagName;
+  return tag === "INPUT" || tag === "TEXTAREA";
+}
+
+export function hasSelectedDocumentText(): boolean {
+  const selection = window.getSelection();
+  if (!selection || selection.isCollapsed || selection.rangeCount === 0) return false;
+  return selection.toString().length > 0;
+}
+
+export function hasSelectedMemoText(): boolean {
+  const selection = window.getSelection();
+  if (!selection || selection.isCollapsed || selection.rangeCount === 0) return false;
+  if (selection.toString().length === 0) return false;
+
+  const commonAncestor = selection.getRangeAt(0).commonAncestorContainer;
+  return [selection.anchorNode, selection.focusNode, commonAncestor].some((node) =>
+    elementFromNode(node)?.closest(
+      ".memo-host .cm-editor, .memo-host .ql-editor, .memo-host .preview"
+    )
+  );
+}

--- a/tests/component/TreeTable.test.js
+++ b/tests/component/TreeTable.test.js
@@ -29,7 +29,7 @@ import {
   theme,
   tree_data,
 } from "@stores";
-import { clearSelection, selected_ids } from "@stores/ui";
+import { clearSelection, copied_task, copied_tasks, selected_ids } from "@stores/ui";
 import { workspace_store } from "@features/workspace/stores/workspace";
 
 function createProjectData() {
@@ -113,6 +113,8 @@ describe("TreeTable", () => {
     clearSelection();
     selected_type.set("Projects");
     table_selected_id.set(undefined);
+    copied_task.set(null);
+    copied_tasks.set([]);
     closed_node_ids.set(new Set());
     column_settings.set([
       { id: "name", label: "タスク名", visible: true },
@@ -206,6 +208,53 @@ describe("TreeTable", () => {
     await fireEvent.click(screen.getByTestId("open-folder-task-1"));
 
     expect(wsOpenTaskFolder).toHaveBeenCalledWith("C:/workspace/project", "task-1");
+  });
+
+  test("lets selected text copy before the task copy shortcut", async () => {
+    render(TreeTable);
+
+    await fireEvent.click(screen.getByTestId("select-task-1"));
+    await tick();
+
+    const memoHost = document.createElement("div");
+    memoHost.className = "memo-host";
+    const preview = document.createElement("div");
+    preview.className = "preview";
+    const paragraph = document.createElement("p");
+    paragraph.textContent = "Selected markdown text";
+    preview.appendChild(paragraph);
+    memoHost.appendChild(preview);
+    document.body.appendChild(memoHost);
+
+    const range = document.createRange();
+    range.selectNodeContents(paragraph);
+    const selection = window.getSelection();
+    selection.removeAllRanges();
+    selection.addRange(range);
+
+    try {
+      await fireEvent.keyDown(window, { key: "c", ctrlKey: true });
+      await tick();
+
+      expect(get(copied_task)).toBeNull();
+      expect(get(copied_tasks)).toEqual([]);
+    } finally {
+      selection.removeAllRanges();
+      memoHost.remove();
+    }
+  });
+
+  test("copies the selected task when no document text is selected", async () => {
+    render(TreeTable);
+
+    await fireEvent.click(screen.getByTestId("select-task-1"));
+    await tick();
+
+    await fireEvent.keyDown(window, { key: "c", ctrlKey: true });
+    await tick();
+
+    expect(get(copied_task)?.id).toBe("task-1");
+    expect(get(copied_tasks).map((task) => task.id)).toEqual(["task-1"]);
   });
 
   test("positions resizers after the selection checkbox column", async () => {


### PR DESCRIPTION
## Summary
- Add shared hotkey-priority helpers for editable targets and memo text selections.
- Let TreeTable global shortcuts defer when selected text exists in Markdown preview, CodeMirror, or Quill memo content.
- Add regression coverage for selected memo text copy and normal task copy behavior.

## Why
TreeTable handled global `Ctrl+C` even when the user had selected text inside memo content, so copying Markdown/Quill text could accidentally copy the selected task instead.

## Validation
- `svelte-check --tsconfig ./tsconfig.json`
- `vitest run tests/component/TreeTable.test.js --pool=threads`

## Rebase
- Rebased on `origin/main` at `85c8f4c`.
- GitHub compare reports `ahead_by: 1`, `behind_by: 0`, with merge base equal to `main`.