### PR TITLE
feat: compact/flat density mode and zoomable memo image viewer

### DIFF
--- a/electron/index.js
+++ b/electron/index.js
@@ -121,12 +121,55 @@ function shouldOpenDevTools() {
   return !app.isPackaged && !testLikeEnvironment;
 }
 
+// Page-zoom wiring shared by every BrowserWindow we create. Ctrl/Cmd
+// modifiers + = / + / - / 0 step the zoom level, and Ctrl + mouse wheel
+// is forwarded by Chromium as zoom-changed once setVisualZoomLevelLimits
+// is opened up. We clamp to [MIN_LEVEL, MAX_LEVEL] so a fast scroll
+// can't drift past the usable range. allowEscapeClose=true makes the
+// window dismissible with Esc — appropriate for the image-viewer popup,
+// not for the main / task-detail windows.
+function attachZoomControls(win, { allowEscapeClose = false } = {}) {
+  const ZOOM_STEP = 0.5;
+  const MIN_LEVEL = -5;
+  const MAX_LEVEL = 5;
+  const clamp = (level) => Math.max(MIN_LEVEL, Math.min(MAX_LEVEL, level));
+
+  win.webContents.setVisualZoomLevelLimits(1, 5).catch(() => {});
+
+  win.webContents.on("before-input-event", (event, input) => {
+    if (input.type !== "keyDown") return;
+    const mod = input.control || input.meta;
+    if (mod) {
+      if (input.key === "=" || input.key === "+") {
+        win.webContents.setZoomLevel(clamp(win.webContents.getZoomLevel() + ZOOM_STEP));
+        event.preventDefault();
+      } else if (input.key === "-") {
+        win.webContents.setZoomLevel(clamp(win.webContents.getZoomLevel() - ZOOM_STEP));
+        event.preventDefault();
+      } else if (input.key === "0") {
+        win.webContents.setZoomLevel(0);
+        event.preventDefault();
+      }
+    } else if (allowEscapeClose && input.key === "Escape") {
+      win.close();
+      event.preventDefault();
+    }
+  });
+
+  win.webContents.on("zoom-changed", (_, zoomDirection) => {
+    const cur = win.webContents.getZoomLevel();
+    const next = clamp(cur + (zoomDirection === "in" ? ZOOM_STEP : -ZOOM_STEP));
+    win.webContents.setZoomLevel(next);
+  });
+}
+
 app.on("ready", () => {
   const t0 = Date.now();
 
   let mainWindow = new BrowserWindow({
     webPreferences: {
       preload: path.join(__dirname, "preload.js"),
+      zoomFactor: 1.0,
     },
     width: 1000,
     height: 800,
@@ -136,6 +179,8 @@ app.on("ready", () => {
     titleBarStyle: "hidden",
   });
   log.info(`[perf] BrowserWindow created: ${Date.now() - t0}ms`);
+
+  attachZoomControls(mainWindow);
 
   function sendWindowState(win) {
     if (!win || win.isDestroyed()) return;
@@ -767,6 +812,41 @@ app.on("ready", () => {
     }
   });
 
+  // Memo image enlarged view: open the image in a dedicated BrowserWindow.
+  // We load the image URL directly (no HTML wrapper) because a wrapping
+  // data:text/html page lives in a different origin and Chromium blocks
+  // cross-origin file:// resource loads by default — which would silently
+  // fail for workspace memo images served as file://. Loading the image
+  // URL as the page itself avoids that restriction; Chromium auto-fits
+  // the image to the window and shows scrollbars for larger images.
+  // Zoom wiring (Ctrl+= / Ctrl+- / Ctrl+0 / Ctrl+wheel) and Esc-to-close
+  // are delegated to attachZoomControls — the same helper used by the
+  // main and task-detail windows, keeping zoom behavior consistent.
+  ipcMain.on("open-image-window", (event, src) => {
+    if (!src || typeof src !== "string") return;
+    try {
+      const win = new BrowserWindow({
+        width: 960,
+        height: 720,
+        title: "Image",
+        autoHideMenuBar: true,
+        backgroundColor: "#1f1f1f",
+        webPreferences: {
+          sandbox: true,
+          contextIsolation: true,
+          nodeIntegration: false,
+          zoomFactor: 1.0,
+        },
+      });
+      attachZoomControls(win, { allowEscapeClose: true });
+      win.loadURL(src).catch((err) => {
+        log.error("Failed to load image window:", err);
+      });
+    } catch (err) {
+      log.error("Failed to open image window:", err);
+    }
+  });
+
   // 繧ｿ繧ｹ繧ｯ隧ｳ邏ｰ繧ｦ繧｣繝ｳ繝峨え縺ｮ螟画焚
   const taskDetailWindows = new Map(); // taskId -> BrowserWindow
 
@@ -923,8 +1003,11 @@ app.on("ready", () => {
           preload: path.join(__dirname, "preload.js"),
           nodeIntegration: false,
           contextIsolation: true,
+          zoomFactor: 1.0,
         },
       });
+
+      attachZoomControls(win);
 
       if (process.env.VITE_DEV === "true") {
         const params = new URLSearchParams(safeDetailData);

--- a/electron/preload.js
+++ b/electron/preload.js
@@ -23,6 +23,9 @@ const electronAPI = {
   openExternalLink: (url) => {
     ipcRenderer.send("open-external-link", url);
   },
+  openImageWindow: (src) => {
+    ipcRenderer.send("open-image-window", src);
+  },
   // タスク詳細ウィンドウを開く
   openTaskDetailWindow: (detailData) => {
     ipcRenderer.send("open-task-detail-window", detailData);

--- a/public/global.css
+++ b/public/global.css
@@ -50,6 +50,87 @@
   --on-theme-primary: #42a5f5;
   --on-theme-tooltip-bg: #e8edf0;
   --on-theme-tooltip-fg: #262d32;
+
+  /* Card body padding — overridable by density mode so we don't squash
+     every other --sp3 consumer. Defaults to the comfortable 12px. */
+  --card-pad: var(--sp3);
+  /* Card border tint — same intent: overridable so flat mode can make the
+     hairline a bit stronger as the only remaining zoning cue. */
+  --card-border-alpha: 12%;
+  /* Card corner radius — separate from --shape-* so flat mode can square
+     off cards without also squaring buttons / inputs / chips that share
+     --shape-sm/-xs. */
+  --card-radius: var(--shape-sm);
+  /* CardHeader chrome — slim height + tinted strip + 14px title is the
+     comfortable default. Compact collapses to a content-sized strip with
+     a 12px title and no tint so it reads as a hairline label, not a bar. */
+  --card-header-min-h: 2.25rem;
+  --card-header-pad-y: var(--sp1);
+  --card-header-font: var(--font-title-sm);
+  --card-header-bg: color-mix(
+    in srgb,
+    var(--theme-color-Primary-main) 12%,
+    var(--theme-color-Main-main)
+  );
+  /* Gap around each SplitPane child that hosts a Card. In comfortable mode
+     this is the 16px gutter that gives Cards their "floating" feel.
+     Compact mode collapses it to 0 for an edge-to-edge VSCode layout. */
+  --pane-pad: var(--sp4);
+  /* Outer padding inside the standalone Task Detail window. Separate from
+     --pane-pad because it sits at 8px (comfortable) vs 16px — both go to
+     0 in compact. */
+  --detail-window-pad: var(--sp2);
+  /* Inner padding around the MemoTab container inside TaskDetail's memo
+     pane. 4px in comfortable, 0 in compact (memo runs edge-to-edge). */
+  --memotab-pad: var(--sp1);
+  /* Outer frame around the Markdown editor wrapper. Compact drops it so
+     the memo bleeds into the Card edge. Quill's own frame is removed
+     separately via a :global(.density-compact) override in QuillMemo
+     because its internal frame comes from the Quill library CSS. */
+  --memo-wrapper-border: 1px solid color-mix(in srgb, var(--theme-color-Sub-dark) 45%, transparent);
+}
+
+/* ============================================================
+   Compact / flat density — VSCode-like layout.
+   Toggled by ui_density store via class on <html>. Strategy:
+     - kill all elevation halos (flat surfaces)
+     - sharp corners (2-4px instead of 8-16px)
+     - tighter card padding via dedicated --card-pad token
+     - stronger hairline border on cards to keep zone identifiable
+   We intentionally do NOT shrink the base --sp* tokens: that would
+   collapse button heights and header gaps. Only Card-scoped padding
+   gets tightened, plus the visual flat treatment.
+   ============================================================ */
+.density-compact {
+  --elevation-1: none;
+  --elevation-2: none;
+  --elevation-3: none;
+
+  /* NOTE: we intentionally do NOT override --shape-xs/sm/md/lg here.
+     Buttons, inputs, chips, and segmented controls all read those tokens
+     and should keep their rounded corners in compact mode. Only Cards
+     (and Card-like placeholders) get squared off, via --card-radius. */
+  --card-radius: 2px;
+  --card-pad: var(--sp1);
+  --card-border-alpha: 28%;
+
+  /* Slim the CardHeader: pin min-height to the IconButton size (2rem) so
+     left/right Card headers stay the same height regardless of slot
+     content (text-only vs IconButton-filled), zero vertical pad to drop
+     the 8px of unused padding, smaller 12px label.
+     NOTE: --card-header-bg is intentionally NOT overridden — the Primary
+     12% tint stays so the title strip reads as a header in either mode. */
+  --card-header-min-h: 2rem;
+  --card-header-pad-y: 0px;
+  --card-header-font: var(--font-label-md);
+
+  --memotab-pad: 0px;
+  --memo-wrapper-border: none;
+
+  /* Collapse the Card gutter: panes butt up against each other separated
+     only by the 5px resizer (and Card's own 1px border). */
+  --pane-pad: 0px;
+  --detail-window-pad: 0px;
 }
 
 html,

--- a/src/features/memos/components/MarkdownMemo.svelte
+++ b/src/features/memos/components/MarkdownMemo.svelte
@@ -88,8 +88,6 @@
   const SPLIT_MIN_PERCENT = 30;
   const SPLIT_MAX_PERCENT = 72;
   const SPLIT_KEY_STEP = 5;
-  const PREVIEW_IMAGE_MAX_WIDTH_VAR = "--memo-preview-image-max-width";
-  const measuredPreviewImages = new WeakSet<HTMLImageElement>();
 
   const EXTERNAL_LINK_PATTERN = /^(https?:\/\/|mailto:|file:\/\/)/i;
   // Quill 標準の `code` と `code-block` は同じ SVG (`<>`) で視覚的に区別できないため、
@@ -1016,24 +1014,6 @@
     });
   }
 
-  function syncPreviewImageNaturalWidth(image: HTMLImageElement) {
-    if (image.naturalWidth > 0) {
-      image.style.setProperty(PREVIEW_IMAGE_MAX_WIDTH_VAR, `${image.naturalWidth}px`);
-    }
-  }
-
-  function applyPreviewImageNaturalWidths(root: HTMLElement | null) {
-    if (!root) return;
-
-    root.querySelectorAll<HTMLImageElement>("img").forEach((image) => {
-      syncPreviewImageNaturalWidth(image);
-
-      if (measuredPreviewImages.has(image)) return;
-      measuredPreviewImages.add(image);
-      image.addEventListener("load", () => syncPreviewImageNaturalWidth(image), { once: true });
-    });
-  }
-
   // mermaid の初期化はテーマに依存する。最初の renderMermaidBlocks 呼び出し
   // および theme 変更時に setupMermaidTheme で再初期化する。
   let mermaidThemeApplied: "dark" | "default" | null = null;
@@ -1089,8 +1069,6 @@
     }) as string;
     renderedHtml = baseHtml;
     await tick();
-    applyPreviewImageNaturalWidths(previewEl);
-    applyPreviewImageNaturalWidths(livePreviewEl);
     injectCopyButtons(previewEl);
     injectCopyButtons(livePreviewEl);
     await renderMermaidBlocks(previewEl);
@@ -1100,8 +1078,6 @@
     if (sequence === renderSequence) {
       renderedHtml = nextHtml;
       await tick();
-      applyPreviewImageNaturalWidths(previewEl);
-      applyPreviewImageNaturalWidths(livePreviewEl);
       injectCopyButtons(previewEl);
       injectCopyButtons(livePreviewEl);
       await renderMermaidBlocks(previewEl);
@@ -1690,6 +1666,16 @@
       platform.openExternalLink(link.href);
       return;
     }
+    // Click an image in the rendered preview → open it in a dedicated
+    // BrowserWindow at its natural size. Skipped when the click came
+    // from inside a link (handled above) and skipped for missing/broken
+    // images so a placeholder doesn't pop a blank window.
+    const img = target?.closest("img") as HTMLImageElement | null;
+    if (img?.src && img.dataset.missingImage !== "true") {
+      e.preventDefault();
+      platform.openImageWindow(img.src);
+      return;
+    }
   }
 
   function handlePreviewKeydown(e: KeyboardEvent) {
@@ -2012,7 +1998,7 @@
     min-height: 0;
     overflow: hidden;
     background-color: var(--theme-color-Main-light);
-    border: 1px solid color-mix(in srgb, var(--theme-color-Sub-dark) 45%, transparent);
+    border: var(--memo-wrapper-border);
     box-sizing: border-box;
   }
 
@@ -2615,14 +2601,21 @@
   .preview :global(img) {
     display: block;
     box-sizing: border-box;
-    width: min(100%, var(--memo-preview-image-max-width, 100%));
-    max-width: 100%;
+    /* Fixed cap (32rem) keeps the rendered size identical between
+       Preview-only and Split modes for any image wider than the cap,
+       so the layout doesn't visually jump when the user toggles the
+       view. Smaller images still display at their natural size in
+       both modes. Click opens the image in a dedicated window for
+       a full-resolution look. */
+    width: auto;
+    max-width: min(100%, 32rem);
     height: auto;
     margin: var(--sp3) 0;
     border-radius: var(--shape-md);
     border: 1px solid color-mix(in srgb, var(--theme-color-Sub-main) 25%, transparent);
     background: color-mix(in srgb, var(--theme-color-Main-dark) 80%, transparent);
     box-shadow: var(--elevation-2);
+    cursor: zoom-in;
   }
 
   .preview :global(img[data-missing-image="true"]) {

--- a/src/features/memos/components/MemoTab.svelte
+++ b/src/features/memos/components/MemoTab.svelte
@@ -609,6 +609,11 @@
     container-type: inline-size;
     flex-shrink: 0;
   }
+  /* Compact mode drops the divider between the tag bar and the editor
+     so the memo area reads as one continuous edge-to-edge surface. */
+  :global(.density-compact) .tag-panel {
+    border-bottom: none;
+  }
 
   /* Tag area — 2-section layout (追加済み / 候補) */
   .tag-row {

--- a/src/features/memos/components/QuillMemo.svelte
+++ b/src/features/memos/components/QuillMemo.svelte
@@ -813,6 +813,14 @@
     background-color: var(--theme-color-Main-dark);
   }
 
+  /* Compact (flat) mode strips Quill's internal frame so the editor
+     runs edge-to-edge inside the Card, matching MarkdownMemo's
+     --memo-wrapper-border: none behavior. */
+  :global(.density-compact) .wrapper :global(.ql-container.ql-snow),
+  :global(.density-compact) .wrapper :global(.ql-toolbar) {
+    border: none !important;
+  }
+
   .wrapper :global(.ql-toolbar .ql-formats) {
     margin-right: var(--sp1) !important;
   }

--- a/src/features/settings/components/SettingsModal.svelte
+++ b/src/features/settings/components/SettingsModal.svelte
@@ -1,13 +1,18 @@
 <script lang="ts">
   import Modal from "@lib/primitives/Modal.svelte";
   import SegmentedControl from "@lib/primitives/SegmentedControl.svelte";
-  import { date_time_format, type DateFormat } from "@stores/preferences";
+  import {
+    date_time_format,
+    ui_density,
+    type DateFormat,
+    type UiDensity,
+  } from "@stores/preferences";
   import { formatDate, formatTime } from "@lib/utils/datetime_shortcuts";
 
   export let show = false;
   export let toggle: () => void;
 
-  type CategoryId = "datetime-format" | "about";
+  type CategoryId = "appearance" | "datetime-format" | "about";
 
   type Category = {
     id: CategoryId;
@@ -17,6 +22,11 @@
   };
 
   const categories: Category[] = [
+    {
+      id: "appearance",
+      label: "外観",
+      description: "表示密度・フラットモード",
+    },
     {
       id: "datetime-format",
       label: "日時フォーマット",
@@ -47,11 +57,20 @@
     { value: "japanese", label: "2026年5月26日" },
   ];
 
+  const densityOptions = [
+    { value: "comfortable", label: "Comfortable" },
+    { value: "compact", label: "Compact (Flat)" },
+  ];
+
   $: previewDate = formatDate(now, $date_time_format);
   $: previewTime = formatTime(now, $date_time_format);
 
   function handleFormatChange(event: CustomEvent<{ value: string }>) {
     date_time_format.set(event.detail.value as DateFormat);
+  }
+
+  function handleDensityChange(event: CustomEvent<{ value: string }>) {
+    ui_density.set(event.detail.value as UiDensity);
   }
 </script>
 
@@ -96,7 +115,31 @@
       </nav>
 
       <section class="Detail" aria-live="polite">
-        {#if selected === "datetime-format"}
+        {#if selected === "appearance"}
+          <header class="DetailHeader">
+            <h3 class="DetailTitle">外観</h3>
+            <p class="DetailHint">
+              <strong>Comfortable</strong> はカードに影と丸みを付けた既定の見た目。
+              <strong>Compact (Flat)</strong> はVSCode風のフラットレイアウトで、影と角の丸みを消し、余白を詰めて密度を上げます。
+            </p>
+          </header>
+
+          <div class="Field">
+            <span class="FieldLabel">表示密度</span>
+            <SegmentedControl
+              options={densityOptions}
+              value={$ui_density}
+              ariaLabel="表示密度"
+              size="md"
+              on:change={handleDensityChange}
+            />
+          </div>
+
+          <p class="Note">
+            <strong>補足:</strong>
+            切り替えは即時反映され、次回起動時にも復元されます。テーマ（Dark / Light）の選択とは独立して機能します。
+          </p>
+        {:else if selected === "datetime-format"}
           <header class="DetailHeader">
             <h3 class="DetailTitle">日時フォーマット</h3>
             <p class="DetailHint">

--- a/src/features/tasks/components/TaskDetail.svelte
+++ b/src/features/tasks/components/TaskDetail.svelte
@@ -15,6 +15,7 @@
     workspace_tasks_cache,
     tag_index,
     theme,
+    ui_density,
   } from "@stores";
   import { selected_ids } from "@stores/ui";
   import { debounce } from "lodash";
@@ -66,7 +67,19 @@
   let detailPaneSize = "40%";
   let splitState = "open";
   let splitSnapping = false;
+  // Compact (flat) mode hides the task-name / status / dates header by
+  // default — the user explicitly asked for a memo-first view when the
+  // UI is in VSCode mode. The reactive below keeps this in sync if they
+  // flip density mid-session: switching to compact collapses the detail
+  // pane, switching back opens it. Manual toggle still wins within a mode
+  // (we only overwrite when $ui_density itself changes).
   let memoFocusMode = false;
+  let previousUiDensity = undefined;
+  $: if ($ui_density !== previousUiDensity) {
+    previousUiDensity = $ui_density;
+    memoFocusMode = $ui_density === "compact";
+    resetCardSplit();
+  }
   let previousTaskDetailId = "";
   let snapTimer;
   let resizeStartY = 0;
@@ -889,6 +902,15 @@
   .task-detail-card-body.memo-mini .memotab-container {
     display: none;
   }
+  /* When one pane is collapsed to zero the resizer is unreachable anyway
+     — drop the 5px strip so the visible pane butts up against the
+     CardHeader. This is what keeps the right-Card chrome height aligned
+     with the left-Card chrome height (toolbar's 2 rows). Re-opening via
+     the toggle button restores the resizer naturally. */
+  .task-detail-card-body.detail-mini .card-split-resizer,
+  .task-detail-card-body.memo-mini .card-split-resizer {
+    display: none;
+  }
   .card-split-resizer {
     position: relative;
     display: flex;
@@ -1042,7 +1064,7 @@
     min-height: 0;
     box-sizing: border-box;
     margin: 0;
-    padding: var(--sp1);
+    padding: var(--memotab-pad);
     overflow: hidden;
   }
   .memotab-container > :global(.container) {

--- a/src/lib/ipc/platform.ts
+++ b/src/lib/ipc/platform.ts
@@ -95,6 +95,10 @@ export function openExternalLink(url: string): void {
   api()?.openExternalLink?.(url);
 }
 
+export function openImageWindow(src: string): void {
+  api()?.openImageWindow?.(src);
+}
+
 export function openTaskDetailWindow(detailData: TaskDetailWindowData): void {
   api()?.openTaskDetailWindow?.(detailData);
 }

--- a/src/lib/layouts/Pane.svelte
+++ b/src/lib/layouts/Pane.svelte
@@ -24,6 +24,6 @@
     align-items: stretch;
     justify-content: stretch;
     overflow: hidden;
-    padding: var(--sp4);
+    padding: var(--pane-pad);
   }
 </style>

--- a/src/lib/layouts/SplitPanes.svelte
+++ b/src/lib/layouts/SplitPanes.svelte
@@ -475,10 +475,12 @@
   }
   /* Mini pane: overflow hidden so nothing bleeds out, and force padding so
      the placeholder Card has breathing room regardless of whether the pane's
-     original child was a Card (which would have applied padding via :has). */
+     original child was a Card (which would have applied padding via :has).
+     Uses the same --pane-pad token as the normal Card-hosting pane, so flat
+     mode collapses both consistently. */
   .SplitPaneRoot > :global(.Pane.PaneMini) {
     overflow: hidden;
-    padding: var(--sp4);
+    padding: var(--pane-pad);
   }
 
   .SplitPaneRoot > :global(.Pane.PaneMini > :not(.PaneMiniPlaceholder)) {
@@ -499,7 +501,7 @@
       var(--theme-color-Main-main)
     );
     border: 1px solid color-mix(in srgb, var(--theme-color-Sub-main) 12%, transparent);
-    border-radius: var(--shape-sm);
+    border-radius: var(--card-radius);
     box-shadow: var(--elevation-2);
     box-sizing: border-box;
   }

--- a/src/lib/primitives/Card.svelte
+++ b/src/lib/primitives/Card.svelte
@@ -24,11 +24,12 @@
     display: flex;
     flex-direction: column;
     box-shadow: var(--elevation-2);
-    border-radius: var(--shape-sm);
+    border-radius: var(--card-radius);
     overflow: hidden;
     box-sizing: border-box;
     background-color: var(--theme-color-Main-main);
-    border: 1px solid color-mix(in srgb, var(--theme-color-Sub-main) 12%, transparent);
+    border: 1px solid
+      color-mix(in srgb, var(--theme-color-Sub-main) var(--card-border-alpha), transparent);
     transition:
       box-shadow 0.18s ease,
       transform 0.18s ease;
@@ -41,19 +42,15 @@
     align-items: center;
     gap: var(--sp2);
     flex-shrink: 0;
-    min-height: 2.25rem;
-    padding: var(--sp1) var(--sp3);
+    min-height: var(--card-header-min-h);
+    padding: var(--card-header-pad-y) var(--sp3);
     border-bottom: 1px solid color-mix(in srgb, var(--theme-color-Sub-main) 20%, transparent);
-    background-color: color-mix(
-      in srgb,
-      var(--theme-color-Primary-main) 12%,
-      var(--theme-color-Main-main)
-    );
+    background-color: var(--card-header-bg);
   }
   .CardHeaderTitle {
     flex: 1 1 auto;
     min-width: 0;
-    font-size: var(--font-title-sm);
+    font-size: var(--card-header-font);
     font-weight: 600;
     color: var(--theme-color-Sub-main);
     line-height: 1.2;
@@ -73,6 +70,6 @@
     overflow: auto;
   }
   .CardBody.padded {
-    padding: var(--sp3);
+    padding: var(--card-pad);
   }
 </style>

--- a/src/pages/MainPage.svelte
+++ b/src/pages/MainPage.svelte
@@ -11,6 +11,7 @@
   import SearchBox from "@lib/primitives/SearchBox.svelte";
   import Loading from "@lib/primitives/Loading.svelte";
   import ActiveFilterBar from "@features/search/components/ActiveFilterBar.svelte";
+  import TaskMenu from "@features/tasks/components/TaskMenu.svelte";
   import { tick } from "svelte";
   import {
     table_selected_id,
@@ -18,6 +19,7 @@
     closed_node_ids,
     ganttVisible,
     selected_type,
+    ui_density,
   } from "@stores";
   import { convertMemoContent, normalizeMemoFormat } from "@features/memos/utils/memo_utils";
   import {
@@ -499,6 +501,157 @@
   };
   const handleExpandAll = () => closed_node_ids.expandAll();
   const handleCollapseAll = () => closed_node_ids.collapseAll();
+
+  // Overflow ("kebab") menu — collapses the secondary action groups into
+  // a single trigger. Only enabled in compact (flat) mode; comfortable
+  // mode keeps the full toolbar inline so power users don't lose any
+  // one-click affordance.
+  $: isCompact = $ui_density === "compact";
+  let showOverflowMenu = false;
+  let overflowMenuPosition = { x: 0, y: 0, position: "left" };
+  // If the user flips back to comfortable while the menu is open, the
+  // kebab trigger disappears and the floating menu would orphan — close it.
+  $: if (!isCompact && showOverflowMenu) {
+    showOverflowMenu = false;
+  }
+
+  $: markdownConvertCount = countProjectMemosForFormat(
+    $tree_data?.data,
+    "markdown",
+    defaultMemoFormat
+  );
+  $: quillConvertCount = countProjectMemosForFormat($tree_data?.data, "quill", defaultMemoFormat);
+
+  $: overflowMenuItems = (() => {
+    const moveGroup = [
+      {
+        id: "moveUp",
+        action: "overflowAction",
+        title: "上に移動",
+        disabled: anchorIsArchived || (isMultiSelect && !canMultiSiblingMove),
+      },
+      {
+        id: "moveDown",
+        action: "overflowAction",
+        title: "下に移動",
+        disabled: anchorIsArchived || (isMultiSelect && !canMultiSiblingMove),
+      },
+      {
+        id: "outdent",
+        action: "overflowAction",
+        title: "アウトデント",
+        disabled: anchorIsArchived || (isMultiSelect && (!canMultiTreeOp || !canMultiOutdent)),
+      },
+      {
+        id: "indent",
+        action: "overflowAction",
+        title: "インデント",
+        disabled: anchorIsArchived || (isMultiSelect && !canMultiTreeOp),
+      },
+    ];
+    const expandGroup = [
+      { id: "expandAll", action: "overflowAction", title: "すべて展開" },
+      { id: "collapseAll", action: "overflowAction", title: "すべて折りたたみ" },
+    ];
+    const memoGroup = [
+      {
+        id: "memoMarkdown",
+        action: "overflowAction",
+        title: "全メモをMarkdownへ変換",
+        disabled: markdownConvertCount === 0,
+      },
+      {
+        id: "memoQuill",
+        action: "overflowAction",
+        title: "全メモをQuillへ変換",
+        disabled: quillConvertCount === 0,
+      },
+    ];
+    const viewGroup = [
+      {
+        id: "toggleGantt",
+        action: "overflowAction",
+        title: $ganttVisible ? "ガントチャートを閉じる" : "ガントチャートを表示",
+      },
+      {
+        id: "toggleDetail",
+        action: "overflowAction",
+        title: detailPaneVisible ? "詳細欄を隠す" : "詳細欄を表示",
+      },
+      {
+        id: "toggleArchived",
+        action: "overflowAction",
+        title: $show_archived ? "アーカイブ済みを隠す" : "アーカイブ済みを表示",
+      },
+    ];
+    const groups = [moveGroup, expandGroup, memoGroup, viewGroup];
+    const out = [];
+    for (const g of groups) {
+      if (out.length) out.push({ type: "separator" });
+      out.push(...g);
+    }
+    return out;
+  })();
+
+  function openOverflowMenu(e) {
+    e.stopPropagation();
+    if (showOverflowMenu) {
+      showOverflowMenu = false;
+      return;
+    }
+    const rect = e.currentTarget.getBoundingClientRect();
+    overflowMenuPosition = { x: rect.right, y: rect.bottom, position: "left" };
+    showOverflowMenu = true;
+  }
+
+  function closeOverflowMenu() {
+    showOverflowMenu = false;
+  }
+
+  function handleOverflowAction(event) {
+    const id = event.detail?.id;
+    switch (id) {
+      case "moveUp":
+        handleMoveUp();
+        break;
+      case "moveDown":
+        handleMoveDown();
+        break;
+      case "indent":
+        handleIndent();
+        break;
+      case "outdent":
+        handleOutdent();
+        break;
+      case "undo":
+        undoHistory();
+        break;
+      case "redo":
+        redoHistory();
+        break;
+      case "expandAll":
+        handleExpandAll();
+        break;
+      case "collapseAll":
+        handleCollapseAll();
+        break;
+      case "memoMarkdown":
+        requestBulkMemoFormat("markdown");
+        break;
+      case "memoQuill":
+        requestBulkMemoFormat("quill");
+        break;
+      case "toggleGantt":
+        $ganttVisible = !$ganttVisible;
+        break;
+      case "toggleDetail":
+        detailPaneVisible = !detailPaneVisible;
+        break;
+      case "toggleArchived":
+        show_archived.set(!$show_archived);
+        break;
+    }
+  }
 </script>
 
 {#if $tree_data}
@@ -508,99 +661,88 @@
         <Card title={projectName} padded={false} style={"height: 100%; width: 100%;"}>
           <span slot="header-actions" class="storage-badge">{projectStorageLabel}</span>
           <div class="TaskListToolbar">
-            <!-- Group 1: Add / Delete -->
-            <div class="TbGroup">
-              <IconButton
-                tooltipContent={anchorIsArchived
-                  ? "アーカイブ済みタスクには追加できません"
-                  : "タスク追加"}
-                ariaLabel="タスク追加"
-                disabled={anchorIsArchived}
-                activeColor={"var(--theme-color-Primary-dark)"}
-                normalColor={"var(--theme-color-Primary-main)"}
-                on:click={(e) => handleAdd(e, "insert_after")}
-              >
-                <svg viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg"
-                  ><path
-                    d="M12 5V19M5 12H19"
-                    stroke="var(--theme-color-Main-main)"
-                    stroke-width="2"
-                    stroke-linecap="round"
-                    stroke-linejoin="round"
-                  ></path></svg
-                >
-              </IconButton>
-              <IconButton
-                tooltipContent={anchorIsArchived
-                  ? "アーカイブ済みタスクには追加できません"
-                  : "子タスク追加"}
-                ariaLabel="子タスク追加"
-                disabled={anchorIsArchived}
-                variant="outlined"
-                activeColor={"var(--theme-color-Primary-main)"}
-                normalColor={"var(--theme-color-Primary-main)"}
-                on:click={(e) => handleAdd(e, "append")}
-              >
-                <svg viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
-                  <path
-                    d="M5 4V12C5 13.1 5.9 14 7 14H14"
-                    stroke="currentColor"
-                    stroke-width="2"
-                    stroke-linecap="round"
-                  />
-                  <path
-                    d="M11 11L14 14L11 17"
-                    stroke="currentColor"
-                    stroke-width="2"
-                    stroke-linecap="round"
-                    stroke-linejoin="round"
-                  />
-                  <path
-                    d="M18 14V18M16 16H20"
-                    stroke="currentColor"
-                    stroke-width="2"
-                    stroke-linecap="round"
-                  />
-                </svg>
-              </IconButton>
-              <IconButton
-                tooltipContent={isMultiSelect
-                  ? `${selectionSize}件を削除（アーカイブ／完全削除を自動振り分け）`
-                  : anchorIsArchived
-                    ? "完全に削除"
-                    : "アーカイブ"}
-                ariaLabel={isMultiSelect
-                  ? `${selectionSize}件を削除`
-                  : anchorIsArchived
-                    ? "完全に削除"
-                    : "アーカイブ"}
-                variant="text"
-                activeColor={"var(--theme-color-Error-main)"}
-                normalColor={"var(--theme-color-Error-main)"}
-                on:click={(e) => handleRemove(e, anchorIsArchived ? "permanent" : "archive")}
-              >
-                <svg viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
-                  <path
-                    d="M3 6H21M8 6V4C8 3.4 8.4 3 9 3H15C15.6 3 16 3.4 16 4V6M10 11V17M14 11V17M5 6L6 20C6 20.6 6.4 21 7 21H17C17.6 21 18 20.6 18 20L19 6"
-                    stroke="currentColor"
-                    stroke-width="2"
-                    stroke-linecap="round"
-                    stroke-linejoin="round"
-                  />
-                </svg>
-              </IconButton>
-              {#if selectionHasArchived}
+            <!-- Two-row layout: buttons on top, filter search on the
+                 bottom. Splitting these into separate rows pads out the
+                 toolbar height so it matches the memo tab strip on the
+                 TaskDetail side, keeping the two Cards visually aligned. -->
+            <div class="TbRow TbButtonsRow" class:TbButtonsRowCompact={isCompact}>
+              <!-- Primary actions: add / add-child / delete (+ restore when
+                   the selection contains archived rows). Everything else
+                   lives in the overflow ("⋯") menu so the toolbar stays
+                   readable at any width. -->
+              <div class="TbGroup">
                 <IconButton
-                  tooltipContent={isMultiSelect ? "選択中のアーカイブ済みタスクを復元" : "復元"}
-                  ariaLabel="アーカイブから復元"
-                  variant="text"
+                  tooltipContent={anchorIsArchived
+                    ? "アーカイブ済みタスクには追加できません"
+                    : "タスク追加"}
+                  ariaLabel="タスク追加"
+                  disabled={anchorIsArchived}
+                  activeColor={"var(--theme-color-Primary-dark)"}
+                  normalColor={"var(--theme-color-Primary-main)"}
+                  on:click={(e) => handleAdd(e, "insert_after")}
+                >
+                  <svg viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg"
+                    ><path
+                      d="M12 5V19M5 12H19"
+                      stroke="var(--theme-color-Main-main)"
+                      stroke-width="2"
+                      stroke-linecap="round"
+                      stroke-linejoin="round"
+                    ></path></svg
+                  >
+                </IconButton>
+                <IconButton
+                  tooltipContent={anchorIsArchived
+                    ? "アーカイブ済みタスクには追加できません"
+                    : "子タスク追加"}
+                  ariaLabel="子タスク追加"
+                  disabled={anchorIsArchived}
+                  variant="outlined"
                   activeColor={"var(--theme-color-Primary-main)"}
                   normalColor={"var(--theme-color-Primary-main)"}
-                  on:click={handleRestore}
+                  on:click={(e) => handleAdd(e, "append")}
                 >
                   <svg viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
                     <path
-                      d="M3 12a9 9 0 1 1 3.6 7.2M3 12V6M3 12h6"
+                      d="M5 4V12C5 13.1 5.9 14 7 14H14"
+                      stroke="currentColor"
+                      stroke-width="2"
+                      stroke-linecap="round"
+                    />
+                    <path
+                      d="M11 11L14 14L11 17"
+                      stroke="currentColor"
+                      stroke-width="2"
+                      stroke-linecap="round"
+                      stroke-linejoin="round"
+                    />
+                    <path
+                      d="M18 14V18M16 16H20"
+                      stroke="currentColor"
+                      stroke-width="2"
+                      stroke-linecap="round"
+                    />
+                  </svg>
+                </IconButton>
+                <IconButton
+                  tooltipContent={isMultiSelect
+                    ? `${selectionSize}件を削除（アーカイブ／完全削除を自動振り分け）`
+                    : anchorIsArchived
+                      ? "完全に削除"
+                      : "アーカイブ"}
+                  ariaLabel={isMultiSelect
+                    ? `${selectionSize}件を削除`
+                    : anchorIsArchived
+                      ? "完全に削除"
+                      : "アーカイブ"}
+                  variant="text"
+                  activeColor={"var(--theme-color-Error-main)"}
+                  normalColor={"var(--theme-color-Error-main)"}
+                  on:click={(e) => handleRemove(e, anchorIsArchived ? "permanent" : "archive")}
+                >
+                  <svg viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
+                    <path
+                      d="M3 6H21M8 6V4C8 3.4 8.4 3 9 3H15C15.6 3 16 3.4 16 4V6M10 11V17M14 11V17M5 6L6 20C6 20.6 6.4 21 7 21H17C17.6 21 18 20.6 18 20L19 6"
                       stroke="currentColor"
                       stroke-width="2"
                       stroke-linecap="round"
@@ -608,310 +750,351 @@
                     />
                   </svg>
                 </IconButton>
+                {#if selectionHasArchived}
+                  <IconButton
+                    tooltipContent={isMultiSelect ? "選択中のアーカイブ済みタスクを復元" : "復元"}
+                    ariaLabel="アーカイブから復元"
+                    variant="text"
+                    activeColor={"var(--theme-color-Primary-main)"}
+                    normalColor={"var(--theme-color-Primary-main)"}
+                    on:click={handleRestore}
+                  >
+                    <svg viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
+                      <path
+                        d="M3 12a9 9 0 1 1 3.6 7.2M3 12V6M3 12h6"
+                        stroke="currentColor"
+                        stroke-width="2"
+                        stroke-linecap="round"
+                        stroke-linejoin="round"
+                      />
+                    </svg>
+                  </IconButton>
+                {/if}
+              </div>
+              <span class="TbSep" aria-hidden="true"></span>
+
+              {#if !isCompact}
+                <!-- Move / Indent -->
+                <div class="TbGroup">
+                  <IconButton
+                    tooltipContent={isMultiSelect
+                      ? canMultiSiblingMove
+                        ? `${selectionSize}件 上に移動`
+                        : "同じ親の連続した兄弟のみ移動できます"
+                      : "上に移動 (Alt+↑)"}
+                    ariaLabel={isMultiSelect ? `${selectionSize}件 上に移動` : "上に移動"}
+                    variant="text"
+                    normalColor={"var(--theme-color-Sub-main)"}
+                    activeColor={"var(--theme-color-Primary-main)"}
+                    disabled={anchorIsArchived || (isMultiSelect && !canMultiSiblingMove)}
+                    on:click={handleMoveUp}
+                  >
+                    <svg viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
+                      <path
+                        d="M12 19V5M5 12L12 5L19 12"
+                        stroke="currentColor"
+                        stroke-width="2"
+                        stroke-linecap="round"
+                        stroke-linejoin="round"
+                      />
+                    </svg>
+                  </IconButton>
+                  <IconButton
+                    tooltipContent={isMultiSelect
+                      ? canMultiSiblingMove
+                        ? `${selectionSize}件 下に移動`
+                        : "同じ親の連続した兄弟のみ移動できます"
+                      : "下に移動 (Alt+↓)"}
+                    ariaLabel={isMultiSelect ? `${selectionSize}件 下に移動` : "下に移動"}
+                    variant="text"
+                    normalColor={"var(--theme-color-Sub-main)"}
+                    activeColor={"var(--theme-color-Primary-main)"}
+                    disabled={anchorIsArchived || (isMultiSelect && !canMultiSiblingMove)}
+                    on:click={handleMoveDown}
+                  >
+                    <svg viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
+                      <path
+                        d="M12 5V19M5 12L12 19L19 12"
+                        stroke="currentColor"
+                        stroke-width="2"
+                        stroke-linecap="round"
+                        stroke-linejoin="round"
+                      />
+                    </svg>
+                  </IconButton>
+                  <IconButton
+                    tooltipContent={isMultiSelect
+                      ? canMultiTreeOp && canMultiOutdent
+                        ? `${selectionSize}件 アウトデント`
+                        : canMultiTreeOp
+                          ? "これ以上アウトデントできません"
+                          : "同じ親の兄弟のみアウトデントできます"
+                      : "アウトデント (Shift+Tab)"}
+                    ariaLabel={isMultiSelect ? `${selectionSize}件 アウトデント` : "アウトデント"}
+                    variant="text"
+                    normalColor={"var(--theme-color-Sub-main)"}
+                    activeColor={"var(--theme-color-Primary-main)"}
+                    disabled={anchorIsArchived ||
+                      (isMultiSelect && (!canMultiTreeOp || !canMultiOutdent))}
+                    on:click={handleOutdent}
+                  >
+                    <svg viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
+                      <path
+                        d="M21 4H10M21 12H10M21 20H10M7 8L3 12L7 16"
+                        stroke="currentColor"
+                        stroke-width="2"
+                        stroke-linecap="round"
+                        stroke-linejoin="round"
+                      />
+                    </svg>
+                  </IconButton>
+                  <IconButton
+                    tooltipContent={isMultiSelect
+                      ? canMultiTreeOp
+                        ? `${selectionSize}件 インデント`
+                        : "同じ親の兄弟のみインデントできます"
+                      : "インデント (Tab)"}
+                    ariaLabel={isMultiSelect ? `${selectionSize}件 インデント` : "インデント"}
+                    variant="text"
+                    normalColor={"var(--theme-color-Sub-main)"}
+                    activeColor={"var(--theme-color-Primary-main)"}
+                    disabled={anchorIsArchived || (isMultiSelect && !canMultiTreeOp)}
+                    on:click={handleIndent}
+                  >
+                    <svg viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
+                      <path
+                        d="M3 4H14M3 12H14M3 20H14M17 8L21 12L17 16"
+                        stroke="currentColor"
+                        stroke-width="2"
+                        stroke-linecap="round"
+                        stroke-linejoin="round"
+                      />
+                    </svg>
+                  </IconButton>
+                </div>
+                <span class="TbSep" aria-hidden="true"></span>
+
+                <!-- Expand / Collapse -->
+                <div class="TbGroup">
+                  <IconButton
+                    tooltipContent="すべて展開"
+                    ariaLabel="すべて展開"
+                    variant="text"
+                    normalColor={"var(--theme-color-Sub-main)"}
+                    activeColor={"var(--theme-color-Primary-main)"}
+                    on:click={handleExpandAll}
+                  >
+                    <svg viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
+                      <path
+                        d="M8 10L12 6L16 10M8 14L12 18L16 14"
+                        stroke="currentColor"
+                        stroke-width="2"
+                        stroke-linecap="round"
+                        stroke-linejoin="round"
+                      />
+                    </svg>
+                  </IconButton>
+                  <IconButton
+                    tooltipContent="すべて折りたたみ"
+                    ariaLabel="すべて折りたたみ"
+                    variant="text"
+                    normalColor={"var(--theme-color-Sub-main)"}
+                    activeColor={"var(--theme-color-Primary-main)"}
+                    on:click={handleCollapseAll}
+                  >
+                    <svg viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
+                      <path
+                        d="M8 6L12 10L16 6M8 18L12 14L16 18"
+                        stroke="currentColor"
+                        stroke-width="2"
+                        stroke-linecap="round"
+                        stroke-linejoin="round"
+                      />
+                    </svg>
+                  </IconButton>
+                </div>
+                <span class="TbSep" aria-hidden="true"></span>
+              {/if}
+
+              <!-- Edit history: Undo / Redo. Kept visible because Ctrl+Z/Y
+                 also relies on these being the canonical "edit" affordance. -->
+              <div class="TbGroup">
+                <IconButton
+                  tooltipContent="元に戻す (Ctrl+Z)"
+                  ariaLabel="元に戻す"
+                  variant="text"
+                  normalColor={"var(--theme-color-Sub-main)"}
+                  activeColor={"var(--theme-color-Primary-main)"}
+                  on:click={undoHistory}
+                >
+                  <svg viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
+                    <path
+                      d="M3 7L7 3M3 7L7 11M3 7H15C18.3 7 21 9.7 21 13C21 16.3 18.3 19 15 19H9"
+                      stroke="currentColor"
+                      stroke-width="2"
+                      stroke-linecap="round"
+                      stroke-linejoin="round"
+                    />
+                  </svg>
+                </IconButton>
+                <IconButton
+                  tooltipContent="やり直し (Ctrl+Y)"
+                  ariaLabel="やり直し"
+                  variant="text"
+                  normalColor={"var(--theme-color-Sub-main)"}
+                  activeColor={"var(--theme-color-Primary-main)"}
+                  on:click={redoHistory}
+                >
+                  <svg viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
+                    <path
+                      d="M21 7L17 3M21 7L17 11M21 7H9C5.7 7 3 9.7 3 13C3 16.3 5.7 19 9 19H15"
+                      stroke="currentColor"
+                      stroke-width="2"
+                      stroke-linecap="round"
+                      stroke-linejoin="round"
+                    />
+                  </svg>
+                </IconButton>
+              </div>
+              <span class="TbSep" aria-hidden="true"></span>
+
+              {#if !isCompact}
+                <!-- Bulk memo format conversion -->
+                <div class="TbGroup">
+                  <IconButton
+                    tooltipContent="全メモをMarkdownへ変換"
+                    ariaLabel="全メモをMarkdownへ変換"
+                    variant="text"
+                    normalColor={"var(--theme-color-Sub-main)"}
+                    activeColor={"var(--theme-color-Primary-main)"}
+                    disabled={markdownConvertCount === 0}
+                    on:click={() => requestBulkMemoFormat("markdown")}
+                  >
+                    <svg viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
+                      <path
+                        d="M4 17V7L8 13L12 7V17M17 7V15M14 12L17 15L20 12"
+                        stroke="currentColor"
+                        stroke-width="2"
+                        stroke-linecap="round"
+                        stroke-linejoin="round"
+                      />
+                    </svg>
+                  </IconButton>
+                  <IconButton
+                    tooltipContent="全メモをQuillへ変換"
+                    ariaLabel="全メモをQuillへ変換"
+                    variant="text"
+                    normalColor={"var(--theme-color-Sub-main)"}
+                    activeColor={"var(--theme-color-Primary-main)"}
+                    disabled={quillConvertCount === 0}
+                    on:click={() => requestBulkMemoFormat("quill")}
+                  >
+                    <svg viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
+                      <path
+                        d="M12 4C7.6 4 4 7.2 4 11.5S7.6 19 12 19H16M12 8C9.8 8 8 9.6 8 11.5S9.8 15 12 15H14.5L17.5 19"
+                        stroke="currentColor"
+                        stroke-width="2"
+                        stroke-linecap="round"
+                        stroke-linejoin="round"
+                      />
+                    </svg>
+                  </IconButton>
+                </div>
+              {/if}
+
+              {#if !isCompact}
+                <!-- View toggles: Gantt / detail pane / archived rows -->
+                <div class="TbGroup">
+                  <IconButton
+                    tooltipContent={$ganttVisible
+                      ? "ガントチャートを閉じる"
+                      : "ガントチャートを表示"}
+                    ariaLabel="ガントチャートの表示切替"
+                    variant="text"
+                    normalColor={$ganttVisible
+                      ? "var(--theme-color-Primary-main)"
+                      : "var(--theme-color-Sub-main)"}
+                    activeColor={"var(--theme-color-Primary-main)"}
+                    on:click={() => ($ganttVisible = !$ganttVisible)}
+                  >
+                    <svg viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
+                      <rect x="3" y="4" width="4" height="3" rx="0.5" fill="currentColor" />
+                      <rect x="3" y="10.5" width="7" height="3" rx="0.5" fill="currentColor" />
+                      <rect x="3" y="17" width="5" height="3" rx="0.5" fill="currentColor" />
+                    </svg>
+                  </IconButton>
+                  <IconButton
+                    tooltipContent={detailPaneVisible ? "Hide detail pane" : "Show detail pane"}
+                    ariaLabel={detailPaneVisible ? "Hide detail pane" : "Show detail pane"}
+                    variant="text"
+                    normalColor={detailPaneVisible
+                      ? "var(--theme-color-Primary-main)"
+                      : "var(--theme-color-Sub-main)"}
+                    activeColor={"var(--theme-color-Primary-main)"}
+                    on:click={() => (detailPaneVisible = !detailPaneVisible)}
+                  >
+                    <svg viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
+                      <rect
+                        x="3"
+                        y="4"
+                        width="18"
+                        height="16"
+                        rx="2"
+                        stroke="currentColor"
+                        stroke-width="1.8"
+                      />
+                      <path d="M15 4V20" stroke="currentColor" stroke-width="1.8" />
+                    </svg>
+                  </IconButton>
+                  <IconButton
+                    tooltipContent={$show_archived
+                      ? "アーカイブ済みタスクを隠す"
+                      : "アーカイブ済みタスクを表示"}
+                    ariaLabel="アーカイブ表示の切替"
+                    variant="text"
+                    normalColor={$show_archived
+                      ? "var(--theme-color-Primary-main)"
+                      : "var(--theme-color-Sub-main)"}
+                    activeColor={"var(--theme-color-Primary-main)"}
+                    on:click={() => show_archived.set(!$show_archived)}
+                  >
+                    <svg viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
+                      <path
+                        d="M3 7h18v3H3V7zM5 10v9a1 1 0 0 0 1 1h12a1 1 0 0 0 1-1v-9M10 14h4"
+                        stroke="currentColor"
+                        stroke-width="1.8"
+                        stroke-linecap="round"
+                        stroke-linejoin="round"
+                      />
+                    </svg>
+                  </IconButton>
+                </div>
+              {:else}
+                <!-- Overflow menu (compact only): move/indent, expand/collapse,
+                   memo format conversion, and view toggles. The wrapping
+                   span carries data-task-menu-trigger so TaskMenu's
+                   outside-click handler doesn't fight the toggle click. -->
+                <span class="TbGroup" data-task-menu-trigger="overflow">
+                  <IconButton
+                    tooltipContent="その他の操作"
+                    ariaLabel="その他の操作"
+                    variant="text"
+                    normalColor={"var(--theme-color-Sub-main)"}
+                    activeColor={"var(--theme-color-Primary-main)"}
+                    on:click={openOverflowMenu}
+                  >
+                    <svg viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
+                      <circle cx="5" cy="12" r="1.6" fill="currentColor" />
+                      <circle cx="12" cy="12" r="1.6" fill="currentColor" />
+                      <circle cx="19" cy="12" r="1.6" fill="currentColor" />
+                    </svg>
+                  </IconButton>
+                </span>
               {/if}
             </div>
-            <span class="TbSep" aria-hidden="true"></span>
-
-            <!-- Group 2: Move / Indent -->
-            <div class="TbGroup">
-              <IconButton
-                tooltipContent={isMultiSelect
-                  ? canMultiSiblingMove
-                    ? `${selectionSize}件 上に移動`
-                    : "同じ親の連続した兄弟のみ移動できます"
-                  : "上に移動 (Alt+↑)"}
-                ariaLabel={isMultiSelect ? `${selectionSize}件 上に移動` : "上に移動"}
-                variant="text"
-                normalColor={"var(--theme-color-Sub-main)"}
-                activeColor={"var(--theme-color-Primary-main)"}
-                disabled={anchorIsArchived || (isMultiSelect && !canMultiSiblingMove)}
-                on:click={handleMoveUp}
-              >
-                <svg viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
-                  <path
-                    d="M12 19V5M5 12L12 5L19 12"
-                    stroke="currentColor"
-                    stroke-width="2"
-                    stroke-linecap="round"
-                    stroke-linejoin="round"
-                  />
-                </svg>
-              </IconButton>
-              <IconButton
-                tooltipContent={isMultiSelect
-                  ? canMultiSiblingMove
-                    ? `${selectionSize}件 下に移動`
-                    : "同じ親の連続した兄弟のみ移動できます"
-                  : "下に移動 (Alt+↓)"}
-                ariaLabel={isMultiSelect ? `${selectionSize}件 下に移動` : "下に移動"}
-                variant="text"
-                normalColor={"var(--theme-color-Sub-main)"}
-                activeColor={"var(--theme-color-Primary-main)"}
-                disabled={anchorIsArchived || (isMultiSelect && !canMultiSiblingMove)}
-                on:click={handleMoveDown}
-              >
-                <svg viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
-                  <path
-                    d="M12 5V19M5 12L12 19L19 12"
-                    stroke="currentColor"
-                    stroke-width="2"
-                    stroke-linecap="round"
-                    stroke-linejoin="round"
-                  />
-                </svg>
-              </IconButton>
-              <IconButton
-                tooltipContent={isMultiSelect
-                  ? canMultiTreeOp && canMultiOutdent
-                    ? `${selectionSize}件 アウトデント`
-                    : canMultiTreeOp
-                      ? "これ以上アウトデントできません"
-                      : "同じ親の兄弟のみアウトデントできます"
-                  : "アウトデント (Shift+Tab)"}
-                ariaLabel={isMultiSelect ? `${selectionSize}件 アウトデント` : "アウトデント"}
-                variant="text"
-                normalColor={"var(--theme-color-Sub-main)"}
-                activeColor={"var(--theme-color-Primary-main)"}
-                disabled={anchorIsArchived ||
-                  (isMultiSelect && (!canMultiTreeOp || !canMultiOutdent))}
-                on:click={handleOutdent}
-              >
-                <svg viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
-                  <path
-                    d="M21 4H10M21 12H10M21 20H10M7 8L3 12L7 16"
-                    stroke="currentColor"
-                    stroke-width="2"
-                    stroke-linecap="round"
-                    stroke-linejoin="round"
-                  />
-                </svg>
-              </IconButton>
-              <IconButton
-                tooltipContent={isMultiSelect
-                  ? canMultiTreeOp
-                    ? `${selectionSize}件 インデント`
-                    : "同じ親の兄弟のみインデントできます"
-                  : "インデント (Tab)"}
-                ariaLabel={isMultiSelect ? `${selectionSize}件 インデント` : "インデント"}
-                variant="text"
-                normalColor={"var(--theme-color-Sub-main)"}
-                activeColor={"var(--theme-color-Primary-main)"}
-                disabled={anchorIsArchived || (isMultiSelect && !canMultiTreeOp)}
-                on:click={handleIndent}
-              >
-                <svg viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
-                  <path
-                    d="M3 4H14M3 12H14M3 20H14M17 8L21 12L17 16"
-                    stroke="currentColor"
-                    stroke-width="2"
-                    stroke-linecap="round"
-                    stroke-linejoin="round"
-                  />
-                </svg>
-              </IconButton>
-            </div>
-            <span class="TbSep" aria-hidden="true"></span>
-
-            <!-- Group 3: Expand / Collapse -->
-            <div class="TbGroup">
-              <IconButton
-                tooltipContent="すべて展開"
-                ariaLabel="すべて展開"
-                variant="text"
-                normalColor={"var(--theme-color-Sub-main)"}
-                activeColor={"var(--theme-color-Primary-main)"}
-                on:click={handleExpandAll}
-              >
-                <svg viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
-                  <path
-                    d="M8 10L12 6L16 10M8 14L12 18L16 14"
-                    stroke="currentColor"
-                    stroke-width="2"
-                    stroke-linecap="round"
-                    stroke-linejoin="round"
-                  />
-                </svg>
-              </IconButton>
-              <IconButton
-                tooltipContent="すべて折りたたみ"
-                ariaLabel="すべて折りたたみ"
-                variant="text"
-                normalColor={"var(--theme-color-Sub-main)"}
-                activeColor={"var(--theme-color-Primary-main)"}
-                on:click={handleCollapseAll}
-              >
-                <svg viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
-                  <path
-                    d="M8 6L12 10L16 6M8 18L12 14L16 18"
-                    stroke="currentColor"
-                    stroke-width="2"
-                    stroke-linecap="round"
-                    stroke-linejoin="round"
-                  />
-                </svg>
-              </IconButton>
-            </div>
-            <span class="TbSep" aria-hidden="true"></span>
-
-            <!-- Group 4: Undo / Redo -->
-            <div class="TbGroup">
-              <IconButton
-                tooltipContent="元に戻す (Ctrl+Z)"
-                ariaLabel="元に戻す"
-                variant="text"
-                normalColor={"var(--theme-color-Sub-main)"}
-                activeColor={"var(--theme-color-Primary-main)"}
-                on:click={undoHistory}
-              >
-                <svg viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
-                  <path
-                    d="M3 7L7 3M3 7L7 11M3 7H15C18.3 7 21 9.7 21 13C21 16.3 18.3 19 15 19H9"
-                    stroke="currentColor"
-                    stroke-width="2"
-                    stroke-linecap="round"
-                    stroke-linejoin="round"
-                  />
-                </svg>
-              </IconButton>
-              <IconButton
-                tooltipContent="やり直し (Ctrl+Y)"
-                ariaLabel="やり直し"
-                variant="text"
-                normalColor={"var(--theme-color-Sub-main)"}
-                activeColor={"var(--theme-color-Primary-main)"}
-                on:click={redoHistory}
-              >
-                <svg viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
-                  <path
-                    d="M21 7L17 3M21 7L17 11M21 7H9C5.7 7 3 9.7 3 13C3 16.3 5.7 19 9 19H15"
-                    stroke="currentColor"
-                    stroke-width="2"
-                    stroke-linecap="round"
-                    stroke-linejoin="round"
-                  />
-                </svg>
-              </IconButton>
-            </div>
-            <span class="TbSep" aria-hidden="true"></span>
-
-            <!-- Group 5: Bulk memo format conversion -->
-            <div class="TbGroup">
-              <IconButton
-                tooltipContent="全メモをMarkdownへ変換"
-                ariaLabel="全メモをMarkdownへ変換"
-                variant="text"
-                normalColor={"var(--theme-color-Sub-main)"}
-                activeColor={"var(--theme-color-Primary-main)"}
-                disabled={countProjectMemosForFormat(
-                  $tree_data?.data,
-                  "markdown",
-                  defaultMemoFormat
-                ) === 0}
-                on:click={() => requestBulkMemoFormat("markdown")}
-              >
-                <svg viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
-                  <path
-                    d="M4 17V7L8 13L12 7V17M17 7V15M14 12L17 15L20 12"
-                    stroke="currentColor"
-                    stroke-width="2"
-                    stroke-linecap="round"
-                    stroke-linejoin="round"
-                  />
-                </svg>
-              </IconButton>
-              <IconButton
-                tooltipContent="全メモをQuillへ変換"
-                ariaLabel="全メモをQuillへ変換"
-                variant="text"
-                normalColor={"var(--theme-color-Sub-main)"}
-                activeColor={"var(--theme-color-Primary-main)"}
-                disabled={countProjectMemosForFormat(
-                  $tree_data?.data,
-                  "quill",
-                  defaultMemoFormat
-                ) === 0}
-                on:click={() => requestBulkMemoFormat("quill")}
-              >
-                <svg viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
-                  <path
-                    d="M12 4C7.6 4 4 7.2 4 11.5S7.6 19 12 19H16M12 8C9.8 8 8 9.6 8 11.5S9.8 15 12 15H14.5L17.5 19"
-                    stroke="currentColor"
-                    stroke-width="2"
-                    stroke-linecap="round"
-                    stroke-linejoin="round"
-                  />
-                </svg>
-              </IconButton>
-            </div>
-
-            <!-- Tree filter search (filters rows by name) -->
-            <div class="TbSearch">
+            <!-- Filter row: SearchBox stretches to the full toolbar width. -->
+            <div class="TbRow TbSearchRow">
               <SearchBox />
-            </div>
-
-            <!-- Group 5: View toggles -->
-            <div class="TbGroup">
-              <IconButton
-                tooltipContent={$ganttVisible ? "ガントチャートを閉じる" : "ガントチャートを表示"}
-                ariaLabel="ガントチャートの表示切替"
-                variant="text"
-                normalColor={$ganttVisible
-                  ? "var(--theme-color-Primary-main)"
-                  : "var(--theme-color-Sub-main)"}
-                activeColor={"var(--theme-color-Primary-main)"}
-                on:click={() => ($ganttVisible = !$ganttVisible)}
-              >
-                <svg viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
-                  <rect x="3" y="4" width="4" height="3" rx="0.5" fill="currentColor" />
-                  <rect x="3" y="10.5" width="7" height="3" rx="0.5" fill="currentColor" />
-                  <rect x="3" y="17" width="5" height="3" rx="0.5" fill="currentColor" />
-                </svg>
-              </IconButton>
-              <IconButton
-                tooltipContent={detailPaneVisible ? "Hide detail pane" : "Show detail pane"}
-                ariaLabel={detailPaneVisible ? "Hide detail pane" : "Show detail pane"}
-                variant="text"
-                normalColor={detailPaneVisible
-                  ? "var(--theme-color-Primary-main)"
-                  : "var(--theme-color-Sub-main)"}
-                activeColor={"var(--theme-color-Primary-main)"}
-                on:click={() => (detailPaneVisible = !detailPaneVisible)}
-              >
-                <svg viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
-                  <rect
-                    x="3"
-                    y="4"
-                    width="18"
-                    height="16"
-                    rx="2"
-                    stroke="currentColor"
-                    stroke-width="1.8"
-                  />
-                  <path d="M15 4V20" stroke="currentColor" stroke-width="1.8" />
-                </svg>
-              </IconButton>
-              <IconButton
-                tooltipContent={$show_archived
-                  ? "アーカイブ済みタスクを隠す"
-                  : "アーカイブ済みタスクを表示"}
-                ariaLabel="アーカイブ表示の切替"
-                variant="text"
-                normalColor={$show_archived
-                  ? "var(--theme-color-Primary-main)"
-                  : "var(--theme-color-Sub-main)"}
-                activeColor={"var(--theme-color-Primary-main)"}
-                on:click={() => show_archived.set(!$show_archived)}
-              >
-                <svg viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
-                  <path
-                    d="M3 7h18v3H3V7zM5 10v9a1 1 0 0 0 1 1h12a1 1 0 0 0 1-1v-9M10 14h4"
-                    stroke="currentColor"
-                    stroke-width="1.8"
-                    stroke-linecap="round"
-                    stroke-linejoin="round"
-                  />
-                </svg>
-              </IconButton>
             </div>
           </div>
           <ActiveFilterBar />
@@ -956,6 +1139,13 @@
     content={alert_content}
     ok={false}
     cancel={"close"}
+  />
+  <TaskMenu
+    menuItems={overflowMenuItems}
+    position={overflowMenuPosition}
+    show={showOverflowMenu}
+    on:close={closeOverflowMenu}
+    on:overflowAction={handleOverflowAction}
   />
   <Modal
     show={show_memo_format_confirm}
@@ -1063,27 +1253,60 @@
     height: 1.75rem;
     margin: 0;
   }
-  .TbSearch {
-    display: flex;
-    flex: 1 1 auto;
-    align-items: center;
-    margin-left: auto;
-    height: 1.75rem;
-    min-width: 8rem;
-    max-width: 22rem;
-  }
   .TaskListToolbar {
+    display: flex;
+    flex-direction: column;
+    align-items: stretch;
+    gap: var(--sp1);
+    width: 100%;
+    min-width: 0;
+    padding: var(--sp1) var(--sp2);
+    box-sizing: border-box;
+    border-bottom: 1px solid color-mix(in srgb, var(--theme-color-Sub-main) 12%, transparent);
+    flex-shrink: 0;
+  }
+  .TbRow {
     display: flex;
     flex-direction: row;
     align-items: center;
     gap: var(--sp2);
     width: 100%;
     min-width: 0;
-    padding: var(--sp1) var(--sp2);
-    box-sizing: border-box;
+  }
+  .TbButtonsRow {
     flex-wrap: wrap;
-    border-bottom: 1px solid color-mix(in srgb, var(--theme-color-Sub-main) 12%, transparent);
-    flex-shrink: 0;
+  }
+  /* Compact (flat) mode: lock the row to a single line and scroll
+     horizontally instead of wrapping. Wrapping would grow the toolbar
+     height at narrow widths, throwing off the height alignment with the
+     TaskDetail Card next door. Comfortable mode keeps the natural wrap
+     behavior because button density is lower there. */
+  .TbButtonsRowCompact {
+    flex-wrap: nowrap;
+    overflow-x: auto;
+    overflow-y: hidden;
+    scrollbar-width: thin;
+  }
+  .TbButtonsRowCompact::-webkit-scrollbar {
+    height: 4px;
+  }
+  .TbButtonsRowCompact::-webkit-scrollbar-thumb {
+    background: color-mix(in srgb, var(--theme-color-Sub-main) 35%, transparent);
+    border-radius: 2px;
+  }
+  .TbButtonsRowCompact::-webkit-scrollbar-track {
+    background: transparent;
+  }
+  .TbSearchRow {
+    /* SearchBox sits alone on the second row; let it use its natural
+       2rem height (defined in SearchBox.svelte). This adds the row
+       height that brings the toolbar in line with the memo tab strip
+       on the TaskDetail side. */
+    min-height: 2rem;
+  }
+  .TbSearchRow :global(> *) {
+    flex: 1 1 auto;
+    min-width: 0;
   }
   .storage-badge {
     flex: 0 0 auto;

--- a/src/pages/TaskDetailPage.svelte
+++ b/src/pages/TaskDetailPage.svelte
@@ -72,7 +72,7 @@
     flex-direction: column;
     width: 100%;
     height: 100%;
-    padding: var(--sp2);
+    padding: var(--detail-window-pad);
     box-sizing: border-box;
     background: var(--theme-color-Main-dark);
     color: var(--theme-color-Sub-main);

--- a/src/stores/index.ts
+++ b/src/stores/index.ts
@@ -33,7 +33,7 @@ import { workspace_conflict_policy } from "@features/workspace/stores/policy";
 import { active_tag } from "@features/memos/stores/tags";
 import { sort_state } from "@features/tasks/stores/sort";
 import { inbox_store } from "@features/inbox/stores/inbox";
-import { date_time_format } from "./preferences";
+import { date_time_format, ui_density } from "./preferences";
 import { navigation_history } from "./navigation_history";
 
 let initStoreReady: Promise<void> | null = null;
@@ -59,6 +59,7 @@ export function init_store(): Promise<void> {
   workspace_conflict_policy.init();
   inbox_store.init();
   date_time_format.init();
+  ui_density.init();
 
   // 履歴記録は selected_type / selected_id への subscribe を張る。
   // タスク詳細サブウィンドウ (`#task-detail-window`) では戻る/進むの概念が

--- a/src/stores/preferences.ts
+++ b/src/stores/preferences.ts
@@ -36,3 +36,78 @@ function createDateFormatStore(): DateFormatStore {
 
 // eslint-disable-next-line prefer-const
 export let date_time_format: DateFormatStore = createDateFormatStore();
+
+// UI density — "comfortable" (default, card-based with elevation) or
+// "compact" (VSCode-like flat layout: tighter spacing, no shadows, sharper
+// corners, hairline borders for zoning).
+export type UiDensity = "comfortable" | "compact";
+
+const UI_DENSITY_KEY = "preferences.ui_density";
+const UI_DENSITY_DEFAULT: UiDensity = "comfortable";
+
+function isUiDensity(value: unknown): value is UiDensity {
+  return value === "comfortable" || value === "compact";
+}
+
+export interface UiDensityStore extends Writable<UiDensity> {
+  init: () => void;
+}
+
+function applyUiDensityClass(value: UiDensity) {
+  if (typeof document === "undefined") return;
+  const el = document.documentElement;
+  el.classList.toggle("density-compact", value === "compact");
+}
+
+function createUiDensityStore(): UiDensityStore {
+  const { subscribe, set, update } = writable<UiDensity>(UI_DENSITY_DEFAULT);
+
+  // Cross-window live sync. BroadcastChannel works between BrowserWindow
+  // renderers within the same Electron app (same origin), so a density
+  // change in the main window propagates to any open Task Detail windows
+  // (and vice versa) without needing the main process to broker an event.
+  const channel: BroadcastChannel | null =
+    typeof BroadcastChannel !== "undefined" ? new BroadcastChannel("preferences") : null;
+  const BROADCAST_TYPE = "ui_density";
+
+  // Apply a value locally without re-broadcasting. Used for incoming
+  // BroadcastChannel messages and the initial getMetaData hydration —
+  // both already know the canonical value, so re-emitting would just
+  // bounce the message back and (for setMetaData) cause a redundant disk
+  // write in every window.
+  function setLocal(value: UiDensity) {
+    set(value);
+    applyUiDensityClass(value);
+  }
+
+  return {
+    subscribe,
+    set: (value: UiDensity) => {
+      setLocal(value);
+      platform.setMetaData(UI_DENSITY_KEY, value);
+      channel?.postMessage({ type: BROADCAST_TYPE, value });
+    },
+    update,
+    init: () => {
+      channel?.addEventListener("message", (event: MessageEvent) => {
+        const data = event.data;
+        if (
+          data &&
+          typeof data === "object" &&
+          (data as { type?: unknown }).type === BROADCAST_TYPE &&
+          isUiDensity((data as { value?: unknown }).value)
+        ) {
+          setLocal((data as { value: UiDensity }).value);
+        }
+      });
+      platform.getMetaData(UI_DENSITY_KEY).then((result) => {
+        if (isUiDensity(result)) {
+          setLocal(result);
+        }
+      });
+    },
+  };
+}
+
+// eslint-disable-next-line prefer-const
+export let ui_density: UiDensityStore = createUiDensityStore();

--- a/src/types/app.ts
+++ b/src/types/app.ts
@@ -102,6 +102,7 @@ export interface ElectronAPI {
   deleteProject: (projectId: string) => void;
   message: (message: string) => void;
   openExternalLink: (url: string) => void;
+  openImageWindow: (src: string) => void;
   openTaskDetailWindow: (detailData: TaskDetailWindowData) => void;
   findInPage: (text: string, options?: Record<string, unknown>) => Promise<FindInPageResult | void>;
   findInPageNext: (text: string) => Promise<void>;

--- a/tests/component/Memo.test.js
+++ b/tests/component/Memo.test.js
@@ -531,7 +531,14 @@ describe("Markdown Memo - view mode", () => {
     });
   });
 
-  test("caps markdown preview image growth at the image's natural width", async () => {
+  test("markdown preview image relies on the static CSS cap, not a JS-set per-image variable", async () => {
+    // Image sizing was previously driven by a JS path that measured each
+    // image's naturalWidth and pushed it into a `--memo-preview-image-max-width`
+    // inline custom property. That created a visible size mismatch between
+    // Preview-only and Split modes (different containers, different
+    // computed widths) and was replaced with a static `max-width: min(100%, 32rem)`
+    // rule in CSS. This regression test fails fast if the per-image JS hook
+    // is reintroduced.
     await renderMarkdownMemo({ saveMemo, content: "![Diagram](data:image/png;base64,AAAA)" });
 
     const image = document.querySelector(".preview img");
@@ -540,7 +547,7 @@ describe("Markdown Memo - view mode", () => {
     Object.defineProperty(image, "naturalWidth", { configurable: true, value: 640 });
     await fireEvent.load(image);
 
-    expect(image.style.getPropertyValue("--memo-preview-image-max-width")).toBe("640px");
+    expect(image.style.getPropertyValue("--memo-preview-image-max-width")).toBe("");
   }, 30000);
 
   test("converts legacy Quill Delta object to readable markdown text in workspace view", async () => {


### PR DESCRIPTION
## Summary

- **Compact (Flat) UI density mode** — settings-driven toggle that strips card chrome (elevations → none, large radii → 2px, gutters → 0, tighter card body padding) for a denser VSCode-style layout. Buttons keep their rounded corners; only Cards / placeholders are squared off via a dedicated `--card-radius` token. Persisted per-user via `setMetaData` and synced across BrowserWindows via `BroadcastChannel`.
- **Toolbar restructuring** — the project Card toolbar is now two rows (buttons on top, search filter on the bottom) so its top chrome height matches the memo tab strip on the TaskDetail side. In Compact mode the buttons row stops wrapping and scrolls horizontally instead, and secondary actions (move/indent, expand/collapse, memo format, view toggles) collapse into a "⋯" overflow menu — keeping only Add / Add-child / Delete / Restore / Undo / Redo + Search visible.
- **TaskDetail alignment in Compact** — detail-pane defaults closed (memo-first view) and the inner split resizer hides when one side is collapsed so the right Card's top chrome matches the left's two-row toolbar height.
- **Memo image viewer** — Markdown preview images now render at a consistent 32rem cap in both Preview and Split modes, gain a `zoom-in` cursor, and clicking opens the image in a dedicated `BrowserWindow` for a full-resolution look.
- **Window zoom controls** — `Ctrl +` / `Ctrl -` / `Ctrl 0` / `Ctrl + wheel` / pinch zoom are wired across the main window, task-detail window, and image viewer. The image viewer also closes on `Esc`.
- **Memo border cleanup in Compact** — outer frames around Markdown / Quill editors and the MemoTab tag-panel divider are removed so the memo content runs edge-to-edge.

## Test plan

- [ ] Open Settings → 外観 and toggle between Comfortable / Compact (Flat). Verify cards lose their elevation, sharpen corners, and the Pane gutter collapses to 0.
- [ ] In Compact, verify the toolbar buttons row scrolls horizontally at narrow widths instead of wrapping, and confirm the overflow `⋯` menu opens with all secondary actions enabled/disabled per current selection state.
- [ ] Open the standalone Task Detail window from main, toggle density in main, and verify the detail window updates live (BroadcastChannel sync) and respects `--detail-window-pad: 0` in Compact.
- [ ] Add a tall markdown image to a memo. In Preview mode it should display at the same width as in Split mode (32rem cap). Clicking it should open a new BrowserWindow showing the image; verify `Ctrl + =`, `Ctrl + -`, `Ctrl + 0`, `Ctrl + wheel`, and `Esc` all behave as expected.
- [ ] In Compact, confirm the MarkdownMemo and QuillMemo editors have no outer border and the MemoTab tag-panel divider is gone.
- [ ] Verify Comfortable mode still renders identically to the previous behavior (no toolbar overflow menu, full button bar visible, original card elevation / radii / paddings).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
