### PR TITLE
fix: configure marked once so code blocks aren't escaped repeatedly

### DIFF
--- a/src/features/memos/components/MarkdownMemo.svelte
+++ b/src/features/memos/components/MarkdownMemo.svelte
@@ -1,4 +1,9 @@
-﻿<script lang="ts">
+﻿<script context="module" lang="ts">
+  // marked.use() の設定はモジュール読込時に一度だけ行う (下の instance <script> 参照)。
+  let markedConfigured = false;
+</script>
+
+<script lang="ts">
   import { tick, onDestroy } from "svelte";
   import {
     Direction,
@@ -32,29 +37,38 @@
   import { theme } from "@stores/theme";
   import "@features/memos/styles/hljs-theme.css";
 
-  marked.use(
-    markedHighlight({
-      langPrefix: "hljs language-",
-      highlight(code, lang) {
-        const language = lang && hljs.getLanguage(lang) ? lang : "plaintext";
-        return hljs.highlight(code, { language, ignoreIllegals: true }).value;
-      },
-    }),
-    {
-      gfm: true,
-      breaks: false,
-      tokenizer: {
-        code() {
-          return undefined;
+  // marked は共有シングルトンで marked.use() は extension を「積み上げる」ため、
+  // この設定はコンポーネントのマウントごとではなく一度だけ実行する必要がある。
+  // 以前はこの呼び出しがインスタンス <script> にあり、マウントのたびに markedHighlight が
+  // 再登録され、その walkTokens によるコードブロックの hljs エスケープが 1 段ずつ重なっていた
+  // (`>` → `&gt;` → `&amp;gt;` → `&amp;amp;gt;` …)。本文(段落)は renderer が一度だけ
+  // エスケープするため影響を受けず、コードブロックだけで多重エスケープが顕在化していた。
+  if (!markedConfigured) {
+    markedConfigured = true;
+    marked.use(
+      markedHighlight({
+        langPrefix: "hljs language-",
+        highlight(code, lang) {
+          const language = lang && hljs.getLanguage(lang) ? lang : "plaintext";
+          return hljs.highlight(code, { language, ignoreIllegals: true }).value;
         },
-      },
-      renderer: {
-        checkbox({ checked }) {
-          return `<input type="checkbox"${checked ? " checked" : ""}>`;
+      }),
+      {
+        gfm: true,
+        breaks: false,
+        tokenizer: {
+          code() {
+            return undefined;
+          },
         },
-      },
-    }
-  );
+        renderer: {
+          checkbox({ checked }) {
+            return `<input type="checkbox"${checked ? " checked" : ""}>`;
+          },
+        },
+      }
+    );
+  }
 
   export let saveMemo: (content: string) => void;
   export let content: unknown = "";


### PR DESCRIPTION
## 概要

Markdown メモのプレビューで、コードブロック内の `&` / `<` / `>` が多重エスケープされ、`&amp;amp;gt;` のような文字列がそのまま表示される不具合を修正します。

例: コードブロックに `>` を入力 → プレビューに `&amp;amp;gt;` と表示される。

## 原因

`marked.use(markedHighlight(...))` が `MarkdownMemo.svelte` のインスタンス `<script>`（トップレベル）にあり、**コンポーネントのマウントごとに実行**されていました。

- `marked` は共有シングルトンで、`marked.use()` は extension を「積み上げる」（`walkTokens` が登録数ぶん走る）
- `markedHighlight` の `walkTokens` は **code トークンだけ** を hljs で再ハイライト＝再 HTML エスケープする
- hljs は `&` / `<` / `>` をエンティティ化するため、マウントのたびにコードブロックが 1 段ずつ多重エスケープされる

```
>  →  &gt;  →  &amp;gt;  →  &amp;amp;gt;  →  &amp;amp;amp;gt;(実HTML / 表示は &amp;amp;gt;)
```

段落本文は renderer が一度だけエスケープするため影響を受けず、**コードブロックだけ**で顕在化していました。マウント回数（メモを開いた回数）に応じて段数が増えるため、「セッションが進むほど増える」挙動になります。

## 修正

`marked.use(...)` を `<script context="module">` 側のガード（`markedConfigured`）へ移動し、**モジュール読込時に一度だけ**実行されるようにしました。`MarkdownMemo` は `Memo.svelte` で遅延 `import()` されるため、登録は確実に 1 回だけになります。

## マイグレーション

不要です。多重エスケープはプレビュー描画時のみで、保存される本文は常に生のエディタテキスト（`>` のまま）でした。再ビルド／リロードで既存メモも正しく表示されます。

## 検証

- 実機の `marked@18` + `marked-highlight@2.2.4` + `highlight.js` で `marked.use` を 4 回呼ぶと code の innerHTML が `&amp;amp;amp;gt;`（表示 `&amp;amp;gt;`）になり、報告と完全一致することを確認
- 修正後、コンポーネントが警告 0 でコンパイルされることを確認
- `npm test`（pre-push フック）: 40 files / **492 passed**, 7 skipped ✓

🤖 Generated with [Claude Code](https://claude.com/claude-code)
